### PR TITLE
i#1948 add libcall args sym printing: syscall args support

### DIFF
--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -68,6 +68,7 @@ configure_DynamoRIO_client(drltracelib)
 use_DynamoRIO_extension(drltracelib drmgr_static)
 use_DynamoRIO_extension(drltracelib drwrap_static)
 use_DynamoRIO_extension(drltracelib drx_static)
+use_DynamoRIO_extension(drltracelib drsyscall_static)
 
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
   # i#1805: see comment in drstrace/CMakeLists.txt

--- a/drltrace/drltrace_frontend.cpp
+++ b/drltrace/drltrace_frontend.cpp
@@ -97,11 +97,15 @@ static droption_t<bool> op_print_ret_addr
 (DROPTION_SCOPE_CLIENT, "print_ret_addr", false, "Print library call's return address",
  "Print return addresses of library calls.");
 
-static droption_t<uint> op_all_args
-(DROPTION_SCOPE_CLIENT, "all_args", 2, "Number of library call arguments to print",
- "Number of library call arguments to print. Specify 0 to disable. Drltrace will print "
- "symbolic representation of arguments in case of known library call including all "
- "known arguments.");
+static droption_t<uint> op_unknown_args
+(DROPTION_SCOPE_CLIENT, "num_unknown_args", 2, "Number of unknown libcall args to print",
+ "Number of arguments to print for unknown library calls.  Specify 0 to disable "
+ "unknown args printing.");
+
+static droption_t<uint> op_max_args
+(DROPTION_SCOPE_CLIENT, "num_max_args", 6, "Maximum number of arguments to print",
+ "Maximum number of arguments to print.  This option allows to limit the number of "
+ "arguments to be printed.  Specify 0 to disable args printing (including unknown).");
 
 static droption_t<bool> op_ignore_underscore
 (DROPTION_SCOPE_CLIENT, "ignore_underscore", false, "Ignores library routine names "

--- a/drltrace/drltrace_frontend.cpp
+++ b/drltrace/drltrace_frontend.cpp
@@ -97,6 +97,12 @@ static droption_t<bool> op_print_ret_addr
 (DROPTION_SCOPE_CLIENT, "print_ret_addr", false, "Print library call's return address",
  "Print return addresses of library calls.");
 
+static droption_t<uint> op_all_args
+(DROPTION_SCOPE_CLIENT, "all_args", 2, "Number of library call arguments to print",
+ "Number of library call arguments to print. Specify 0 to disable. Drltrace will print "
+ "symbolic representation of arguments in case of known library call including all "
+ "known arguments.");
+
 static droption_t<bool> op_ignore_underscore
 (DROPTION_SCOPE_CLIENT, "ignore_underscore", false, "Ignores library routine names "
  "starting with \"_\".", "Ignores library routine names starting with \"_\".");

--- a/drsyscall/drsyscall.c
+++ b/drsyscall/drsyscall.c
@@ -252,11 +252,13 @@ drsys_name_to_syscall(const char *name, drsys_syscall_t **syscall OUT)
     }
 
 #ifdef DEBUG
+#ifdef WINDOWS
     /* ignore possible Nt/Zw mismatch */
     if (((sysinfo->name[0] == 'N' && sysinfo->name[1] == 't') ||
         (sysinfo->name[0] == 'Z' && sysinfo->name[1] == 'w')) &&
         ((name[0] == 'N' && name[1] == 't') || (name[0] == 'Z' && name[1] == 'w')))
         offset = 2;
+#endif
 
     ASSERT(stri_eq(sysinfo->name + offset, name + offset)
            IF_WINDOWS(||


### PR DESCRIPTION
Added arguments printing of already known syscalls from drsyscall's
tables for Windows and Linux.