### PR TITLE
droption usage in the drltrace client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1862,7 +1862,9 @@ if (TOOL_DR_MEMORY AND WIN32)
   add_subdirectory(drstrace)
 endif (TOOL_DR_MEMORY AND WIN32)
 
-add_subdirectory(drltrace)
+if (NOT APPLE)
+  add_subdirectory(drltrace)
+endif()
 
 add_subdirectory(framework/samples)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1862,6 +1862,7 @@ if (TOOL_DR_MEMORY AND WIN32)
   add_subdirectory(drstrace)
 endif (TOOL_DR_MEMORY AND WIN32)
 
+# FIXME i#1987: enable support of drltrace under MacOS
 if (NOT APPLE)
   add_subdirectory(drltrace)
 endif()

--- a/common/utils.h
+++ b/common/utils.h
@@ -20,6 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef _UTILS_H_
 #define _UTILS_H_ 1
 
@@ -1087,3 +1091,7 @@ void
 utils_thread_set_file(void *drcontext, file_t f);
 
 #endif /* _UTILS_H_ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/utils.h
+++ b/common/utils.h
@@ -20,12 +20,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifndef _UTILS_H_
+#define _UTILS_H_ 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#ifndef _UTILS_H_
-#define _UTILS_H_ 1
 
 #ifdef WINDOWS
 /* DRi#1424: avoid pulling in features from recent versions to keep compatibility */
@@ -1090,8 +1090,8 @@ utils_thread_exit(void *drcontext);
 void
 utils_thread_set_file(void *drcontext, file_t f);
 
-#endif /* _UTILS_H_ */
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _UTILS_H_ */

--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -37,9 +37,7 @@ include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 # drltracelib
 
 set(srcs
-    drltrace.c)
-
-set(external_srcs ../framework/drmf_utils.c)
+    drltrace.cpp)
 
 if (WIN32)
   set(srcs ${srcs} ${PROJECT_SOURCE_DIR}/make/resources.rc)
@@ -47,7 +45,7 @@ endif ()
 
 set(DynamoRIO_USE_LIBC OFF)
 
-add_library(drltracelib SHARED ${srcs} ${external_srcs})
+add_library(drltracelib SHARED ${srcs})
 
 # We share the framework version # for now
 set_library_version(drltracelib ${DRMF_VERSION_MAJOR_MINOR})
@@ -70,7 +68,12 @@ use_DynamoRIO_extension(drltracelib drwrap_static)
 use_DynamoRIO_extension(drltracelib drx_static)
 use_DynamoRIO_extension(drltracelib drsyscall_static)
 use_DynamoRIO_extension(drltracelib drcovlib_static)
+use_DynamoRIO_extension(drltracelib droption)
 
+if (UNIX)
+  # to avoid conflicts with new declaration with "C" linkage in utils.h
+  append_property_string(TARGET drltracelib COMPILE_FLAGS "-DNOLINK_STRCASESTR")
+endif()
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
   # i#1805: see comment in drstrace/CMakeLists.txt
   append_property_string(TARGET drltracelib LINK_FLAGS "/force:multiple")

--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -70,6 +70,9 @@ use_DynamoRIO_extension(drltracelib drsyscall_static)
 use_DynamoRIO_extension(drltracelib drcovlib_static)
 use_DynamoRIO_extension(drltracelib droption)
 
+# XXX i#2429: DR's droption.h includes both <string.h> and <string.h>
+# we should remove <string.h> and replace the strcmp comparison with
+# a std::string. Then we can remove special if here and below.
 if (UNIX)
   # to avoid conflicts with new declaration with "C" linkage in utils.h
   append_property_string(TARGET drltracelib COMPILE_FLAGS "-DNOLINK_STRCASESTR")
@@ -109,6 +112,7 @@ else ()
   set_property(TARGET drltrace PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
 endif ()
 
+# XXX: see DR's i#2429 and comment above.
 if (UNIX)
   # to avoid conflicts with new declaration with "C" linkage in utils.h
   append_property_string(TARGET drltrace COMPILE_FLAGS "-DNOLINK_STRCASESTR")

--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -109,6 +109,11 @@ else ()
   set_property(TARGET drltrace PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
 endif ()
 
+if (UNIX)
+  # to avoid conflicts with new declaration with "C" linkage in utils.h
+  append_property_string(TARGET drltrace COMPILE_FLAGS "-DNOLINK_STRCASESTR")
+endif()
+
 install(TARGETS drltrace DESTINATION "${INSTALL_BIN}"
   PERMISSIONS ${owner_access} OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
   WORLD_READ WORLD_EXECUTE)

--- a/drltrace/drltrace.cpp
+++ b/drltrace/drltrace.cpp
@@ -316,7 +316,7 @@ iterate_exports(const module_data_t *info, bool add)
 static bool
 library_matches_filter(const module_data_t *info)
 {
-    if (op_only_to_lib.get_value().c_str()[0] != '\0') {
+    if (!op_only_to_lib.get_value().empty()) {
         const char *libname = dr_module_preferred_name(info);
 #ifdef WINDOWS
         return (libname != NULL && strcasestr(libname,
@@ -351,7 +351,7 @@ static void
 open_log_file(void)
 {
     char buf[MAXIMUM_PATH];
-    if (strcmp(op_logdir.get_value().c_str(), "-") == 0)
+    if (op_logdir.get_value().compare("-") == 0)
         outf = STDERR;
     else {
         outf = drx_open_unique_appid_file(op_logdir.get_value().c_str(),

--- a/drltrace/drltrace.cpp
+++ b/drltrace/drltrace.cpp
@@ -34,7 +34,7 @@
  *
  * Records calls to exported library routines.
  *
- * The runtime options for this client is specified in drltrace_options.h,
+ * The runtime options for this client are specified in drltrace_options.h,
  * see DROPTION_SCOPE_CLIENT options.
  */
 #include "dr_api.h"
@@ -44,14 +44,8 @@
 #include "drx.h"
 #include "drcovlib.h"
 #include <string.h>
-#ifdef __cplusplus
-extern "C" {
-#endif
 #undef TESTANY
 #include "utils.h"
-#ifdef __cplusplus
-}
-#endif
 
 /* XXX i#1349: features to add:
  *
@@ -78,18 +72,6 @@ extern "C" {
 } while (0)
 
 #define OPTION_MAX_LENGTH MAXIMUM_PATH
-
-typedef struct _drltrace_options_t {
-    char logdir[MAXIMUM_PATH];
-    bool only_from_app;
-    bool ignore_underscore;
-    char only_to_lib[MAXIMUM_PATH];
-    uint num_unknown_args;
-    int max_args;
-    bool print_ret_addr;
-} drltrace_options_t;
-
-static drltrace_options_t options;
 
 /* Where to write the trace */
 static file_t outf;
@@ -155,7 +137,7 @@ drlib_iter_arg_cb(drsys_arg_t *arg, void *wrapcxt)
 {
     if (arg->ordinal == -1)
         return true;
-    if (arg->ordinal >= options.max_args)
+    if (arg->ordinal >= op_max_args.get_value())
         return false; /* limit number of arguments to be printed */
 
     arg->value = (ptr_uint_t)drwrap_get_arg(wrapcxt, arg->ordinal);
@@ -170,7 +152,7 @@ print_args_unknown_call(app_pc func, void *wrapcxt)
     uint i;
     void *drcontext = drwrap_get_drcontext(wrapcxt);
     DR_TRY_EXCEPT(drcontext, {
-        for (i = 0; i < options.num_unknown_args; i++) {
+        for (i = 0; i < op_unknown_args.get_value(); i++) {
             dr_fprintf(outf, "\n    arg %d: " PFX, i,
                        drwrap_get_arg(wrapcxt, i));
         }
@@ -179,7 +161,7 @@ print_args_unknown_call(app_pc func, void *wrapcxt)
         /* Just keep going */
     });
     /* all args have been sucessfully printed */
-    dr_fprintf(outf, options.print_ret_addr ? "\n   ": "");
+    dr_fprintf(outf, op_print_ret_addr.get_value() ? "\n   ": "");
 }
 
 static void
@@ -188,7 +170,7 @@ print_symbolic_args(const char *name, void *wrapcxt, app_pc func)
     drmf_status_t res;
     drsys_syscall_t *syscall;
 
-    if (options.max_args == 0)
+    if (op_max_args.get_value() == 0)
         return;
 
     res = drsys_name_to_syscall(name, &syscall);
@@ -197,11 +179,11 @@ print_symbolic_args(const char *name, void *wrapcxt, app_pc func)
         if (res != DRMF_SUCCESS && res != DRMF_ERROR_DETAILS_UNKNOWN)
             ASSERT(false, "drsys_iterate_arg_types failed in print_symbolic_args");
         /* all args have been sucessfully printed */
-        dr_fprintf(outf, options.print_ret_addr ? "\n   ": "");
+        dr_fprintf(outf, op_print_ret_addr.get_value() ? "\n   ": "");
         return;
     } else {
         /* use standard type-blind scheme */
-        if (options.num_unknown_args > 0)
+        if (op_unknown_args.get_value() > 0)
             print_args_unknown_call(func, wrapcxt);
     }
 }
@@ -224,7 +206,7 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
 
     void *drcontext = drwrap_get_drcontext(wrapcxt);
 
-    if (options.only_from_app) {
+    if (op_only_from_app.get_value()) {
         /* For just this option, the modxfer approach might be better */
         app_pc retaddr =  NULL;
         DR_TRY_EXCEPT(drcontext, {
@@ -273,12 +255,13 @@ lib_entry(void *wrapcxt, INOUT void **user_data)
      */
     print_symbolic_args(name, wrapcxt, func);
 
-    if (options.print_ret_addr) {
+    if (op_print_ret_addr.get_value()) {
         ret_addr = drwrap_get_retaddr(wrapcxt);
         res = drmodtrack_lookup(drcontext, ret_addr, &mod_id, &mod_start);
         if (res == DRCOVLIB_SUCCESS) {
             dr_fprintf(outf,
-                       options.print_ret_addr ? " and return to module id:%d, offset:" PIFX : "",
+                       op_print_ret_addr.get_value() ?
+                       " and return to module id:%d, offset:" PIFX : "",
                        mod_id, ret_addr - mod_start);
         }
     }
@@ -311,7 +294,7 @@ iterate_exports(const module_data_t *info, bool add)
                    sym->name, sym->addr, func);
         }
 #endif
-        if (options.ignore_underscore && strstr(sym->name, "_") == sym->name)
+        if (op_ignore_underscore.get_value() && strstr(sym->name, "_") == sym->name)
             func = NULL;
         if (func != NULL) {
             if (add) {
@@ -333,9 +316,15 @@ iterate_exports(const module_data_t *info, bool add)
 static bool
 library_matches_filter(const module_data_t *info)
 {
-    if (options.only_to_lib[0] != '\0') {
+    if (op_only_to_lib.get_value().c_str()[0] != '\0') {
         const char *libname = dr_module_preferred_name(info);
-        return (libname != NULL && strcasestr(libname, options.only_to_lib) != NULL);
+#ifdef WINDOWS
+        return (libname != NULL && strcasestr(libname,
+                                              op_only_to_lib.get_value().c_str()) != NULL);
+#else
+        return (libname != NULL && strstr(libname,
+                                          op_only_to_lib.get_value().c_str()) != NULL);
+#endif
     }
     return true;
 }
@@ -362,10 +351,11 @@ static void
 open_log_file(void)
 {
     char buf[MAXIMUM_PATH];
-    if (strcmp(options.logdir, "-") == 0)
+    if (strcmp(op_logdir.get_value().c_str(), "-") == 0)
         outf = STDERR;
     else {
-        outf = drx_open_unique_appid_file(options.logdir, dr_get_process_id(),
+        outf = drx_open_unique_appid_file(op_logdir.get_value().c_str(),
+                                          dr_get_process_id(),
                                           "drltrace", "log",
 #ifndef WINDOWS
                                           DR_FILE_CLOSE_ON_FORK |
@@ -390,45 +380,23 @@ event_fork(void *drcontext)
 static void
 event_exit(void)
 {
-    if (options.max_args > 0)
+    if (op_max_args.get_value() > 0)
         drsys_exit();
 
     if (outf != STDERR) {
-        if (options.print_ret_addr)
+        if (op_print_ret_addr.get_value())
             drmodtrack_dump(outf);
         dr_close_file(outf);
     }
     drx_exit();
     drwrap_exit();
     drmgr_exit();
-    if (options.print_ret_addr)
+    if (op_print_ret_addr.get_value())
         drmodtrack_exit();
 }
 
-static void
-options_init(client_id_t id)
-{
-    std::string parse_err;
-    if (!dr_parse_options(id, &parse_err, NULL))
-        ASSERT(false, "unable to parse options specified for drltracelib");
-
-    op_print_stderr = true;
-
-    /* to avoid numerous get_value() calls we copy all options here */
-    options.ignore_underscore = op_ignore_underscore.get_value();
-    dr_snprintf(options.logdir, BUFFER_SIZE_ELEMENTS(options.logdir), "%s",
-                op_logdir.get_value().c_str());
-    options.max_args = op_max_args.get_value();
-    options.num_unknown_args = op_unknown_args.get_value();
-    options.only_from_app = op_only_from_app.get_value();
-    dr_snprintf(options.only_to_lib, BUFFER_SIZE_ELEMENTS(options.logdir), "%s",
-                op_only_to_lib.get_value().c_str());
-    options.print_ret_addr = op_print_ret_addr.get_value();
-
-}
-
 DR_EXPORT void
-dr_init(client_id_t id)
+dr_client_main(client_id_t id, int argc, const char *argv[])
 {
     module_data_t *exe;
     drsys_options_t ops = { sizeof(ops), 0, };
@@ -436,7 +404,11 @@ dr_init(client_id_t id)
 
     dr_set_client_name("Dr. LTrace", "http://drmemory.org/issues");
 
-    options_init(id);
+    if (!droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv,
+                                       NULL, NULL))
+        ASSERT(false, "unable to parse options specified for drltracelib");
+
+    op_print_stderr = true;
 
     IF_DEBUG(ok = )
         drmgr_init();
@@ -447,7 +419,7 @@ dr_init(client_id_t id)
     IF_DEBUG(ok = )
         drx_init();
     ASSERT(ok, "drx failed to initialize");
-    if (options.print_ret_addr) {
+    if (op_print_ret_addr.get_value()) {
         IF_DEBUG(ok = )
             drmodtrack_init();
         ASSERT(ok == DRCOVLIB_SUCCESS, "drmodtrack failed to initialize");
@@ -464,7 +436,7 @@ dr_init(client_id_t id)
      * we don't care about the app context.
      */
     drwrap_set_global_flags((drwrap_global_flags_t)
-                                (DRWRAP_NO_FRILLS | DRWRAP_FAST_CLEANCALLS));
+                            (DRWRAP_NO_FRILLS | DRWRAP_FAST_CLEANCALLS));
 
     dr_register_exit_event(event_exit);
 #ifdef UNIX
@@ -476,7 +448,7 @@ dr_init(client_id_t id)
 #ifdef WINDOWS
     dr_enable_console_printing();
 #endif
-    if (options.max_args > 0)
+    if (op_max_args.get_value() > 0)
         drsys_init(id, &ops);
 
     open_log_file();

--- a/drltrace/drltrace_frontend.cpp
+++ b/drltrace/drltrace_frontend.cpp
@@ -41,7 +41,7 @@
 #include "dr_inject.h"
 #include "dr_config.h"
 #include "dr_frontend.h"
-#include "droption.h"
+#include "drltrace_options.h"
 #undef TESTANY
 #include "utils.h"
 #include <string.h>
@@ -73,58 +73,6 @@
         DRLTRACE_ERROR("drfront_bufprint failed: %d\n", sc); \
     NULL_TERMINATE_BUFFER(buf); \
 } while (0)
-
-/* Frontend scope is defined here because if logdir is a forbidden path we have to change
- * it and provide for our client manually.
- */
-static droption_t<std::string> op_logdir
-(DROPTION_SCOPE_FRONTEND, "logdir", ".", "Log directory to print library call data",
- "Specify log directory where library call data will be written, in a separate file per "
- "process.  The default value is \".\" (current dir).  If set to \"-\", data for all "
- "processes are printed to stderr (warning: this can be slow).");
-
-static droption_t<bool> op_only_from_app
-(DROPTION_SCOPE_CLIENT, "only_from_app", false, "Reports only library calls from the app",
- "Only reports library calls from the application itself, as opposed to all calls even "
- "from other libraries or within the same library.");
-
-static droption_t<bool> op_follow_children
-(DROPTION_SCOPE_FRONTEND, "follow_children", true, "Trace child processes",
- "Trace child processes created by a target application. Specify -no_follow_children "
- "to disable.");
-
-static droption_t<bool> op_print_ret_addr
-(DROPTION_SCOPE_CLIENT, "print_ret_addr", false, "Print library call's return address",
- "Print return addresses of library calls.");
-
-static droption_t<uint> op_unknown_args
-(DROPTION_SCOPE_CLIENT, "num_unknown_args", 2, "Number of unknown libcall args to print",
- "Number of arguments to print for unknown library calls.  Specify 0 to disable "
- "unknown args printing.");
-
-static droption_t<uint> op_max_args
-(DROPTION_SCOPE_CLIENT, "num_max_args", 6, "Maximum number of arguments to print",
- "Maximum number of arguments to print.  This option allows to limit the number of "
- "arguments to be printed.  Specify 0 to disable args printing (including unknown).");
-
-static droption_t<bool> op_ignore_underscore
-(DROPTION_SCOPE_CLIENT, "ignore_underscore", false, "Ignores library routine names "
- "starting with \"_\".", "Ignores library routine names starting with \"_\".");
-
-static droption_t<bool> op_help
-(DROPTION_SCOPE_FRONTEND, "help", false, "Print this message.", "Print this message");
-
-static droption_t<bool> op_version
-(DROPTION_SCOPE_FRONTEND, "version", 0, "Print version number.", "Print version number.");
-
-static droption_t<unsigned int> op_verbose
-(DROPTION_SCOPE_ALL, "verbose", 1, "Change verbosity.", "Change verbosity.");
-
-static droption_t<std::string> op_ltracelib_ops
-(DROPTION_SCOPE_CLIENT, "ltracelib_ops",
- DROPTION_FLAG_SWEEP | DROPTION_FLAG_ACCUMULATE | DROPTION_FLAG_INTERNAL,
- "", "(For internal use: sweeps up drltracelib options)",
- "This is an internal option that sweeps up other options to pass to the drltracelib.");
 
 /* check that drltracelib.dll, dynamorio.dll and target executable exist */
 static void

--- a/drltrace/drltrace_options.h
+++ b/drltrace/drltrace_options.h
@@ -70,7 +70,7 @@ static droption_t<bool> op_ignore_underscore
 
 static droption_t<std::string> op_only_to_lib
 (DROPTION_SCOPE_CLIENT, "only_to_lib", "", "Only reports calls to the library <lib_name>. ",
- "Only reports calls to the library <lib_name>. Argument is case insensitive.");
+ "Only reports calls to the library <lib_name>. Argument is case insensitive on Windows.");
 
 static droption_t<bool> op_help
 (DROPTION_SCOPE_FRONTEND, "help", false, "Print this message.", "Print this message");

--- a/drltrace/drltrace_options.h
+++ b/drltrace/drltrace_options.h
@@ -59,7 +59,7 @@ static droption_t<uint> op_unknown_args
  "Number of arguments to print for unknown library calls.  Specify 0 to disable "
  "unknown args printing.");
 
-static droption_t<uint> op_max_args
+static droption_t<int> op_max_args
 (DROPTION_SCOPE_CLIENT, "num_max_args", 6, "Maximum number of arguments to print",
  "Maximum number of arguments to print.  This option allows to limit the number of "
  "arguments to be printed.  Specify 0 to disable args printing (including unknown).");
@@ -69,7 +69,7 @@ static droption_t<bool> op_ignore_underscore
  "starting with \"_\".", "Ignores library routine names starting with \"_\".");
 
 static droption_t<std::string> op_only_to_lib
-(DROPTION_SCOPE_CLIENT, "only_to_lib", "\0", "Only reports calls to the library <lib_name>. ",
+(DROPTION_SCOPE_CLIENT, "only_to_lib", "", "Only reports calls to the library <lib_name>. ",
  "Only reports calls to the library <lib_name>. Argument is case insensitive.");
 
 static droption_t<bool> op_help

--- a/drltrace/drltrace_options.h
+++ b/drltrace/drltrace_options.h
@@ -35,7 +35,7 @@
  * it and provide for our client manually.
  */
 static droption_t<std::string> op_logdir
-(DROPTION_SCOPE_FRONTEND, "logdir", ".", "Log directory to print library call data",
+(DROPTION_SCOPE_ALL, "logdir", ".", "Log directory to print library call data",
  "Specify log directory where library call data will be written, in a separate file per "
  "process.  The default value is \".\" (current dir).  If set to \"-\", data for all "
  "processes are printed to stderr (warning: this can be slow).");

--- a/drltrace/drltrace_options.h
+++ b/drltrace/drltrace_options.h
@@ -1,0 +1,89 @@
+/* ***************************************************************************
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * ***************************************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "droption.h"
+/* Frontend scope is defined here because if logdir is a forbidden path we have to change
+ * it and provide for our client manually.
+ */
+static droption_t<std::string> op_logdir
+(DROPTION_SCOPE_FRONTEND, "logdir", ".", "Log directory to print library call data",
+ "Specify log directory where library call data will be written, in a separate file per "
+ "process.  The default value is \".\" (current dir).  If set to \"-\", data for all "
+ "processes are printed to stderr (warning: this can be slow).");
+
+static droption_t<bool> op_only_from_app
+(DROPTION_SCOPE_CLIENT, "only_from_app", false, "Reports only library calls from the app",
+ "Only reports library calls from the application itself, as opposed to all calls even "
+ "from other libraries or within the same library.");
+
+static droption_t<bool> op_follow_children
+(DROPTION_SCOPE_FRONTEND, "follow_children", true, "Trace child processes",
+ "Trace child processes created by a target application. Specify -no_follow_children "
+ "to disable.");
+
+static droption_t<bool> op_print_ret_addr
+(DROPTION_SCOPE_CLIENT, "print_ret_addr", false, "Print library call's return address",
+ "Print return addresses of library calls.");
+
+static droption_t<uint> op_unknown_args
+(DROPTION_SCOPE_CLIENT, "num_unknown_args", 2, "Number of unknown libcall args to print",
+ "Number of arguments to print for unknown library calls.  Specify 0 to disable "
+ "unknown args printing.");
+
+static droption_t<uint> op_max_args
+(DROPTION_SCOPE_CLIENT, "num_max_args", 6, "Maximum number of arguments to print",
+ "Maximum number of arguments to print.  This option allows to limit the number of "
+ "arguments to be printed.  Specify 0 to disable args printing (including unknown).");
+
+static droption_t<bool> op_ignore_underscore
+(DROPTION_SCOPE_CLIENT, "ignore_underscore", false, "Ignores library routine names "
+ "starting with \"_\".", "Ignores library routine names starting with \"_\".");
+
+static droption_t<std::string> op_only_to_lib
+(DROPTION_SCOPE_CLIENT, "only_to_lib", "\0", "Only reports calls to the library <lib_name>. ",
+ "Only reports calls to the library <lib_name>. Argument is case insensitive.");
+
+static droption_t<bool> op_help
+(DROPTION_SCOPE_FRONTEND, "help", false, "Print this message.", "Print this message");
+
+static droption_t<bool> op_version
+(DROPTION_SCOPE_FRONTEND, "version", 0, "Print version number.", "Print version number.");
+
+static droption_t<unsigned int> op_verbose
+(DROPTION_SCOPE_ALL, "verbose", 1, "Change verbosity.", "Change verbosity.");
+
+static droption_t<std::string> op_ltracelib_ops
+(DROPTION_SCOPE_CLIENT, "ltracelib_ops",
+ DROPTION_FLAG_SWEEP | DROPTION_FLAG_ACCUMULATE | DROPTION_FLAG_INTERNAL,
+ "", "(For internal use: sweeps up drltracelib options)",
+ "This is an internal option that sweeps up other options to pass to the drltracelib.");
+


### PR DESCRIPTION
Added droption usage instead of manual parsing in the drltrace client.
Added only_to_lib argument support in the drltrace_frontend.
Made only_to_lib case insensitive.
Drltrace is changed to be C++.