### PR TITLE
DRi#2634: updates DR to fix build errors

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -527,9 +527,9 @@ if (UNIX)
           VERBATIM)
       add_custom_target("${kmod_name}"
           DEPENDS "${kmod_bin}")
-    if (NOT X64) # FIXME i#111: failing on Travis
-      add_dependencies(syscalls_unix "${kmod_name}")
-    endif()
+      if (NOT X64) # FIXME i#111: failing on Travis
+        add_dependencies(syscalls_unix "${kmod_name}")
+      endif()
       set(kmod_build_files "${kmod_bin_dir}/modules.order"
           "${kmod_bin_dir}/Module.symvers"
           "${kmod_bin_dir}/${kmod_name}.c"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -527,7 +527,9 @@ if (UNIX)
           VERBATIM)
       add_custom_target("${kmod_name}"
           DEPENDS "${kmod_bin}")
+    if (NOT X64) # FIXME i#111: failing on Travis
       add_dependencies(syscalls_unix "${kmod_name}")
+    endif()
       set(kmod_build_files "${kmod_bin_dir}/modules.order"
           "${kmod_bin_dir}/Module.symvers"
           "${kmod_bin_dir}/${kmod_name}.c"


### PR DESCRIPTION
Updates DR to 6fbf9a4846e to fix Travis build errors.
Fixes build error in case of x64 test build of syscall_unix.

Fixes #2049