### PR TITLE
DRi#2167 shrink pdbs: set space-saving linker options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -955,6 +955,13 @@ if (DEFINED GENERATE_PDBS AND NOT GENERATE_PDBS)
   endforeach ()
 endif (DEFINED GENERATE_PDBS AND NOT GENERATE_PDBS)
 
+# Shrink binaries and pdbs (/Gy should already be there)
+foreach (var CMAKE_EXE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER};
+    CMAKE_MODULE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER};
+    CMAKE_SHARED_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER})
+  set(${var} "${${var}} /opt:ref /opt:icf /pdbcompress")
+endforeach ()
+
 if (APPLE)
   # install_name_tool needs write access (i#1372)
   set(owner_access OWNER_READ OWNER_WRITE)
@@ -1326,6 +1333,8 @@ if (WIN32)
 
   # Reduce size by stripping out unused code (we don't seem to need /Gy for this,
   # and VS generators seem to set it already, so we add here for Ninja).
+  # XXX: DRi#2167 is adding this for all clients so we can remove this once
+  # we update to a recent DR.
   set(new_flags "${new_flags} /opt:ref")
   if (NOT DEBUG_BUILD)
     # Match DR's settings, though again it's not clear the benefit w/o /Gy.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -956,11 +956,13 @@ if (DEFINED GENERATE_PDBS AND NOT GENERATE_PDBS)
 endif (DEFINED GENERATE_PDBS AND NOT GENERATE_PDBS)
 
 # Shrink binaries and pdbs (/Gy should already be there)
-foreach (var CMAKE_EXE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER};
-    CMAKE_MODULE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER};
-    CMAKE_SHARED_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER})
-  set(${var} "${${var}} /opt:ref /opt:icf /pdbcompress")
-endforeach ()
+if (WIN32)
+  foreach (var CMAKE_EXE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER};
+      CMAKE_MODULE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER};
+      CMAKE_SHARED_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER})
+    set(${var} "${${var}} /opt:ref /opt:icf /pdbcompress")
+  endforeach ()
+endif ()
 
 if (APPLE)
   # install_name_tool needs write access (i#1372)


### PR DESCRIPTION
Sets the linker options "/opt:ref /opt:icf /pdbcompress" globally to shrink
binary and pdb sizes on Windows.