### PR TITLE
i#1949 Printing id of current thread + fixes for several bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,12 +550,12 @@ if (WIN32)
     "${DDK_ROOT}/bin/${ARCH_SFX}/dbghelp.dll"
     "${DDK_ROOT}/tools/tracing/${DDK_SFX}/dbghelp.dll"
     "${PROGFILES}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
-    "${PROGFILES32}/Windows Kits/*/Debuggers/${ARCH_SFX}/dbghelp.dll")
+    "${PROGFILES32}/Windows Kits/*/Debuggers/${ARCH_SFX}/dbghelp.dll"
+    # For Visual Studio 2010+, x64 dbghelp.dll resides in Program
+    # Files (x86) rather than Program Files.
+    "${PROGFILES32}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll")
   if (X64)
     set(dbghelp_paths ${dbghelp_paths}
-      # For Visual Studio 2010+, x64 dbghelp.dll resides in Program
-      # Files (x86) rather than Program Files.
-      "${PROGFILES32}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
       # For older versions of windbg, x64 dbghelp.dll resides here.
       "${PROGFILES}/Debugging Tools for Windows (x64)/dbghelp.dll")
   else (X64)
@@ -599,12 +599,12 @@ if (WIN32)
   endif ()
   set(symsrv_paths
     "${PROGFILES}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/symsrv.dll"
-    "${PROGFILES32}/Windows Kits/*/Debuggers/${ARCH_SFX}/symsrv.dll")
+    "${PROGFILES32}/Windows Kits/*/Debuggers/${ARCH_SFX}/symsrv.dll"
+    # For Visual Studio 2010+, x64 symsrv.dll resides in Program
+    # Files (x86) rather than Program Files.
+    "${PROGFILES32}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/symsrv.dll")
   if (X64)
     set(symsrv_paths ${symsrv_paths}
-      # For Visual Studio 2010+, x64 symsrv.dll resides in Program
-      # Files (x86) rather than Program Files.
-      "${PROGFILES32}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/symsrv.dll"
       # For older versions of windbg, x64 symsrv.dll resides here.
       "${PROGFILES}/Debugging Tools for Windows (x64)/symsrv.dll")
   else (X64)

--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -68,8 +68,6 @@ configure_DynamoRIO_client(drltracelib)
 use_DynamoRIO_extension(drltracelib drmgr_static)
 use_DynamoRIO_extension(drltracelib drwrap_static)
 use_DynamoRIO_extension(drltracelib drx_static)
-# ensure we rebuild if includes change
-add_dependencies(drltracelib api_headers)
 
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
   # i#1805: see comment in drstrace/CMakeLists.txt

--- a/drltrace/drltrace.c
+++ b/drltrace/drltrace.c
@@ -161,7 +161,8 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
             dr_fprintf(outf, "<invalid memory>");
             /* Just keep going */
         });
-        dr_fprintf(outf, ")");
+        dr_fprintf(outf, ") thread id: "TIDFMT" and return to "PFX"",
+                   dr_get_thread_id(drcontext), drwrap_get_retaddr(wrapcxt));
     }
     dr_fprintf(outf, "\n");
     if (mod != NULL)

--- a/drltrace/drltrace_frontend.cpp
+++ b/drltrace/drltrace_frontend.cpp
@@ -250,7 +250,7 @@ check_logdir_path(char *logdir, size_t logdir_len) {
     else {
         dr_snprintf(logdir, logdir_len, "%s", absolute_logdir_path);
     }
-    NULL_TERMINATE_BUFFER(logdir);
+    logdir[logdir_len - 1] = '\0';
 }
 
 int


### PR DESCRIPTION
Added printing id of a thread that performs library call
Added return address printing for library calls
Fixed logdir string parsing bug
Fixed a bug when cmake can't find dbghelp.dll in a case of build
without SDK installed.
Fixed a bug that causes warnings during drltrace configuring.

Fixes #1949
Fixes #1954
Fixes #1956