### PR TITLE
i#111 x64: preliminary full mode fastpath support

### DIFF
--- a/drmemory/fastpath.h
+++ b/drmemory/fastpath.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -121,10 +121,12 @@ typedef struct _fastpath_info_t {
     scratch_reg_info_t reg2;
     scratch_reg_info_t reg3;
     /* cached sub-scratch-regs */
+    reg_id_t reg1_16;
     reg_id_t reg1_8;
     reg_id_t reg2_16;
     reg_id_t reg2_8;
     reg_id_t reg2_8h;
+    reg_id_t reg3_16;
     reg_id_t reg3_8;
     /* is this instr using shared xl8? */
     bool use_shared;

--- a/drmemory/optionsx.h
+++ b/drmemory/optionsx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -890,7 +890,9 @@ OPTION_CLIENT_BOOL(internal, disable_crtdbg, true,
 #endif
 
 /* XXX i#1726: port the zeroing loop to ARM */
-OPTION_CLIENT_BOOL(internal, zero_stack, IF_ARM_ELSE(false, true),
+/* FIXME i#1205: zeroing conflicts w/ UNIX x64 redzone: NYI */
+OPTION_CLIENT_BOOL(internal, zero_stack,
+                   IF_ARM_ELSE(false, IF_X64_ELSE(IF_UNIX_ELSE(false, true), true)),
                    "When detecting leaks but not keeping definedness info, zero old stack frames",
                    "When detecting leaks but not keeping definedness info, zero old stack frames in order to avoid false negatives from stale stack values.  This is potentially unsafe.")
 OPTION_CLIENT_BOOL(internal, zero_retaddr, true,

--- a/drmemory/optionsx.h
+++ b/drmemory/optionsx.h
@@ -802,7 +802,8 @@ OPTION_CLIENT_BOOL(internal, size_in_redzone, true,
 OPTION_CLIENT_BOOL(internal, fastpath, true,
                    "Enable fastpath",
                    "Enable fastpath")
-OPTION_CLIENT_BOOL(internal, esp_fastpath, true,
+/* XXX i#2027: implement and enable for x64 */
+OPTION_CLIENT_BOOL(internal, esp_fastpath, IF_X64_ELSE(false, true),
                    "Enable esp-adjust fastpath",
                    "Enable esp-adjust fastpath")
 OPTION_CLIENT_BOOL(internal, shared_slowpath, true,
@@ -866,7 +867,8 @@ OPTION_CLIENT_BOOL(internal, repstr_to_loop, true,
 OPTION_CLIENT_BOOL(internal, replace_realloc, true,
                    "Replace realloc to avoid races and non-delayed frees",
                    "Replace realloc to avoid races and non-delayed frees")
-OPTION_CLIENT_BOOL(internal, share_xl8, true,
+/* XXX i#2025: enable for x64 once failures are fixed */
+OPTION_CLIENT_BOOL(internal, share_xl8, IF_X64_ELSE(false, true),
                    "Share translations among adjacent similar references",
                    "Share translations among adjacent similar references")
 OPTION_CLIENT(internal, share_xl8_max_slow, uint, 5000, 0, UINT_MAX/2,

--- a/drmemory/shadow.h
+++ b/drmemory/shadow.h
@@ -304,6 +304,11 @@ print_shadow_registers(void);
 opnd_t
 opnd_create_shadow_reg_slot(reg_id_t reg);
 
+#ifdef X64
+opnd_t
+opnd_create_shadow_reg_slot_high_dword(reg_id_t reg);
+#endif
+
 /* Also takes mmx reg */
 uint
 get_shadow_xmm_offs(reg_id_t reg);

--- a/drmemory/stack.c
+++ b/drmemory/stack.c
@@ -466,6 +466,8 @@ generate_shared_esp_fastpath(void *drcontext, instrlist_t *ilist, app_pc pc)
     int eflags_live;
     sp_adjust_action_t sp_action;
     esp_adjust_t type;
+    if (!options.esp_fastpath)
+        return pc;
     ASSERT(ESP_ADJUST_FAST_FIRST == 0, "esp enum error");
     /* No shared_esp_fastpath gencode for zeroing. */
     for (sp_action = 0; sp_action <= SP_ADJUST_ACTION_FASTPATH_MAX; sp_action++) {

--- a/drmemory/stack_x86.c
+++ b/drmemory/stack_x86.c
@@ -699,6 +699,8 @@ generate_shared_esp_fastpath_helper(void *drcontext, instrlist_t *bb,
     int shadow_dqword_newmem = (sp_action == SP_ADJUST_ACTION_DEFINED ?
                                 SHADOW_DQWORD_DEFINED : SHADOW_DQWORD_UNDEFINED);
 
+    IF_X64(ASSERT_NOT_IMPLEMENTED()); /* XXX i#2027: NYI */
+
     push_unaligned = INSTR_CREATE_label(drcontext);
     push_aligned = INSTR_CREATE_label(drcontext);
     push_one_done = INSTR_CREATE_label(drcontext);


### PR DESCRIPTION
Generalizes the full mode fastpath to handle 2-byte shadows and scratch
registers.  Defines the top 32 bits of 32-bit written registers.  Includes
numerous other miscellaneous fixes.

Some common instructions are not yet on the fastpath, including push and
pop.

Disables -share_xl8 for now for x64 (i#2025 covers getting to work).
Disables -esp_fastpath for now for x64 (i#2027 covers implementing it).

Does not yet enable tests: that is coming soon.

Issue: #111