### PR TITLE
i#2039: Opts out of auto-predication

### DIFF
--- a/common/alloc.c
+++ b/common/alloc.c
@@ -7086,6 +7086,7 @@ alloc_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     app_pc pc = instr_get_app_pc(inst);
     if (pc == NULL)
         return DR_EMIT_DEFAULT;
+    drmgr_disable_auto_predication(drcontext, bb);
 #ifdef WINDOWS
     if (instr_get_opcode(inst) == OP_int &&
         opnd_get_immed_int(instr_get_src(inst, 0)) == CBRET_INTERRUPT_NUM) {

--- a/common/alloc.c
+++ b/common/alloc.c
@@ -7086,7 +7086,6 @@ alloc_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     app_pc pc = instr_get_app_pc(inst);
     if (pc == NULL)
         return DR_EMIT_DEFAULT;
-    drmgr_disable_auto_predication(drcontext, bb);
 #ifdef WINDOWS
     if (instr_get_opcode(inst) == OP_int &&
         opnd_get_immed_int(instr_get_src(inst, 0)) == CBRET_INTERRUPT_NUM) {

--- a/drheapstat/drheapstat.c
+++ b/drheapstat/drheapstat.c
@@ -1362,6 +1362,8 @@ event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
     if (instr_is_meta(inst))
         return DR_EMIT_DEFAULT;
 
+    drmgr_disable_auto_predication(drcontext, bb);
+
     ii->instrs_in_bb++;
 
     if (options.time_instrs) {

--- a/drheapstat/drheapstat.c
+++ b/drheapstat/drheapstat.c
@@ -1362,6 +1362,9 @@ event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
     if (instr_is_meta(inst))
         return DR_EMIT_DEFAULT;
 
+    /* i#2402: Temporarily disable auto predication globally due to poor
+     * interaction with internal control flow we emit.
+     */
     drmgr_disable_auto_predication(drcontext, bb);
 
     ii->instrs_in_bb++;

--- a/drmemory/instru.c
+++ b/drmemory/instru.c
@@ -1107,6 +1107,9 @@ instru_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
     bool used_fastpath = false;
     fastpath_info_t mi;
 
+    /* i#2402: Temporarily disable auto predication globally due to poor
+     * interaction with internal control flow we emit.
+     */
     drmgr_disable_auto_predication(drcontext, bb);
 
     if (go_native)

--- a/drmemory/instru.c
+++ b/drmemory/instru.c
@@ -1107,6 +1107,8 @@ instru_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
     bool used_fastpath = false;
     fastpath_info_t mi;
 
+    drmgr_disable_auto_predication(drcontext, bb);
+
     if (go_native)
         return DR_EMIT_GO_NATIVE;
 

--- a/drmemory/perturb.c
+++ b/drmemory/perturb.c
@@ -388,6 +388,9 @@ static dr_emit_flags_t
 perturb_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                         bool for_trace, bool translating, void *user_data)
 {
+    /* i#2402: Temporarily disable auto predication globally due to poor
+     * interaction with internal control flow we emit.
+     */
     drmgr_disable_auto_predication(drcontext, bb);
 
     if (instr_is_synch_op(inst)) {

--- a/drmemory/perturb.c
+++ b/drmemory/perturb.c
@@ -388,6 +388,8 @@ static dr_emit_flags_t
 perturb_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                         bool for_trace, bool translating, void *user_data)
 {
+    drmgr_disable_auto_predication(drcontext, bb);
+
     if (instr_is_synch_op(inst)) {
         dr_insert_clean_call(drcontext, bb, inst, (void *)do_delay, false,
                              1, OPND_CREATE_INT32(SYNCH_INSTR));


### PR DESCRIPTION
To fix immediate test errors due to poor interaction between global
auto-predication (introduced in dynamorio/dynamorio#1723) and meta
control flow, we pre-emptively opt out of auto-predication.

Fixes #2039