### PR TITLE
DRi#2224: avoid asking for size from dr_safe_*

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -141,9 +141,7 @@ safe_read(void *base, size_t size, void *out_buf)
      * setjmp overhead (i#265).
      * Xref the same problem with leak_safe_read_heap (PR 570839).
      */
-    size_t bytes_read = 0;
-    return (dr_safe_read(base, size, out_buf, &bytes_read) &&
-            bytes_read == size);
+    return dr_safe_read(base, size, out_buf, NULL);
 }
 
 /* if returns false, calls instr_free() on inst first */

--- a/drmemory/syscall_linux.c
+++ b/drmemory/syscall_linux.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -250,13 +250,12 @@ handle_pre_execve(void *drcontext)
     char logdir[MAXIMUM_PATH]; /* one reason we're not inside os_post_syscall() */
     size_t bytes_read = 0;
     /* Not using safe_read() since we want a partial read if hits page boundary */
-    if (dr_safe_read((void *) dr_syscall_get_param(drcontext, 0),
-                     BUFFER_SIZE_BYTES(logdir), logdir, &bytes_read)) {
-        if (bytes_read < BUFFER_SIZE_BYTES(logdir))
-            logdir[bytes_read] = '\0';
-        NULL_TERMINATE_BUFFER(logdir);
-        ELOGF(0, f_fork, "EXEC path=%s\n", logdir);
-    }
+    dr_safe_read((void *) dr_syscall_get_param(drcontext, 0),
+                 BUFFER_SIZE_BYTES(logdir), logdir, &bytes_read);
+    if (bytes_read < BUFFER_SIZE_BYTES(logdir))
+        logdir[bytes_read] = '\0';
+    NULL_TERMINATE_BUFFER(logdir);
+    ELOGF(0, f_fork, "EXEC path=%s\n", logdir);
 #endif
 }
 

--- a/drsyscall/drsyscall.c
+++ b/drsyscall/drsyscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -450,7 +450,6 @@ handle_pre_unknown_syscall(void *drcontext, cls_syscall_t *cpt,
                 if (drsys_ops.syscall_sentinels) {
                     for (j=0; j<cpt->sysarg_sz[i]; j++) {
                         if (is_byte_undefined(start + j)) {
-                            size_t written;
                             /* Detect writes to data that happened to have the same
                              * value beforehand (happens often with 0) by writing
                              * a sentinel.
@@ -463,8 +462,7 @@ handle_pre_unknown_syscall(void *drcontext, cls_syscall_t *cpt,
                             if (s_at == NULL)
                                 s_at = start + j;
                             if (!dr_safe_write(start + j, 1,
-                                               &UNKNOWN_SYSVAL_SENTINEL, &written) ||
-                                written != 1) {
+                                               &UNKNOWN_SYSVAL_SENTINEL, NULL)) {
                                 /* if page is read-only then assume rest is not OUT */
                                 LOG(1, "WARNING: unable to write sentinel value @"PFX"\n",
                                     start + j);
@@ -545,10 +543,9 @@ handle_post_unknown_syscall(void *drcontext, cls_syscall_t *cpt,
                                 /* kernel didn't write so restore app value that
                                  * we clobbered w/ our sentinel.
                                  */
-                                size_t written;
                                 LOG(4, "restoring app sysval @"PFX"\n", pc);
                                 if (!dr_safe_write(pc, 1, &cpt->sysarg_val[i][j],
-                                                   &written) || written != 1) {
+                                                   NULL)) {
                                     LOG(1, "WARNING: unable to restore app sysval @"PFX"\n",
                                         pc);
                                 }

--- a/framework/drmf_utils.c
+++ b/framework/drmf_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -86,9 +86,7 @@ nonheap_free(void *p, size_t size, heapstat_t type)
 bool
 safe_read(void *base, size_t size, void *out_buf)
 {
-    size_t bytes_read = 0;
-    return (dr_safe_read(base, size, out_buf, &bytes_read) &&
-            bytes_read == size);
+    return dr_safe_read(base, size, out_buf, NULL);
 }
 
 #if DEBUG


### PR DESCRIPTION
Corrects uses of dr_safe_* that previously checked both the return value
and the size, as leaving the size parameter NULL is more efficient on
Windows 10 now due to kernel behavior changes.