### PR TITLE
DRi#2641: fix failures on Travis

### DIFF
--- a/drsyscall/table_defines.h
+++ b/drsyscall/table_defines.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -43,7 +43,7 @@
 #ifdef LINUX
 /* See the big comment "64-bit vs 32-bit" in drsyscall_linux.c. */
 # ifdef X86
-#  define PACKNUM(x64,x86,arm) (((x64) << 16) | (x86 & 0xffff))
+#  define PACKNUM(x64,x86,arm) ((((uint)x64) << 16) | (x86 & 0xffff))
 # elif defined(ARM)
 /* XXX i#1569: for AArch64 we'll have to see how the numbers change.
  * We can't pack in the same way b/c the arm-specific syscalls use top bits.


### PR DESCRIPTION
Updates DR to bfef8b4 to fix several failures on Travis due to an upgrade
there.

Fixes additional compiler warnings from the Travis upgrade.