### PR TITLE
i#111 x64: heap mismatch generalization

### DIFF
--- a/common/alloc_replace.c
+++ b/common/alloc_replace.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -1961,18 +1961,19 @@ replace_free_common(arena_header_t *arena, void *ptr, alloc_flags_t flags,
             bool identified = false;
             bool valid = false;
             if (p != NULL) {
-                /* try 4 bytes back, in case this is an array w/ size passed to delete */
-                head = header_from_ptr(p - sizeof(int));
-                if (is_live_alloc(p - sizeof(int), arena, head)) {
-                    check_type_match(p - sizeof(int), head, free_type,
+                const size_t slot_sz = sizeof(size_t);
+                /* try one slot back, in case this is an array w/ size passed to delete */
+                head = header_from_ptr(p - slot_sz);
+                if (is_live_alloc(p - slot_sz, arena, head)) {
+                    check_type_match(p - slot_sz, head, free_type,
                                      flags, mc, caller);
                     identified = true;
                 }
                 if (!identified) {
-                    /* try 4 bytes in, in case this is a non-array passed to delete[] */
-                    head = header_from_ptr(p + sizeof(int));
-                    if (is_live_alloc(p + sizeof(int), arena, head)) {
-                        check_type_match(p + sizeof(int), head, free_type,
+                    /* try one slot in, in case this is a non-array passed to delete[] */
+                    head = header_from_ptr(p + slot_sz);
+                    if (is_live_alloc(p + slot_sz, arena, head)) {
+                        check_type_match(p + slot_sz, head, free_type,
                                          flags, mc, caller);
                         identified = true;
                     }

--- a/tests/cs2bug.cpp
+++ b/tests/cs2bug.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -177,12 +177,12 @@ test_leaks()
 static void
 test_exception()
 {
-   try {
-       std::cout << "throwing exception" << std::endl;
-       throw std::exception();
-   } catch (std::exception&) {
-       std::cout << "caught exception" << std::endl;
-   }
+    try {
+        std::cout << "throwing exception" << std::endl;
+        throw std::exception();
+    } catch (std::exception&) {
+        std::cout << "caught exception" << std::endl;
+    }
 }
 
 static void
@@ -198,10 +198,10 @@ test_mismatch_dtr()
     x = new hasdtr[7];
     if (setjmp(mark) == 0)
         free(x);
-    x = (hasdtr *) malloc(7);
+    x = (hasdtr *) malloc(42); /* big enough for hasdtr but same size for x64 */
     if (setjmp(mark) == 0)
         delete x;
-    x = (hasdtr *) malloc(7);
+    x = (hasdtr *) malloc(42); /* big enough for hasdtr but same size for x64 */
     if (setjmp(mark) == 0)
         delete[] x; /* unaddr reading size + dtr calls might crash before mismatch */
     /* not a mismatch, but test debug operator del (i#500) */

--- a/tests/cs2bug.res
+++ b/tests/cs2bug.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -112,5 +112,5 @@ cs2bug.cpp:195
 %ENDOPTIONAL
 : LEAK 88 direct bytes + 196 indirect bytes
 cs2bug.cpp:198
-: LEAK 7 direct bytes + 0 indirect bytes
+: LEAK 42 direct bytes + 0 indirect bytes
 cs2bug.cpp:204

--- a/tests/cs2bug.wrap.res
+++ b/tests/cs2bug.wrap.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -113,5 +113,5 @@ cs2bug.cpp:195
 %ENDOPTIONAL
 : LEAK 88 direct bytes + 196 indirect bytes
 cs2bug.cpp:198
-: LEAK 7 direct bytes + 0 indirect bytes
+: LEAK 42 direct bytes + 0 indirect bytes
 cs2bug.cpp:204

--- a/tests/reachable.res
+++ b/tests/reachable.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -102,7 +102,7 @@ cs2bug.cpp:195
 %ENDOPTIONAL
 : LEAK 88 direct bytes + 196 indirect bytes
 cs2bug.cpp:198
-: LEAK 7 direct bytes + 0 indirect bytes
+: LEAK 42 direct bytes + 0 indirect bytes
 cs2bug.cpp:204
 # ensure reachable leaks are printed, and after regular leaks
 REACHABLE LEAK


### PR DESCRIPTION
For C++ arrays, use size_t not int as the size of the array size field for
finding mismatches.

Fixes a cs2bug wart causing an extra error on x64.

Issue: 111