### PR TITLE
i#1952: fix build failures with SDK 8.1 and 64-bit cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,17 +523,27 @@ if (WIN32)
   # 5.2 does not work (it's not just slower w/o SymSearch: it fails).
   # Haven't tested in between.
   # WINDDK/3790.1830/bin/x86/dbghelp.dll is 6.3.
-  if (X64)
-    set(PROGFILES "$ENV{PROGRAMW6432}") # cmake is 32-bit
-    set(PROGFILES32 "$ENV{PROGRAMFILES}")
-    set(ARCH_SFX "x64")
-    set(DDK_SFX "amd64")
-  else (X64)
+  # Older CMake binaries are 32-bit but newer ones can be 64-bit so we
+  # cannot rely on one or the other.
+  if ("$ENV{PROGRAMW6432}" STREQUAL "")
+    if (X64)
+      message(FATAL_ERROR "On 32-bit Windows: 64-bit build not supported")
+    endif ()
     set(PROGFILES "$ENV{PROGRAMFILES}")
     set(PROGFILES32 "$ENV{PROGRAMFILES}")
     set(ARCH_SFX "x86")
     set(DDK_SFX "i386")
-  endif (X64)
+  else ()
+    set(PROGFILES "$ENV{PROGRAMW6432}")
+    set(PROGFILES32 "$ENV{PROGRAMFILES(x86)}")
+    if (X64)
+      set(ARCH_SFX "x64")
+      set(DDK_SFX "amd64")
+    else (X64)
+      set(ARCH_SFX "x86")
+      set(DDK_SFX "i386")
+    endif (X64)
+  endif ()
   # Even the VS2005 copy is 6.5 (despite its headers being < 6.3) so we can
   # use those as well as the later SDK and standalone DTFW versions.
   set(dbghelp_paths

--- a/make/policies.cmake
+++ b/make/policies.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015 Google, Inc.  All rights reserved.
+# Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -20,6 +20,7 @@
 
 if ("${CMAKE_VERSION}" VERSION_EQUAL "3.1" OR
     "${CMAKE_VERSION}" VERSION_GREATER "3.1")
+  cmake_policy(SET CMP0053 OLD)
   cmake_policy(SET CMP0054 OLD)
 endif ()
 

--- a/tests/app_suite/CMakeLists.txt
+++ b/tests/app_suite/CMakeLists.txt
@@ -63,11 +63,11 @@ elseif (WIN32)
   # i#1283 set _WIN32_WINNT for app_suite power_tests_win test
   # XXX: we did not do every-version-set to avoid over-specifying, however,
   # we could hit similar problems of different win-versions in the future
-  if ("${CMAKE_SYSTEM_VERSION}" STRLESS "6.1")
+  if ("${CMAKE_SYSTEM_VERSION}" VERSION_LESS "6.1")
     # pre-win7, set _WIN32_WINNT to be _WIN32_WINNT_WINXP
     append_compile_flags(app_suite_tests "-D_WIN32_WINNT=0x0501")
   else ()
-    # pre-win7, set _WIN32_WINNT to be _WIN32_WINNT_WIN7
+    # win7+: set _WIN32_WINNT to be _WIN32_WINNT_WIN7
     append_compile_flags(app_suite_tests "-D_WIN32_WINNT=0x0601")
   endif ()
   if (NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 18.0)

--- a/tests/app_suite/fibers_win.cpp
+++ b/tests/app_suite/fibers_win.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2004 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -52,6 +52,10 @@
 
 #include "gtest/gtest.h"
 #include <windows.h>
+#include <ntverp.h>
+#if VER_PRODUCTBUILD >= 9200 /* win8+ SDK */
+# include "fibersapi.h"
+#endif
 #include "stdio.h"
 
 static DWORD flsA_index;

--- a/tests/registers.c
+++ b/tests/registers.c
@@ -1069,7 +1069,8 @@ GLOBAL_LABEL(FUNCNAME:)
          * sub-dword, so we have to read 4 bytes and then expand the bottom 2 bytes.
          */
         mov      ecx, DWORD [4 + REG_XAX]
-        lock xchg ecx, DWORD [0 + REG_XDX] /* undef => slowpath */
+        /* "lock" is automatic here, and adding it can cause ml to fail (i#1952) */
+        xchg ecx, DWORD [0 + REG_XDX] /* undef => slowpath */
         mov      eax, DWORD [0 + REG_XDX] /* propagate lock==0xf0 unless xl8 cleared */
         movzx    eax, ax /* now 0x00==defined unless xl8 cleared */
         cmp      eax, edx /* undef w/ proper clearing */

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -115,7 +115,7 @@ registers.c_asm.asm:1773
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
 registers.c_asm.asm:1787
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1821
+registers.c_asm.asm:1822
 %endif
 %if UNIX
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
@@ -127,7 +127,7 @@ registers.c_asm.asm:1092
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
 registers.c_asm.asm:1106
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1075
+registers.c_asm.asm:1076
 %endif
 %OUT_OF_ORDER
 : LEAK 15 direct bytes + 0 indirect bytes


### PR DESCRIPTION
Fixes 4 build failures:

1) Find dbghelp.dll when cmake is 64-bit.

2) Include the right header for SDK 8+ for app_suite/fibers_win.cpp.

3) Fix ml.exe "error A2" on tests/registers.c.

4) Fix build failures in namespace_tests_win.cpp.

Fixes #1952