### PR TITLE
i#1959: drltrace does incorrect parsing of logdir arg

### DIFF
--- a/drltrace/drltrace_frontend.cpp
+++ b/drltrace/drltrace_frontend.cpp
@@ -250,7 +250,7 @@ check_logdir_path(char *logdir, size_t logdir_len) {
     else {
         dr_snprintf(logdir, logdir_len, "%s", absolute_logdir_path);
     }
-    NULL_TERMINATE_BUFFER(logdir);
+    logdir[logdir_len - 1] = '\0';
 }
 
 int


### PR DESCRIPTION
Fix a bug related to incorrect usage of NULL_TERMINATED_BUFFER on a pointer instead of string.

Fixes #1959