### PR TITLE
i#1948 drltrace libcall args printing: android tests and config fix

### DIFF
--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -135,7 +135,6 @@ set(conf_out ${PROJECT_BINARY_DIR}/${BUILD_BIN}/drltrace.config)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/drltrace.config ${conf_out} COPYONLY)
 install(FILES ${conf_out} DESTINATION "${INSTALL_BIN}" PERMISSIONS ${owner_access}
         GROUP_READ WORLD_READ)
-copy_target_to_device(${conf_out})
 
 ##################################################
 # drltrace tests

--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -135,6 +135,7 @@ set(conf_out ${PROJECT_BINARY_DIR}/${BUILD_BIN}/drltrace.config)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/drltrace.config ${conf_out} COPYONLY)
 install(FILES ${conf_out} DESTINATION "${INSTALL_BIN}" PERMISSIONS ${owner_access}
         GROUP_READ WORLD_READ)
+copy_target_to_device(${conf_out})
 
 ##################################################
 # drltrace tests

--- a/drltrace/drltrace.config
+++ b/drltrace/drltrace.config
@@ -1,46 +1,46 @@
-; ***************************************************************************
-; Copyright (c) 2017 Google, Inc.  All rights reserved.
-; ***************************************************************************
-;
-;
-; Redistribution and use in source and binary forms, with or without
-; modification, are permitted provided that the following conditions are met:
-;
-; * Redistributions of source code must retain the above copyright notice,
-;   this list of conditions and the following disclaimer.
-;
-; * Redistributions in binary form must reproduce the above copyright notice,
-;   this list of conditions and the following disclaimer in the documentation
-;   and/or other materials provided with the distribution.
-;
-; * Neither the name of Google, Inc. nor the names of its contributors may be
-;   used to endorse or promote products derived from this software without
-;   specific prior written permission.
-;
-; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-; ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
-; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-; LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-; OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-; DAMAGE.
-;
+# ***************************************************************************
+# Copyright (c) 2017 Google, Inc.  All rights reserved.
+# ***************************************************************************
+#
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Google, Inc. nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+#
 
-; ***************************************************************************
-; drltrace default config file for library call arguments printing
+# ***************************************************************************
+# drltrace default config file for library call arguments printing
 
-; The syntax of this config file is simple. To add a new function, it's enough to specify
-; function's return type, function name and each argument of the function separated by
-; a pipe | symbol.
-; Example: int strcmp (char *, char *) -> int|strcmp|char *|char *
-; i#1948: The syntax now does not cover many other more complex function prototypes
-; e.g. atexit(). We need to improve that.
-;
-; NOTE: the syntax is not space sensitive.
+# The syntax of this config file is simple. To add a new function, it's enough to specify
+# function's return type, function name and each argument of the function separated by
+# a pipe | symbol.
+# Example: int strcmp (char *, char *) -> int|strcmp|char *|char *
+# i#1948: The syntax now does not cover many other more complex function prototypes
+# e.g. atexit(). We need to improve that.
+#
+# NOTE: the syntax is not space sensitive.
 
 int|strcmp|char *|char *
 int|wcscmp|wchar *|wchar *

--- a/drltrace/drltrace.dox
+++ b/drltrace/drltrace.dox
@@ -65,7 +65,7 @@ The usefull runtime options for this tool include:
  - \b -num_max_args:
     Maximum number of arguments to print.
  - \b -config dir:
-    A path where config file is located.
+    A path where a custom user defined config file is located.
  - \b -use_config:
     Use config file for library call arguments printing.
 Here is an example:

--- a/drltrace/drltrace_libcalls.cpp
+++ b/drltrace/drltrace_libcalls.cpp
@@ -195,7 +195,7 @@ parse_line(const char *line, int line_num)
     if (line == NULL)
         return false;
 
-    if (line[0] == ';') /* just a comment */
+    if (line[0] == '#') /* just a comment */
         return true;
 
     if (strlen(line) <= 0 || line[0] == '\n' || line[0] == '\r')

--- a/drltrace/drltrace_options.cpp
+++ b/drltrace/drltrace_options.cpp
@@ -72,7 +72,7 @@ droption_t<bool> op_config_file_default
  "no_use_config and provide a path to custom config file using -config option.");
 
 droption_t<std::string> op_config_file
-(DROPTION_SCOPE_ALL, "config", "", "The path to drltrace's config file.",
+(DROPTION_SCOPE_ALL, "config", "", "The path to custom config file.",
  "Specify a custom path where config is located. The config file describes the prototype"
  " of library functions for printing library call arguments.  See drltrace documentation"
  " for more details.");


### PR DESCRIPTION
Changed comment delimeter from ; to # in config file
Added config file copying on Android device
Fixed description of drltrace arguments for config file