### PR TITLE
i#111 x64: stack slowpath and redzone handling

### DIFF
--- a/drmemory/stack.h
+++ b/drmemory/stack.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -45,6 +45,13 @@ extern uint zero_loop_aborts_thresh;
  * constant for typical min stack size
  */
 #define TYPICAL_STACK_MIN_SIZE (32*1024)
+
+/* Some ABI's have a stack redzone which we want to mark uninit. */
+#if defined(X86_64) && defined(UNIX)
+# define BEYOND_TOS_REDZONE_SIZE 128
+#else
+# define BEYOND_TOS_REDZONE_SIZE 0
+#endif
 
 /* Indicates what action to take on SP adjustments.  Different from esp_adjust_t
  * in stack.c, which is about what kind of adjustment is being made by the app.

--- a/drmemory/stack_x86.c
+++ b/drmemory/stack_x86.c
@@ -698,8 +698,6 @@ generate_shared_esp_fastpath_helper(void *drcontext, instrlist_t *bb,
     /* We make this signed so that 0xffffffff will encode for x64 as -1. */
     int shadow_dqword_newmem = (sp_action == SP_ADJUST_ACTION_DEFINED ?
                                 SHADOW_DQWORD_DEFINED : SHADOW_DQWORD_UNDEFINED);
-    ASSERT(shadow_dqword_newmem == -1 || shadow_dqword_newmem == 0,
-           "shadow dqword must be -1 or 0");
 
     push_unaligned = INSTR_CREATE_label(drcontext);
     push_aligned = INSTR_CREATE_label(drcontext);

--- a/drmemory/syscall_linux.c
+++ b/drmemory/syscall_linux.c
@@ -156,6 +156,12 @@ handle_clone(void *drcontext, dr_mcontext_t *mc)
                 /* assume that above newsp should stay defined */
                 shadow_set_range(stack_base, newsp, SHADOW_UNADDRESSABLE);
                 check_stack_size_vs_threshold(drcontext, stack_size);
+                if (BEYOND_TOS_REDZONE_SIZE > 0) {
+                    size_t redzone_sz = BEYOND_TOS_REDZONE_SIZE;
+                    if (newsp - BEYOND_TOS_REDZONE_SIZE < stack_base)
+                        redzone_sz = newsp - stack_base;
+                    shadow_set_range(newsp - redzone_sz, newsp, SHADOW_UNDEFINED);
+                }
             }
         } else {
             LOG(0, "ERROR: cannot find bounds of new thread's stack "PFX"\n",


### PR DESCRIPTION
Adds 64-bit shadow-memory handling of stack operations in the slowpath (the
fastpath is NYI for 64-bit), including handling of the 128-byte UNIX ABI
stack redzone, which requires additional shadow writes to maintain the
shifted addressability boundary.

Issue: 111