### PR TITLE
i#111 win64, part 1: syscall and native call updates

### DIFF
--- a/common/alloc_replace.c
+++ b/common/alloc_replace.c
@@ -4942,8 +4942,8 @@ malloc_replace__intercept(app_pc pc, routine_type_t type, alloc_routine_entry_t 
     if (interceptor != NULL) {
         /* optimization: only pass where needed, for Windows libc */
         void *user_data = IF_WINDOWS_ELSE(is_rtl_routine(type) ? NULL : (void *) e, NULL);
-        if (!drwrap_replace_native(pc, interceptor, at_entry, stack_adjust,
-                                   user_data, false))
+        if (!drwrap_replace_native(pc, interceptor, at_entry,
+                                   IF_X64_ELSE(0, stack_adjust), user_data, false))
             ASSERT(false, "failed to replace alloc routine");
     } else {
         LOG(2, "wrapping, not replacing, "PFX"\n", pc);
@@ -4972,7 +4972,8 @@ malloc_replace__unintercept(app_pc pc, routine_type_t type, alloc_routine_entry_
         return;
     }
     if (interceptor != NULL) {
-        if (!drwrap_replace_native(pc, NULL, at_entry, stack_adjust, NULL, true))
+        if (!drwrap_replace_native(pc, NULL, at_entry, IF_X64_ELSE(0, stack_adjust),
+                                   NULL, true))
             ASSERT(false, "failed to un-replace alloc routine");
     } else {
         malloc_wrap__unintercept(pc, type, e, check_mismatch, check_winapi_match);

--- a/drmemory/alloc_drmem.c
+++ b/drmemory/alloc_drmem.c
@@ -1320,9 +1320,10 @@ client_stack_alloc(byte *start, byte *end, bool defined)
     if (options.shadowing &&
         (options.check_uninitialized || options.check_stack_bounds)) {
         shadow_set_range(start, end, defined ? SHADOW_DEFINED : SHADOW_UNDEFINED);
-        if (BEYOND_TOS_REDZONE_SIZE > 0)
+        if (BEYOND_TOS_REDZONE_SIZE > 0) {
             shadow_set_range(start - BEYOND_TOS_REDZONE_SIZE,
                              end - BEYOND_TOS_REDZONE_SIZE, SHADOW_UNDEFINED);
+        }
     }
 }
 

--- a/drsyscall/drsyscall.c
+++ b/drsyscall/drsyscall.c
@@ -1308,7 +1308,19 @@ sysarg_get_size(void *drcontext, cls_syscall_t *pt, sysarg_iter_info_t *ii,
     } else {
         ASSERT(arg->size > 0 || -arg->size < SYSCALL_NUM_ARG_STORE,
                "reached max syscall args stored");
-        size = (arg->size > 0) ? arg->size : ((ptr_uint_t) pt->sysarg[-arg->size]);
+        if (arg->size > 0) {
+            size = arg->size;
+        } else {
+            int sz_argnum;
+            size = (ptr_uint_t) pt->sysarg[-arg->size];
+            sz_argnum = (-arg->size < arg->param) ? 0 : argnum + 1;
+            for (; !sysarg_invalid(&sysinfo->arg[sz_argnum]); sz_argnum++) {
+                if (sysinfo->arg[sz_argnum].param == -arg->size)
+                    break;
+            }
+            if (sysinfo->arg[sz_argnum].size == sizeof(uint))
+                size = (uint) size;
+        }
         if (TEST(SYSARG_LENGTH_INOUT, arg->flags)) {
             size_t *ptr;
             int sz_argnum;

--- a/drsyscall/table_windows_ntoskrnl.c
+++ b/drsyscall/table_windows_ntoskrnl.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1764,8 +1764,8 @@ syscall_info_t syscall_ntdll_info[] = {
          {2, sizeof(MEMORY_INFORMATION_CLASS), SYSARG_INLINED, DRSYS_TYPE_SIGNED_INT},
          {3, -4, W},
          {3, -5, WI},
-         {4, sizeof(ULONG), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
-         {5, sizeof(ULONG), W|HT, DRSYS_TYPE_UNSIGNED_INT},
+         {4, sizeof(SIZE_T), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+         {5, sizeof(SIZE_T), W|HT, DRSYS_TYPE_UNSIGNED_INT},
      }, &sysnum_QueryVirtualMemory
     },
     {{0,0},"NtQueryVolumeInformationFile", OK|SYSINFO_SECONDARY_TABLE, RNTST, 5,


### PR DESCRIPTION
Fixes several issues blocking full mode becoming the default on Windows
64-bit:

+ Replaced heap routines do not use stdcall.

+ get_sysparam_base() needs a one-slot adjustment.

+ There is padding between OBJECT_ATTRIBUTES fields.

+ A syscall param size stored in another field may be sub-pointer-sized.

+ NtQueryVirtualMemory's size fields are SIZE_T, not ULONG.