### PR TITLE
i#1741 wrap_wincrt: mark test as flaky

### DIFF
--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -108,6 +108,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
         my %ignore_failures_32 = ('procterm' => 1,
                                   'winthreads' => 1,
                                   'malloc_callstacks' => 1,
+                                  'wrap_wincrt' => 1, # i#1741: flaky.
                                   'app_suite.pattern' => 1,
                                   'app_suite' => 1,
                                   'drstrace_unit_tests' => 1);


### PR DESCRIPTION
The wrap_wincrt test is flaky and is failing often enough that we ignore
its failures for now.

Issue: #1741