### PR TITLE
i#2032 xl8 sharing: disable xl8 sharing for sub-dword and in general

### DIFF
--- a/drmemory/fastpath_x86.c
+++ b/drmemory/fastpath_x86.c
@@ -1272,6 +1272,11 @@ should_share_addr_helper(fastpath_info_t *mi)
         return false;
     if (mi->mem2mem || mi->load2x || mi->need_offs)
         return false;
+    /* i#2032: sub-dword w/ check-defined was supported before but it was buggy
+     * so we are disabling it until it can be re-examined.
+     */
+    if (mi->memsz < 4)
+        return false;
     /* XXX i#243: we rule out sharing here b/c it's too hard to figure out whether
      * we can use reg3 down below -- probably we can?  it's hard to ensure.
      * once we get drreg we should be able to share these and avoid reg
@@ -3567,6 +3572,11 @@ instrument_fastpath(void *drcontext, instrlist_t *bb, instr_t *inst,
                  * lookup memref but we complicate the code.  This is all
                  * unnecessary for byte-to-byte shadowing.
                  */
+                /* FIXME i#2032: this is broken: it needs to also incorporate
+                 * the delta!  It is now disabled until we have time to either
+                 * fix it or abandon completely.
+                 */
+                ASSERT_NOT_REACHED();
                 instr_t *adjust_sharing = INSTR_CREATE_label(drcontext);
                 instr_t *no_adjust_sharing = INSTR_CREATE_label(drcontext);
                 PRE(bb, inst,

--- a/drmemory/optionsx.h
+++ b/drmemory/optionsx.h
@@ -868,7 +868,8 @@ OPTION_CLIENT_BOOL(internal, replace_realloc, true,
                    "Replace realloc to avoid races and non-delayed frees",
                    "Replace realloc to avoid races and non-delayed frees")
 /* XXX i#2025: enable for x64 once failures are fixed */
-OPTION_CLIENT_BOOL(internal, share_xl8, IF_X64_ELSE(false, true),
+/* XXX i#2032, i#2009: disabling due to lack of confidence in the feature */
+OPTION_CLIENT_BOOL(internal, share_xl8, IF_X64_ELSE(false, false),
                    "Share translations among adjacent similar references",
                    "Share translations among adjacent similar references")
 OPTION_CLIENT(internal, share_xl8_max_slow, uint, 5000, 0, UINT_MAX/2,

--- a/tests/addronly-reg.out
+++ b/tests/addronly-reg.out
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2014 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -32,7 +32,7 @@ after eflags test!
 before addronly test!
 after addronly test!
 ~~Dr.M~~ ERRORS FOUND:
-~~Dr.M~~       3 unique,     6 total unaddressable access(es)
+~~Dr.M~~       4 unique,     8 total unaddressable access(es)
 ~~Dr.M~~       0 unique,     0 total invalid heap argument(s)
 ~~Dr.M~~       0 unique,     0 total warning(s)
 ~~Dr.M~~       2 unique,     2 total,     30 byte(s) of leak(s)

--- a/tests/addronly-reg.res
+++ b/tests/addronly-reg.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -29,6 +29,8 @@ Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
 registers.c_asm.asm:1330
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds:
 registers.c_asm.asm:1343
+Error #4: UNADDRESSABLE ACCESS beyond heap bounds:
+registers.c_asm.asm:1344
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
@@ -37,6 +39,8 @@ Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
 registers.c_asm.asm:624
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds:
 registers.c_asm.asm:637
+Error #4: UNADDRESSABLE ACCESS beyond heap bounds:
+registers.c_asm.asm:638
 %endif
-Error #4: LEAK 15 direct bytes + 0 indirect bytes
 Error #5: LEAK 15 direct bytes + 0 indirect bytes
+Error #6: LEAK 15 direct bytes + 0 indirect bytes


### PR DESCRIPTION
Due to the buggy i#1597 sub-dword xl8 sharing code and the complexity of
fixing it, disables xl8 sharing for sub-dword.
Updates the addronly-reg test template to show the now-visible 4th unaddr
error.

Goes further, given the i#2009 crash: disables xl8 sharing in general,
until we can re-evaluate and are sure no other crashes are caused by it.

Issue: #2032, #2009