### PR TITLE
suppress-default.win.txt - Tcpip6_WSHGetSockaddrType

### DIFF
--- a/drmemory/suppress-default.win.txt
+++ b/drmemory/suppress-default.win.txt
@@ -832,6 +832,14 @@ KERNEL32.dll!...
 pdh.dll!*
 
 ##################################################
+# i#1301: Tcpip6_WSHGetSockaddrType final 9 EA bytes are left uninit
+
+UNINITIALIZED READ
+name=default i#1301 Tcpip6_WSHGetSockaddrType EA
+system call NtCreateFile parameter #9
+MSWSOCK.dll!Tcpip6_WSHGetSockaddrType
+
+##################################################
 # i#1302: SockSocket final 9 EA bytes are left uninit
 
 UNINITIALIZED READ

--- a/drmemory/suppress-default.win.txt
+++ b/drmemory/suppress-default.win.txt
@@ -832,20 +832,12 @@ KERNEL32.dll!...
 pdh.dll!*
 
 ##################################################
-# i#1301: Tcpip6_WSHGetSockaddrType final 9 EA bytes are left uninit
-
-UNINITIALIZED READ
-name=default i#1301 Tcpip6_WSHGetSockaddrType EA
-system call NtCreateFile parameter #9
-MSWSOCK.dll!Tcpip6_WSHGetSockaddrType
-
-##################################################
-# i#1302: SockSocket final 9 EA bytes are left uninit
+# i#1302: MSWSOCK.dll NtCreateFile final 9 EA bytes are left uninit
 
 UNINITIALIZED READ
 name=default i#1302 SockSocket EA
 system call NtCreateFile parameter #9
-MSWSOCK.dll!SockSocket
+MSWSOCK.dll!*Sock*
 
 ##################################################
 # i#1303: real bug in ATL


### PR DESCRIPTION
MSWSOCK.dll!Tcpip6_WSHGetSockaddrType on Windows 8.1 has the same issue as MSWSOCK.dll!SockSocket