### PR TITLE
i#111 x64: 64-bit shadow slowpath

### DIFF
--- a/drmemory/alloc_drmem.c
+++ b/drmemory/alloc_drmem.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1339,7 +1339,7 @@ client_stack_dealloc(byte *start, byte *end)
             shadow_set_range(start, end, SHADOW_UNADDRESSABLE);
     }
     if (options.shadowing && options.check_uninitialized)
-        register_shadow_set_dword(DR_REG_PTR_RETURN, SHADOW_DEFINED);
+        register_shadow_set_ptrsz(DR_REG_PTR_RETURN, SHADOW_PTRSZ_DEFINED);
 }
 
 /* Non-interpreted code about to write to app-visible memory */
@@ -1425,30 +1425,30 @@ client_pre_syscall(void *drcontext, int sysnum)
             safe_read(&cxt->Xsp, sizeof(cxt_xsp), &cxt_xsp)) {
             /* FIXME: what if the syscall fails? */
             if (TESTALL(CONTEXT_CONTROL/*2 bits so ALL*/, cxt_flags)) {
-                register_shadow_set_dword(REG_XSP,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xsp));
+                register_shadow_set_ptrsz(REG_XSP,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xsp));
 # ifndef X64
-                register_shadow_set_dword(REG_XBP,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xbp));
+                register_shadow_set_ptrsz(REG_XBP,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xbp));
 # endif
             }
             if (TESTALL(CONTEXT_INTEGER/*2 bits so ALL*/, cxt_flags)) {
-                register_shadow_set_dword(REG_XAX,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xax));
-                register_shadow_set_dword(REG_XCX,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xcx));
-                register_shadow_set_dword(REG_XDX,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xdx));
-                register_shadow_set_dword(REG_XBX,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xbx));
+                register_shadow_set_ptrsz(REG_XAX,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xax));
+                register_shadow_set_ptrsz(REG_XCX,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xcx));
+                register_shadow_set_ptrsz(REG_XDX,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xdx));
+                register_shadow_set_ptrsz(REG_XBX,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xbx));
 # ifdef X64
-                register_shadow_set_dword(REG_XBP,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xbp));
+                register_shadow_set_ptrsz(REG_XBP,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xbp));
 # endif
-                register_shadow_set_dword(REG_XSI,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xsi));
-                register_shadow_set_dword(REG_XDI,
-                                          shadow_get_byte(&info, (app_pc)&cxt->Xdi));
+                register_shadow_set_ptrsz(REG_XSI,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xsi));
+                register_shadow_set_ptrsz(REG_XDI,
+                                          shadow_get_ptrsz(&info, (app_pc)&cxt->Xdi));
             }
             /* Mark stack AFTER reading cxt since cxt may be on stack! */
             if (TESTALL(CONTEXT_CONTROL/*2 bits so ALL*/, cxt_flags)) {

--- a/drmemory/fuzzer.c
+++ b/drmemory/fuzzer.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -1030,7 +1030,7 @@ shadow_state_restore_stack_frame(dr_mcontext_t *mc, shadow_state_t *shadow)
     uint i;
 
     for (i = 0; i < fuzz_target.arg_count_regs; i++) {
-        register_shadow_set_dword(fuzz_target.callconv_args->regs[i],
+        register_shadow_set_ptrsz(fuzz_target.callconv_args->regs[i],
                                   shadow->reg_args[i]);
     }
     shadow_restore_region(shadow->stack_shadow);

--- a/drmemory/leak.c
+++ b/drmemory/leak.c
@@ -1106,12 +1106,14 @@ check_reachability_helper(byte *start, byte *end, bool skip_heap,
 #endif
                 /* don't count references in DR data */
                 dr_memory_is_dr_internal(pc) ||
+#ifdef TOOL_DR_MEMORY
+                /* skip over shadow memory */
+                shadow_memory_is_shadow(pc) ||
+#endif
                 /* don't count references in DrMem data (e.g., report.c's
                  * page_buf holds a page's worth of old stack data)
                  */
-                dr_memory_is_in_client(pc) ||
-                /* skip over shadow memory */
-                shadow_memory_is_shadow(pc)) {
+                dr_memory_is_in_client(pc)) {
                 if (query_end < pc) /* overflow */
                     break;
                 pc = query_end;

--- a/drmemory/leak.c
+++ b/drmemory/leak.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1109,7 +1109,9 @@ check_reachability_helper(byte *start, byte *end, bool skip_heap,
                 /* don't count references in DrMem data (e.g., report.c's
                  * page_buf holds a page's worth of old stack data)
                  */
-                dr_memory_is_in_client(pc)) {
+                dr_memory_is_in_client(pc) ||
+                /* skip over shadow memory */
+                shadow_memory_is_shadow(pc)) {
                 if (query_end < pc) /* overflow */
                     break;
                 pc = query_end;

--- a/drmemory/shadow.c
+++ b/drmemory/shadow.c
@@ -1818,8 +1818,10 @@ get_shadow_register_common(shadow_registers_t *sr, reg_id_t reg)
     } else if (sz == OPSZ_8) {
         IF_NOT_X86(ASSERT_NOT_REACHED());
         val = *(ushort*)addr;
-    } else
+    } else {
+        val = 0;
         ASSERT_NOT_REACHED();
+    }
     return val;
 }
 

--- a/drmemory/shadow.c
+++ b/drmemory/shadow.c
@@ -109,6 +109,7 @@ bitmapx2_byte(bitmap_t bm, uint i)
     return (bm[BITMAPx2_IDX(i)] >> BITMAPx2_SHIFT(i)) & 0xff;
 }
 
+#ifdef X64
 /* returns the ushort corresponding to offset i */
 static inline uint
 bitmapx2_ushort(bitmap_t bm, uint i)
@@ -116,6 +117,7 @@ bitmapx2_ushort(bitmap_t bm, uint i)
     ASSERT(BITMAPx2_SHIFT(i) %16 == 0, "bitmapx2_ushort: index not aligned");
     return (bm[BITMAPx2_IDX(i)] >> BITMAPx2_SHIFT(i)) & 0xffff;
 }
+#endif
 
 /* returns the uint corresponding to offset i */
 static inline uint
@@ -149,6 +151,7 @@ bytemap_4to1_byte(bitmap_t bm, uint i)
     return bytes[BLOCK_AS_BYTE_ARRAY_IDX(i)];
 }
 
+#ifdef X64
 /* returns the ushort corresponding to offset i */
 static inline uint
 bytemap_4to1_ushort(bitmap_t bm, uint i)
@@ -156,6 +159,7 @@ bytemap_4to1_ushort(bitmap_t bm, uint i)
     char *bytes = (char *) bm;
     return *(ushort*)(&bytes[BLOCK_AS_BYTE_ARRAY_IDX(i)]);
 }
+#endif
 
 /***************************************************************************
  * MEMORY SHADOWING DATA STRUCTURES

--- a/drmemory/shadow.c
+++ b/drmemory/shadow.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -109,6 +109,14 @@ bitmapx2_byte(bitmap_t bm, uint i)
     return (bm[BITMAPx2_IDX(i)] >> BITMAPx2_SHIFT(i)) & 0xff;
 }
 
+/* returns the ushort corresponding to offset i */
+static inline uint
+bitmapx2_ushort(bitmap_t bm, uint i)
+{
+    ASSERT(BITMAPx2_SHIFT(i) %16 == 0, "bitmapx2_ushort: index not aligned");
+    return (bm[BITMAPx2_IDX(i)] >> BITMAPx2_SHIFT(i)) & 0xffff;
+}
+
 /* returns the uint corresponding to offset i */
 static inline uint
 bitmapx2_dword(bitmap_t bm, uint i)
@@ -139,6 +147,14 @@ bytemap_4to1_byte(bitmap_t bm, uint i)
 {
     char *bytes = (char *) bm;
     return bytes[BLOCK_AS_BYTE_ARRAY_IDX(i)];
+}
+
+/* returns the ushort corresponding to offset i */
+static inline uint
+bytemap_4to1_ushort(bitmap_t bm, uint i)
+{
+    char *bytes = (char *) bm;
+    return *(ushort*)(&bytes[BLOCK_AS_BYTE_ARRAY_IDX(i)]);
 }
 
 /***************************************************************************
@@ -395,6 +411,44 @@ shadow_get_dword(INOUT umbra_shadow_memory_info_t *info, app_pc addr)
         return bitmapx2_byte((bitmap_t)info->shadow_base, idx);
     else /* just return byte */
         return bytemap_4to1_byte((bitmap_t)info->shadow_base, idx);
+}
+
+#ifdef X64
+uint
+shadow_get_qword(INOUT umbra_shadow_memory_info_t *info, app_pc addr)
+{
+    ptr_uint_t idx;
+    if (addr < info->app_base || addr >= info->app_base + info->app_size) {
+        ASSERT(info->struct_size == sizeof(*info),
+               "shadow memory info is not initialized properly");
+        if (umbra_get_shadow_memory(umbra_map, addr,
+                                    NULL, info) != DRMF_SUCCESS) {
+            ASSERT(false, "fail to get shadow memory info");
+            return 0;
+        }
+    }
+    /* avoid a fault: if no shadow yet, it's unaddr */
+    if (info->shadow_type == UMBRA_SHADOW_MEMORY_TYPE_SHADOW_NOT_ALLOC)
+        return SHADOW_DWORD_UNADDRESSABLE;
+    /* if non-app-memory (no shadow supported there for x64), it's unaddr */
+    if (info->shadow_type == UMBRA_SHADOW_MEMORY_TYPE_NOT_SHADOW)
+        return SHADOW_DWORD_UNADDRESSABLE;
+    idx = ((ptr_uint_t)ALIGN_BACKWARD(addr, 8)) - (ptr_uint_t)info->app_base;
+    if (!MAP_4B_TO_1B)
+        return bitmapx2_ushort((bitmap_t)info->shadow_base, idx);
+    else /* just return byte */
+        return bytemap_4to1_ushort((bitmap_t)info->shadow_base, idx);
+}
+#endif
+
+uint
+shadow_get_ptrsz(INOUT umbra_shadow_memory_info_t *info, app_pc addr)
+{
+#ifdef X64
+    return shadow_get_qword(info, addr);
+#else
+    return shadow_get_dword(info, addr);
+#endif
 }
 
 /* Sets the two bits for the byte at the passed-in address */
@@ -1478,14 +1532,14 @@ typedef struct _shadow_registers_t {
     shadow_reg_type_t r14;
     shadow_reg_type_t r15;
 # endif
-    /* Third/fifth TLS slot.  We go ahead and write DWORD values here
+    /* Third/fifth TLS slot.  We go ahead and write GPR-sized values here
      * for simplicity in our fastpath even though we treat this as
      * a single tracked value.
      */
-    byte eflags;
+    shadow_reg_type_t eflags;
     /* Used for PR 578892.  Should remain a very small integer so byte is fine. */
     byte in_heap_routine;
-    byte padding[IF_X64_ELSE(6,2)];
+    byte padding[IF_X64_ELSE(4,2)];
     /* Fourth/sixth TLS slot, which provides indirection to additional
      * shadow memory.
      */
@@ -1515,8 +1569,8 @@ opnd_create_shadow_reg_slot(reg_id_t reg)
     ASSERT(options.shadowing, "incorrectly called");
     if (reg_is_gpr(reg)) {
         reg_id_t r = reg_to_pointer_sized(reg);
-        offs = (r - DR_REG_START_GPR) * IF_X64_ELSE(2, 1);
-        opsz = IF_X64_ELSE(OPSZ_2, OPSZ_1);
+        offs = (r - DR_REG_START_GPR) * sizeof(shadow_reg_type_t);
+        opsz = IF_X64(reg_is_32bit(reg) ? OPSZ_1 :) SHADOW_GPR_OPSZ;
     } else {
         ASSERT(reg_is_xmm(reg) || reg_is_mmx(reg), "internal shadow reg error");
         offs = offsetof(shadow_registers_t, aux);
@@ -1554,7 +1608,7 @@ opnd_create_shadow_eflags_slot(void)
     ASSERT(options.shadowing, "incorrectly called");
     return opnd_create_far_base_disp_ex
         (tls_shadow_seg, REG_NULL, REG_NULL, 1, tls_shadow_base +
-         offsetof(shadow_registers_t, eflags), OPSZ_1,
+         offsetof(shadow_registers_t, eflags), SHADOW_GPR_OPSZ,
          /* we do NOT want an addr16 prefix since most likely going to run on
           * Core or Core2, and P4 doesn't care that much */
          false, true, false);
@@ -1718,9 +1772,10 @@ reg_shadow_addr(shadow_registers_t *sr, reg_id_t reg)
     /* REG_NULL means eflags */
     if (reg == REG_NULL)
         return ((byte *)sr) + offsetof(shadow_registers_t, eflags);
-    else if (reg_is_gpr(reg))
-        return ((byte *)sr) + (reg_to_pointer_sized(reg) - DR_REG_START_GPR);
-    else {
+    else if (reg_is_gpr(reg)) {
+        return ((byte *)sr) +
+            (reg_to_pointer_sized(reg) - DR_REG_START_GPR)*sizeof(shadow_reg_type_t);
+    } else {
 #ifdef X86
         /* Caller must ask for xmm to get low bits (won't all fit in uint) */
         if (reg_is_ymm(reg))
@@ -1742,23 +1797,29 @@ reg_shadow_addr(shadow_registers_t *sr, reg_id_t reg)
 static uint
 get_shadow_register_common(shadow_registers_t *sr, reg_id_t reg)
 {
-    byte val;
+    uint val;
     opnd_size_t sz = reg_get_size(reg);
     byte *addr = reg_shadow_addr(sr, reg);
     ASSERT(options.shadowing, "incorrectly called");
     if (reg_is_xmm(reg) || reg_is_mmx(reg))
         return *(uint *)addr;
     ASSERT(reg_is_gpr(reg), "internal shadow reg error");
-    val = *addr;
     if (sz == OPSZ_1) {
+        val = *addr;
         if (reg_is_8bit_high(reg))
             val = (val & 0xc) >> 2;
         else
             val &= 0x3;
-    } else if (sz == OPSZ_2)
+    } else if (sz == OPSZ_2) {
+        val = *addr;
         val &= 0xf;
-    else
-        ASSERT(sz == OPSZ_4, "internal shadow reg error");
+    } else if (sz == OPSZ_4) {
+        val = *addr;
+    } else if (sz == OPSZ_8) {
+        IF_NOT_X86(ASSERT_NOT_REACHED());
+        val = *(ushort*)addr;
+    } else
+        ASSERT_NOT_REACHED();
     return val;
 }
 
@@ -1796,7 +1857,7 @@ register_shadow_set_byte(reg_id_t reg, uint bytenum, uint val)
     ASSERT(options.shadowing, "incorrectly called");
     while (shift > 7) {
         ASSERT(reg_is_xmm(reg) ||
-               (shift < 16 && reg_is_mmx(reg)), "shift too big for reg");
+               (shift < 16 IF_NOT_X64(&& reg_is_mmx(reg))), "shift too big for reg");
         addr++;
         shift -= 8;
     }
@@ -1811,6 +1872,38 @@ register_shadow_set_dword(reg_id_t reg, uint val)
     ASSERT(options.shadowing, "incorrectly called");
     ASSERT(reg_is_gpr(reg), "internal shadow reg error");
     *addr = (byte) val;
+}
+
+#ifdef X64
+void
+register_shadow_set_qword(reg_id_t reg, uint val)
+{
+    shadow_registers_t *sr = get_shadow_registers();
+    byte *addr = reg_shadow_addr(sr, reg);
+    ASSERT(options.shadowing, "incorrectly called");
+    ASSERT(reg_is_gpr(reg), "internal shadow reg error");
+    *(ushort *)addr = (ushort) val;
+}
+
+void
+register_shadow_set_high_dword(reg_id_t reg, uint val)
+{
+    shadow_registers_t *sr = get_shadow_registers();
+    byte *addr = reg_shadow_addr(sr, reg);
+    ASSERT(options.shadowing, "incorrectly called");
+    ASSERT(reg_is_gpr(reg), "internal shadow reg error");
+    *(addr+1) = (byte) val; /* little-endian */
+}
+#endif
+
+void
+register_shadow_set_ptrsz(reg_id_t reg, uint val)
+{
+#ifdef X64
+    register_shadow_set_qword(reg, val);
+#else
+    register_shadow_set_dword(reg, val);
+#endif
 }
 
 void

--- a/drmemory/shadow.h
+++ b/drmemory/shadow.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -120,6 +120,12 @@ const char *shadow_dqword_name(uint dqword);
 /* PR 493257: share shadow translation across multiple instrs */
 #define SHADOW_REDZONE_SIZE 512
 
+#ifdef X64
+# define SHADOW_GPR_OPSZ OPSZ_2
+#else
+# define SHADOW_GPR_OPSZ OPSZ_1
+#endif
+
 #ifdef STATISTICS
 extern uint shadow_block_alloc;
 extern uint shadow_block_free;
@@ -173,6 +179,16 @@ shadow_get_byte(INOUT umbra_shadow_memory_info_t *info, app_pc addr);
 /* see comment in shadow_get_byte about using umbra_shadow_memory_info_t */
 uint
 shadow_get_dword(INOUT umbra_shadow_memory_info_t *info, app_pc addr);
+
+#ifdef X64
+/* Returns the byte that shadows the 8-byte-aligned address */
+/* see comment in shadow_get_byte about using umbra_shadow_memory_info_t */
+uint
+shadow_get_qword(INOUT umbra_shadow_memory_info_t *info, app_pc addr);
+#endif
+
+uint
+shadow_get_ptrsz(INOUT umbra_shadow_memory_info_t *info, app_pc addr);
 
 /* Sets the two bits for the byte at the passed-in address */
 /* see comment in shadow_get_byte about using umbra_shadow_memory_info_t */
@@ -315,6 +331,17 @@ register_shadow_set_byte(reg_id_t reg, uint bytenum, uint val);
 
 void
 register_shadow_set_dword(reg_id_t reg, uint val);
+
+#ifdef X64
+void
+register_shadow_set_qword(reg_id_t reg, uint val);
+
+void
+register_shadow_set_high_dword(reg_id_t reg, uint val);
+#endif
+
+void
+register_shadow_set_ptrsz(reg_id_t reg, uint val);
 
 void
 register_shadow_set_dqword(reg_id_t reg, uint val);

--- a/drmemory/slowpath_x86.c
+++ b/drmemory/slowpath_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -504,7 +504,7 @@ is_rawmemchr_uninit(void *drcontext, app_pc pc, reg_id_t reg,
             memcmp(buf, RAWMEMCHR_PATTERN_NONMOVES,
                    sizeof(RAWMEMCHR_PATTERN_NONMOVES)) == 0) {
             LOG(3, "suppressing positive from glibc rawmemchr pattern\n");
-            register_shadow_set_dword(DR_REG_XCX, SHADOW_DWORD_DEFINED);
+            register_shadow_set_ptrsz(DR_REG_XCX, SHADOW_PTRSZ_DEFINED);
             STATS_INC(rawmemchr_exception);
             return true;
         }
@@ -2038,6 +2038,12 @@ assign_register_shadow_arch(shadow_combine_t *comb INOUT, int opnum, opnd_t opnd
             }
         }
     }
+# ifdef X64
+    if (opnd_get_size(opnd) == OPSZ_4 && reg_is_gpr(reg)) {
+        /* Writing to the 32-bit reg clears the top 32 bits. */
+        register_shadow_set_high_dword(reg, SHADOW_DWORD_DEFINED);
+    }
+# endif
     return false;
 }
 #endif /* TOOL_DR_MEMORY */

--- a/drmemory/syscall.c
+++ b/drmemory/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -555,7 +555,7 @@ event_post_syscall(void *drcontext, int sysnum)
 
     if (options.shadowing) {
         /* post-syscall, eax is defined */
-        register_shadow_set_dword(DR_REG_PTR_RETURN, SHADOW_DWORD_DEFINED);
+        register_shadow_set_ptrsz(DR_REG_PTR_RETURN, SHADOW_PTRSZ_DEFINED);
         if (success) {
             /* commit the writes via MEMREF_WRITE */
             if (drsys_iterate_memargs(drcontext, drsys_iter_memarg_cb, NULL) !=

--- a/tests/asmtest_x86.c
+++ b/tests/asmtest_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -294,6 +294,21 @@ GLOBAL_LABEL(FUNCNAME:)
     post_al_test:
         pop      REG_XAX
         pop      REG_XBX
+
+#ifdef X64
+        /***************************************************
+         * Test the top 32 bits being auto-defined.
+         */
+        jmp      top32_test
+    top32_test:
+        mov      r11d, DWORD [REG_XAX] /* undef */
+        shr      r11, 32
+        cmp      r11, 0
+        jne      top32_never_happens
+        nop
+    top32_never_happens:
+        nop
+#endif
 
         /***************************************************
          * XXX: add more tests here.  Avoid clobbering eax (holds undef mem) or


### PR DESCRIPTION
Generalizes register shadow operations on the slowpath for 64-bit.
Widens the eflags shadow to be 2 bytes to match the other registers, for
ease of propagation.

Clears the top 32 bits of a GPR when the bottom 32 bits are written and
adds an explicit test of this to asmtest.

Skips shadow memory on the leak scan and supports 2-byte shadow value
searches in umbra x64 to get leaks working for x64 shadow.

Fixes a -verbose 5 bug from changes in 33e1c26.

This gets 64-bit tests/free working with -no_fastpath -no_esp_fastpath.

Issue: 111