### PR TITLE
i#1969: use a long jne for inheap_slot instru

### DIFF
--- a/drmemory/fastpath_x86.c
+++ b/drmemory/fastpath_x86.c
@@ -3195,7 +3195,8 @@ instrument_fastpath(void *drcontext, instrlist_t *bb, instr_t *inst,
             INSTR_CREATE_cmp(drcontext, opnd_create_shadow_inheap_slot(),
                              OPND_CREATE_INT8(0)));
         PRE(bb, inst, INSTR_CREATE_jcc
-            (drcontext, OP_jne_short, opnd_create_instr(fastpath_restore)));
+            /* i#1969: OP_jne_short does not always reach. */
+            (drcontext, OP_jne, opnd_create_instr(fastpath_restore)));
         check_ignore_unaddr = false; /* can ignore from now on */
     }
 #endif


### PR DESCRIPTION
Some complex instrumentation sequences end up being too far for the
OP_jne_short used for the inheap_slot check for 64-bit shadow mode.  We
switch to a long jne here.

Fixes #1969