### PR TITLE
DRi#1993: update DR to handle recent win10 pseudo-dlls

### DIFF
--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -478,6 +478,7 @@ static const TCHAR * const known_libs[] = {
     L"advapi32.dll",
     L"sechost.dll",
     L"msvcrt.dll",
+    L"ucrtbase.dll",
     L"drmemory.exe",
     L"dynamorio.dll",
     L"dbghelp.dll",


### PR DESCRIPTION
Updates DR to the latest d747cc1 for DRi#1993's support for new
win10 pseudo-dlls.

Also adds ucrtbase.dll to the list of "usual dlls" to avoid complaining
about it on win10.