### PR TITLE
i#1948 add library calls arguments printing: new dlls and tests

### DIFF
--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -152,10 +152,10 @@ if (BUILD_TOOL_TESTS)
   get_target_path_for_execution(drltrace_path drltrace)
   get_target_path_for_execution(app_path drsyscall_app)
   prefix_cmd_if_necessary(drltrace_path OFF ${drltrace_path})
+
   add_test(drltrace ${drltrace_path} -- ${app_path})
   add_test(drltrace_libcalls ${drltrace_path} -logdir - -print_ret_addr -- ${app_path})
   add_test(drltrace_symargs ${drltrace_path} -logdir - -num_max_args 4 -- ${app_path})
-
   add_test(drltrace_libargs ${drltrace_path} -logdir - -only_from_app -- ${app_path})
 
   #regex strings for libcalls and arguments printing test
@@ -183,11 +183,34 @@ else ()
 
   set(libcall_name1 "~~([0-9a-f]+)~~ libc.so.6!puts\n")
   set(libcall_name2 "~~([0-9a-f]+)~~ libc.so.6!open\n")
-endif(WIN32)
+endif (WIN32)
   set_tests_properties(drltrace_libcalls PROPERTIES PASS_REGULAR_EXPRESSION
                        ${libcall_name1}${libcall_args1_01}${libcall_args1_02}${libcall_ret})
   set_tests_properties(drltrace_symargs PROPERTIES PASS_REGULAR_EXPRESSION
                        ${libcall_name2}${libcall_args2_0}${libcall_args2_1})
   set_tests_properties(drltrace_libargs PROPERTIES PASS_REGULAR_EXPRESSION
                        ${libcall_both_variants})
+
+if (WIN32)
+  # We use an external python script here to have a flexible mechanism for
+  # drltrace log file checking. The python script called test_drltrace_out.py
+  # launches drltrace and searches for expected API calls and their arguments
+  # listed in external file drltrace_test_expected.log. See description in
+  # test_drltrace_out.py for additional details.
+  find_program(PYTHON_PATH "python")
+if (PYTHON_PATH)
+  get_target_path_for_execution(drltrace_test_app_path drltrace_test_app)
+  set(python_test_script_out ${PROJECT_BINARY_DIR}/${BUILD_BIN}/test_drltrace_out.py)
+  set(expected_log_path_out ${PROJECT_BINARY_DIR}/${BUILD_BIN}/drltrace_test_expected.log)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/test_drltrace_out.py
+                 ${python_test_script_out} COPYONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/drltrace_test_expected.log
+                 ${expected_log_path_out} COPYONLY)
+  add_test(drltrace_test_all_libcalls ${PYTHON_PATH} ${python_test_script_out}
+           ${expected_log_path_out} ${drltrace_path} ${drltrace_test_app_path})
+else ()
+  message("Python not found. Some tests for drltrace will not be active.")
+endif (PYTHON_PATH)
+endif (WIN32)
+
 endif (BUILD_TOOL_TESTS)

--- a/drltrace/drltrace_win.config
+++ b/drltrace/drltrace_win.config
@@ -1023,6 +1023,7 @@ bool|SetThreadGroupAffinity|HANDLE|GROUP_AFFINITY*|__out GROUP_AFFINITY*
 DWORD|SetThreadIdealProcessor|HANDLE|DWORD
 bool|SetThreadIdealProcessorEx|HANDLE|PROCESSOR_NUMBER*|__out PROCESSOR_NUMBER*
 bool|SetThreadLocale|LCID
+LCID|GetThreadLocale|void
 bool|SetThreadPreferredUILanguages|DWORD|wchar*|__out ULONG*
 bool|SetThreadPriority|HANDLE|int
 bool|SetThreadPriorityBoost|HANDLE|bool
@@ -2139,3 +2140,2449 @@ ulong|XFORMOBJ_iGetXform|XFORMOBJ*|__out XFORML*
 ulong|XLATEOBJ_cGetPalette|XLATEOBJ*|ulong|ulong|__out ulong*
 HANDLE|XLATEOBJ_hGetColorTransform|XLATEOBJ*
 ulong|XLATEOBJ_iXlate|XLATEOBJ*|ulong
+
+# A group of exported functions from user32.dll
+HKL|ActivateKeyboardLayout|HKL|uint
+bool|AddClipboardFormatListener|HWND
+bool|AdjustWindowRect|__inout RECT*|DWORD|bool
+bool|AdjustWindowRectEx|__inout RECT*|DWORD|bool|DWORD
+bool|AllowSetForegroundWindow|DWORD
+bool|AnimateWindow|HWND|DWORD|DWORD
+bool|AnyPopup|VOID
+bool|AppendMenuA|HMENU|uint|UINT_PTR|char*
+bool|AppendMenuW|HMENU|uint|UINT_PTR|wchar*
+uint|ArrangeIconicWindows|HWND
+bool|AttachThreadInput|DWORD|DWORD|bool
+HDWP|BeginDeferWindowPos|int
+HDC|BeginPaint|HWND|__out PAINTSTRUCT*
+bool|BlockInput|bool
+bool|BringWindowToTop|HWND
+long|BroadcastSystemMessage|DWORD|__inout DWORD*|uint|WPARAM|LPARAM
+long|BroadcastSystemMessageA|DWORD|__inout DWORD*|uint|WPARAM|LPARAM
+long|BroadcastSystemMessageExA|DWORD|__inout DWORD*|uint|WPARAM|LPARAM|__out BSMINFO*
+long|BroadcastSystemMessageExW|DWORD|__inout DWORD*|uint|WPARAM|LPARAM|__out BSMINFO*
+long|BroadcastSystemMessageW|DWORD|__inout DWORD*|uint|WPARAM|LPARAM
+bool|CalculatePopupWindowPosition|POINT*|SIZE*|uint|RECT*|__out RECT*
+bool|CallMsgFilterA|MSG*|int
+bool|CallMsgFilterW|MSG*|int
+LRESULT|CallNextHookEx|HHOOK|int|WPARAM|LPARAM
+LRESULT|CallWindowProcA|WNDPROC|HWND|uint|WPARAM|LPARAM
+LRESULT|CallWindowProcW|WNDPROC|HWND|uint|WPARAM|LPARAM
+bool|CancelShutdown|VOID
+WORD|CascadeWindows|HWND|uint|RECT*|uint|HWND*
+bool|ChangeClipboardChain|HWND|HWND
+long|ChangeDisplaySettingsA|DEVMODEA*|DWORD
+long|ChangeDisplaySettingsExA|char*|DEVMODEA*|HWND|DWORD|VOID*
+long|ChangeDisplaySettingsExW|wchar*|DEVMODEW*|HWND|DWORD|VOID*
+long|ChangeDisplaySettingsW|DEVMODEW*|DWORD
+bool|ChangeMenuA|HMENU|uint|char*|uint|uint
+bool|ChangeMenuW|HMENU|uint|wchar*|uint|uint
+bool|ChangeWindowMessageFilter|uint|DWORD
+bool|ChangeWindowMessageFilterEx|HWND|uint|DWORD|__inout CHANGEFILTERSTRUCT*
+char*|CharLowerA|__inout char*
+DWORD|CharLowerBuffA|__inout char*|DWORD
+DWORD|CharLowerBuffW|__inout wchar*|DWORD
+wchar*|CharLowerW|__inout wchar*
+char*|CharNextA|char*
+char*|CharNextExA|WORD|char*|DWORD
+wchar*|CharNextW|wchar*
+char*|CharPrevA|char*|char*
+char*|CharPrevExA|WORD|char*|char*|DWORD
+wchar*|CharPrevW|wchar*|wchar*
+bool|CharToOemA|char*|__out char*
+bool|CharToOemBuffA|char*|__out char*|DWORD
+bool|CharToOemBuffW|wchar*|__out char*|DWORD
+bool|CharToOemW|wchar*|__out char*
+char*|CharUpperA|__inout char*
+DWORD|CharUpperBuffA|__inout char*|DWORD
+DWORD|CharUpperBuffW|__inout wchar*|DWORD
+wchar*|CharUpperW|__inout wchar*
+bool|CheckDlgButton|HWND|int|uint
+DWORD|CheckMenuItem|HMENU|uint|uint
+bool|CheckMenuRadioItem|HMENU|uint|uint|uint|uint
+bool|CheckRadioButton|HWND|int|int|int
+HWND|ChildWindowFromPoint|HWND|POINT
+HWND|ChildWindowFromPointEx|HWND|POINT|uint
+bool|ClientToScreen|HWND|__inout POINT*
+bool|ClipCursor|RECT*
+bool|CloseClipboard|VOID
+bool|CloseDesktop|HDESK
+bool|CloseGestureInfoHandle|HGESTUREINFO
+bool|CloseTouchInputHandle|HTOUCHINPUT
+bool|CloseWindow|HWND
+bool|CloseWindowStation|HWINSTA
+int|CopyAcceleratorTableA|HACCEL|__out ACCEL*|int
+int|CopyAcceleratorTableW|HACCEL|__out ACCEL*|int
+HICON|CopyIcon|HICON
+HANDLE|CopyImage|HANDLE|uint|int|int|uint
+bool|CopyRect|__out RECT*|RECT*
+int|CountClipboardFormats|VOID
+HACCEL|CreateAcceleratorTableA|ACCEL*|int
+HACCEL|CreateAcceleratorTableW|ACCEL*|int
+bool|CreateCaret|HWND|HBITMAP|int|int
+HCURSOR|CreateCursor|HINSTANCE|int|int|int|int|VOID*|VOID*
+HDESK|CreateDesktopA|char*|char*|DEVMODEA*|DWORD|ACCESS_MASK|SECURITY_ATTRIBUTES*
+HDESK|CreateDesktopExA|char*|char*|DEVMODEA*|DWORD|ACCESS_MASK|SECURITY_ATTRIBUTES*|ulong|VOID*
+HDESK|CreateDesktopExW|wchar*|wchar*|DEVMODEW*|DWORD|ACCESS_MASK|SECURITY_ATTRIBUTES*|ulong|VOID*
+HDESK|CreateDesktopW|wchar*|wchar*|DEVMODEW*|DWORD|ACCESS_MASK|SECURITY_ATTRIBUTES*
+HWND|CreateDialogIndirectParamA|HINSTANCE|DLGTEMPLATEA*|HWND|DLGPROC|LPARAM
+HWND|CreateDialogIndirectParamW|HINSTANCE|DLGTEMPLATEW*|HWND|DLGPROC|LPARAM
+HWND|CreateDialogParamA|HINSTANCE|char*|HWND|DLGPROC|LPARAM
+HWND|CreateDialogParamW|HINSTANCE|wchar*|HWND|DLGPROC|LPARAM
+HICON|CreateIcon|HINSTANCE|int|int|BYTE|BYTE|BYTE*|BYTE*
+HICON|CreateIconFromResource|BYTE*|DWORD|bool|DWORD
+HICON|CreateIconFromResourceEx|BYTE*|DWORD|bool|DWORD|int|int|uint
+HICON|CreateIconIndirect|ICONINFO*
+HWND|CreateMDIWindowA|char*|char*|DWORD|int|int|int|int|HWND|HINSTANCE|LPARAM
+HWND|CreateMDIWindowW|wchar*|wchar*|DWORD|int|int|int|int|HWND|HINSTANCE|LPARAM
+HMENU|CreateMenu|VOID
+HMENU|CreatePopupMenu|VOID
+HWND|CreateWindowExA|DWORD|char*|char*|DWORD|int|int|int|int|HWND|HMENU|HINSTANCE|VOID*
+HWND|CreateWindowExW|DWORD|wchar*|wchar*|DWORD|int|int|int|int|HWND|HMENU|HINSTANCE|VOID*
+HWINSTA|CreateWindowStationA|char*|DWORD|ACCESS_MASK|SECURITY_ATTRIBUTES*
+HWINSTA|CreateWindowStationW|wchar*|DWORD|ACCESS_MASK|SECURITY_ATTRIBUTES*
+bool|DdeAbandonTransaction|DWORD|HCONV|DWORD
+BYTE*|DdeAccessData|HDDEDATA|__out DWORD*
+HDDEDATA|DdeAddData|HDDEDATA|BYTE*|DWORD|DWORD
+HDDEDATA|DdeClientTransaction|BYTE*|DWORD|HCONV|HSZ|uint|uint|DWORD|__out DWORD*
+int|DdeCmpStringHandles|HSZ|HSZ
+HCONV|DdeConnect|DWORD|HSZ|HSZ|CONVCONTEXT*
+HCONVLIST|DdeConnectList|DWORD|HSZ|HSZ|HCONVLIST|CONVCONTEXT*
+HDDEDATA|DdeCreateDataHandle|DWORD|BYTE*|DWORD|DWORD|HSZ|uint|uint
+HSZ|DdeCreateStringHandleA|DWORD|char*|int
+HSZ|DdeCreateStringHandleW|DWORD|wchar*|int
+bool|DdeDisconnect|HCONV
+bool|DdeDisconnectList|HCONVLIST
+bool|DdeEnableCallback|DWORD|HCONV|uint
+bool|DdeFreeDataHandle|HDDEDATA
+bool|DdeFreeStringHandle|DWORD|HSZ
+DWORD|DdeGetData|HDDEDATA|__out BYTE*|DWORD|DWORD
+uint|DdeGetLastError|DWORD
+bool|DdeImpersonateClient|HCONV
+uint|DdeInitializeA|__inout DWORD*|FNCALLBACK*|DWORD|DWORD
+uint|DdeInitializeW|__inout DWORD*|FNCALLBACK*|DWORD|DWORD
+bool|DdeKeepStringHandle|DWORD|HSZ
+HDDEDATA|DdeNameService|DWORD|HSZ|HSZ|uint
+BOOL|DdePostAdvise|DWORD|HSZ|HSZ
+uint|DdeQueryConvInfo|HCONV|DWORD|__inout CONVINFO*
+HCONV|DdeQueryNextServer|HCONVLIST|HCONV
+DWORD|DdeQueryStringA|DWORD|HSZ|__out char*|DWORD|int
+DWORD|DdeQueryStringW|DWORD|HSZ|__out wchar*|DWORD|int
+HCONV|DdeReconnect|HCONV
+bool|DdeSetQualityOfService|HWND|SECURITY_QUALITY_OF_SERVICE*|SECURITY_QUALITY_OF_SERVICE*
+bool|DdeSetUserHandle|HCONV|DWORD|DWORD_PTR
+bool|DdeUnaccessData|HDDEDATA
+bool|DdeUninitialize|DWORD
+LRESULT|DefDlgProcA|HWND|uint|WPARAM|LPARAM
+LRESULT|DefDlgProcW|HWND|uint|WPARAM|LPARAM
+LRESULT|DefFrameProcA|HWND|HWND|uint|WPARAM|LPARAM
+LRESULT|DefFrameProcW|HWND|HWND|uint|WPARAM|LPARAM
+LRESULT|DefMDIChildProcA|HWND|uint|WPARAM|LPARAM
+LRESULT|DefMDIChildProcW|HWND|uint|WPARAM|LPARAM
+LRESULT|DefRawInputProc|RAWINPUT**|int|uint
+LRESULT|DefWindowProcA|HWND|uint|WPARAM|LPARAM
+LRESULT|DefWindowProcW|HWND|uint|WPARAM|LPARAM
+HDWP|DeferWindowPos|HDWP|HWND|HWND|int|int|int|int|uint
+bool|DeleteMenu|HMENU|uint|uint
+bool|DeregisterShellHookWindow|HWND
+bool|DestroyAcceleratorTable|HACCEL
+bool|DestroyCaret|VOID
+bool|DestroyCursor|HCURSOR
+bool|DestroyIcon|HICON
+bool|DestroyMenu|HMENU
+bool|DestroyWindow|HWND
+int|DialogBoxIndirectParamA|HINSTANCE|DLGTEMPLATEA*|HWND|DLGPROC|LPARAM
+int|DialogBoxIndirectParamW|HINSTANCE|DLGTEMPLATEW*|HWND|DLGPROC|LPARAM
+int|DialogBoxParamA|HINSTANCE|char*|HWND|DLGPROC|LPARAM
+int|DialogBoxParamW|HINSTANCE|wchar*|HWND|DLGPROC|LPARAM
+VOID|DisableProcessWindowsGhosting|VOID
+LRESULT|DispatchMessageA|MSG*
+LRESULT|DispatchMessageW|MSG*
+long|DisplayConfigGetDeviceInfo|__inout DISPLAYCONFIG_DEVICE_INFO_HEADER*
+long|DisplayConfigSetDeviceInfo|DISPLAYCONFIG_DEVICE_INFO_HEADER*
+int|DlgDirListA|HWND|__inout char*|int|int|uint
+int|DlgDirListComboBoxA|HWND|__inout char*|int|int|uint
+int|DlgDirListComboBoxW|HWND|__inout wchar*|int|int|uint
+int|DlgDirListW|HWND|__inout wchar*|int|int|uint
+bool|DlgDirSelectComboBoxExA|HWND|__out char*|int|int
+bool|DlgDirSelectComboBoxExW|HWND|__out wchar*|int|int
+bool|DlgDirSelectExA|HWND|__out char*|int|int
+bool|DlgDirSelectExW|HWND|__out wchar*|int|int
+bool|DragDetect|HWND|POINT
+DWORD|DragObject|HWND|HWND|uint|ULONG_PTR|HCURSOR
+bool|DrawAnimatedRects|HWND|int|RECT*|RECT*
+bool|DrawCaption|HWND|HDC|RECT*|uint
+bool|DrawEdge|HDC|__inout RECT*|uint|uint
+bool|DrawFocusRect|HDC|RECT*
+bool|DrawFrameControl|HDC|__inout RECT*|uint|uint
+bool|DrawIcon|HDC|int|int|HICON
+bool|DrawIconEx|HDC|int|int|HICON|int|int|uint|HBRUSH|uint
+bool|DrawMenuBar|HWND
+bool|DrawStateA|HDC|HBRUSH|DRAWSTATEPROC|LPARAM|WPARAM|int|int|int|int|uint
+bool|DrawStateW|HDC|HBRUSH|DRAWSTATEPROC|LPARAM|WPARAM|int|int|int|int|uint
+int|DrawTextA|HDC|__inout char*|int|__inout RECT*|uint
+int|DrawTextExA|HDC|__inout char*|int|__inout RECT*|uint|DRAWTEXTPARAMS*
+int|DrawTextExW|HDC|__inout wchar*|int|__inout RECT*|uint|DRAWTEXTPARAMS*
+int|DrawTextW|HDC|__inout wchar*|int|__inout RECT*|uint
+bool|EmptyClipboard|VOID
+bool|EnableMenuItem|HMENU|uint|uint
+bool|EnableScrollBar|HWND|uint|uint
+bool|EnableWindow|HWND|bool
+bool|EndDeferWindowPos|HDWP
+bool|EndDialog|HWND|int
+bool|EndMenu|VOID
+bool|EndPaint|HWND|PAINTSTRUCT*
+bool|EndTask|HWND|bool|bool
+bool|EnumChildWindows|HWND|WNDENUMPROC|LPARAM
+uint|EnumClipboardFormats|uint
+bool|EnumDesktopWindows|HDESK|WNDENUMPROC|LPARAM
+bool|EnumDesktopsA|HWINSTA|DESKTOPENUMPROCA|LPARAM
+bool|EnumDesktopsW|HWINSTA|DESKTOPENUMPROCW|LPARAM
+bool|EnumDisplayDevicesA|char*|DWORD|__inout DISPLAY_DEVICEA*|DWORD
+bool|EnumDisplayDevicesW|wchar*|DWORD|__inout DISPLAY_DEVICEW*|DWORD
+bool|EnumDisplayMonitors|HDC|RECT*|MONITORENUMPROC|LPARAM
+bool|EnumDisplaySettingsA|char*|DWORD|__inout DEVMODEA*
+bool|EnumDisplaySettingsExA|char*|DWORD|__inout DEVMODEA*|DWORD
+bool|EnumDisplaySettingsExW|wchar*|DWORD|__inout DEVMODEW*|DWORD
+bool|EnumDisplaySettingsW|wchar*|DWORD|__inout DEVMODEW*
+int|EnumPropsA|HWND|PROPENUMPROCA
+int|EnumPropsExA|HWND|PROPENUMPROCEXA|LPARAM
+int|EnumPropsExW|HWND|PROPENUMPROCEXW|LPARAM
+int|EnumPropsW|HWND|PROPENUMPROCW
+bool|EnumThreadWindows|DWORD|WNDENUMPROC|LPARAM
+bool|EnumWindowStationsA|WINSTAENUMPROCA|LPARAM
+bool|EnumWindowStationsW|WINSTAENUMPROCW|LPARAM
+bool|EnumWindows|WNDENUMPROC|LPARAM
+bool|EqualRect|RECT*|RECT*
+int|ExcludeUpdateRgn|HDC|HWND
+BOOL|ExitWindowsEx|uint|DWORD
+int|FillRect|HDC|RECT*|HBRUSH
+HWND|FindWindowA|char*|char*
+HWND|FindWindowExA|HWND|HWND|char*|char*
+HWND|FindWindowExW|HWND|HWND|wchar*|wchar*
+HWND|FindWindowW|wchar*|wchar*
+bool|FlashWindow|HWND|bool
+bool|FlashWindowEx|FLASHWINFO*
+int|FrameRect|HDC|RECT*|HBRUSH
+bool|FreeDDElParam|uint|LPARAM
+HWND|GetActiveWindow|VOID
+bool|GetAltTabInfoA|HWND|int|__inout ALTTABINFO*|__out char*|uint
+bool|GetAltTabInfoW|HWND|int|__inout ALTTABINFO*|__out wchar*|uint
+HWND|GetAncestor|HWND|uint
+SHORT|GetAsyncKeyState|int
+HWND|GetCapture|VOID
+uint|GetCaretBlinkTime|VOID
+bool|GetCaretPos|__out POINT*
+bool|GetClassInfoA|HINSTANCE|char*|__out WNDCLASSA*
+bool|GetClassInfoExA|HINSTANCE|char*|__out WNDCLASSEXA*
+bool|GetClassInfoExW|HINSTANCE|wchar*|__out WNDCLASSEXW*
+bool|GetClassInfoW|HINSTANCE|wchar*|__out WNDCLASSW*
+DWORD|GetClassLongA|HWND|int
+DWORD|GetClassLongW|HWND|int
+int|GetClassNameA|HWND|__out char*|int
+int|GetClassNameW|HWND|__out wchar*|int
+WORD|GetClassWord|HWND|int
+bool|GetClientRect|HWND|__out RECT*
+bool|GetClipCursor|__out RECT*
+HANDLE|GetClipboardData|uint
+int|GetClipboardFormatNameA|uint|__out char*|int
+int|GetClipboardFormatNameW|uint|__out wchar*|int
+HWND|GetClipboardOwner|VOID
+DWORD|GetClipboardSequenceNumber|VOID
+HWND|GetClipboardViewer|VOID
+bool|GetComboBoxInfo|HWND|__inout COMBOBOXINFO*
+HCURSOR|GetCursor|VOID
+bool|GetCursorInfo|__inout CURSORINFO*
+bool|GetCursorPos|__out POINT*
+HDC|GetDC|HWND
+HDC|GetDCEx|HWND|HRGN|DWORD
+HWND|GetDesktopWindow|VOID
+long|GetDialogBaseUnits|VOID
+long|GetDisplayConfigBufferSizes|UINT32|__out UINT32*|__out UINT32*
+int|GetDlgCtrlID|HWND
+HWND|GetDlgItem|HWND|int
+uint|GetDlgItemInt|HWND|int|__out bool*|bool
+uint|GetDlgItemTextA|HWND|int|__out char*|int
+uint|GetDlgItemTextW|HWND|int|__out wchar*|int
+uint|GetDoubleClickTime|VOID
+HWND|GetFocus|VOID
+HWND|GetForegroundWindow|VOID
+bool|GetGUIThreadInfo|DWORD|__inout GUITHREADINFO*
+bool|GetGestureConfig|HWND|DWORD|DWORD|UINT*|__inout GESTURECONFIG*|uint
+BOOL|GetGestureExtraArgs|HGESTUREINFO|uint|__out BYTE*
+BOOL|GetGestureInfo|HGESTUREINFO|__out GESTUREINFO*
+DWORD|GetGuiResources|HANDLE|DWORD
+bool|GetIconInfo|HICON|__out ICONINFO*
+bool|GetIconInfoExA|HICON|__inout ICONINFOEXA*
+bool|GetIconInfoExW|HICON|__inout ICONINFOEXW*
+bool|GetInputState|VOID
+uint|GetKBCodePage|VOID
+int|GetKeyNameTextA|long|__out char*|int
+int|GetKeyNameTextW|long|__out wchar*|int
+SHORT|GetKeyState|int
+HKL|GetKeyboardLayout|DWORD
+int|GetKeyboardLayoutList|int|__out HKL*
+bool|GetKeyboardLayoutNameA|__out char*
+bool|GetKeyboardLayoutNameW|__out wchar*
+bool|GetKeyboardState|__out BYTE*
+int|GetKeyboardType|int
+HWND|GetLastActivePopup|HWND
+bool|GetLastInputInfo|__out LASTINPUTINFO*
+bool|GetLayeredWindowAttributes|HWND|__out COLORREF*|__out BYTE*|__out DWORD*
+DWORD|GetListBoxInfo|HWND
+HMENU|GetMenu|HWND
+bool|GetMenuBarInfo|HWND|long|long|__inout MENUBARINFO*
+long|GetMenuCheckMarkDimensions|VOID
+DWORD|GetMenuContextHelpId|HMENU
+uint|GetMenuDefaultItem|HMENU|uint|uint
+bool|GetMenuInfo|HMENU|__inout MENUINFO*
+int|GetMenuItemCount|HMENU
+uint|GetMenuItemID|HMENU|int
+bool|GetMenuItemInfoA|HMENU|uint|bool|__inout MENUITEMINFOA*
+bool|GetMenuItemInfoW|HMENU|uint|bool|__inout MENUITEMINFOW*
+bool|GetMenuItemRect|HWND|HMENU|uint|__out RECT*
+uint|GetMenuState|HMENU|uint|uint
+int|GetMenuStringA|HMENU|uint|__out char*|int|uint
+int|GetMenuStringW|HMENU|uint|__out wchar*|int|uint
+bool|GetMessageA|__out MSG*|HWND|uint|uint
+LPARAM|GetMessageExtraInfo|VOID
+DWORD|GetMessagePos|VOID
+long|GetMessageTime|VOID
+bool|GetMessageW|__out MSG*|HWND|uint|uint
+bool|GetMonitorInfoA|HMONITOR|__inout MONITORINFO*
+bool|GetMonitorInfoW|HMONITOR|__inout MONITORINFO*
+int|GetMouseMovePointsEx|uint|MOUSEMOVEPOINT*|__out MOUSEMOVEPOINT*|int|DWORD
+HWND|GetNextDlgGroupItem|HWND|HWND|bool
+HWND|GetOpenClipboardWindow|VOID
+HWND|GetParent|HWND
+bool|GetPhysicalCursorPos|__out POINT*
+int|GetPriorityClipboardFormat|uint*|int
+bool|GetProcessDefaultLayout|__out DWORD*
+HWINSTA|GetProcessWindowStation|VOID
+HANDLE|GetPropA|HWND|char*
+HANDLE|GetPropW|HWND|wchar*
+DWORD|GetQueueStatus|uint
+uint|GetRawInputBuffer|__out RAWINPUT*|__inout UINT*|uint
+uint|GetRawInputData|HRAWINPUT|uint|__out VOID*|__inout UINT*|uint
+uint|GetRawInputDeviceInfoA|HANDLE|uint|__inout VOID*|__inout UINT*
+uint|GetRawInputDeviceInfoW|HANDLE|uint|__inout VOID*|__inout UINT*
+uint|GetRawInputDeviceList|__out RAWINPUTDEVICELIST*|__inout UINT*|uint
+uint|GetRegisteredRawInputDevices|__out RAWINPUTDEVICE*|__inout UINT*|uint
+bool|GetScrollBarInfo|HWND|long|__inout SCROLLBARINFO*
+bool|GetScrollInfo|HWND|int|__inout SCROLLINFO*
+int|GetScrollPos|HWND|int
+bool|GetScrollRange|HWND|int|__out int*|__out int*
+HWND|GetShellWindow|VOID
+HMENU|GetSubMenu|HMENU|int
+DWORD|GetSysColor|int
+HBRUSH|GetSysColorBrush|int
+HMENU|GetSystemMenu|HWND|bool
+int|GetSystemMetrics|int
+DWORD|GetTabbedTextExtentA|HDC|char*|int|int|int*
+DWORD|GetTabbedTextExtentW|HDC|wchar*|int|int|int*
+HDESK|GetThreadDesktop|DWORD
+bool|GetTitleBarInfo|HWND|__inout TITLEBARINFO*
+HWND|GetTopWindow|HWND
+bool|GetTouchInputInfo|HTOUCHINPUT|UINT|__out TOUCHINPUT*|int
+bool|GetUpdateRect|HWND|__out RECT*|bool
+int|GetUpdateRgn|HWND|HRGN|bool
+bool|GetUpdatedClipboardFormats|__out UINT*|uint|__out UINT*
+bool|GetUserObjectInformationA|HANDLE|int|__out VOID*|DWORD|__out DWORD*
+bool|GetUserObjectInformationW|HANDLE|int|__out VOID*|DWORD|__out DWORD*
+bool|GetUserObjectSecurity|HANDLE|SECURITY_INFORMATION*|__out SECURITY_DESCRIPTOR*|DWORD|__out DWORD*
+HWND|GetWindow|HWND|uint
+DWORD|GetWindowContextHelpId|HWND
+HDC|GetWindowDC|HWND
+bool|GetWindowDisplayAffinity|HWND|__out DWORD*
+bool|GetWindowInfo|HWND|__inout WINDOWINFO*
+long|GetWindowLongA|HWND|int
+long|GetWindowLongW|HWND|int
+uint|GetWindowModuleFileNameA|HWND|__out char*|uint
+uint|GetWindowModuleFileNameW|HWND|__out wchar*|uint
+bool|GetWindowPlacement|HWND|__inout WINDOWPLACEMENT*
+bool|GetWindowRect|HWND|__out RECT*
+int|GetWindowRgn|HWND|HRGN
+int|GetWindowRgnBox|HWND|__out RECT*
+int|GetWindowTextA|HWND|__out char*|int
+int|GetWindowTextLengthA|HWND
+int|GetWindowTextLengthW|HWND
+int|GetWindowTextW|HWND|__out wchar*|int
+DWORD|GetWindowThreadProcessId|HWND|__out DWORD*
+WORD|GetWindowWord|HWND|int
+bool|GrayStringA|HDC|HBRUSH|GRAYSTRINGPROC|LPARAM|int|int|int|int|int
+bool|GrayStringW|HDC|HBRUSH|GRAYSTRINGPROC|LPARAM|int|int|int|int|int
+bool|HideCaret|HWND
+bool|HiliteMenuItem|HWND|HMENU|uint|uint
+bool|IMPGetIMEA|HWND|IMEPROA*
+bool|IMPGetIMEW|HWND|IMEPROW*
+bool|IMPQueryIMEA|IMEPROA*
+bool|IMPQueryIMEW|IMEPROW*
+bool|IMPSetIMEA|HWND|IMEPROA*
+bool|IMPSetIMEW|HWND|IMEPROW*
+bool|ImpersonateDdeClientWindow|HWND|HWND
+bool|InSendMessage|VOID
+DWORD|InSendMessageEx|VOID*
+bool|InflateRect|__inout RECT*|int|int
+bool|InsertMenuA|HMENU|uint|uint|UINT_PTR|char*
+bool|InsertMenuItemA|HMENU|uint|bool|MENUITEMINFOA*
+bool|InsertMenuItemW|HMENU|uint|bool|MENUITEMINFOW*
+bool|InsertMenuW|HMENU|uint|uint|UINT_PTR|wchar*
+int|InternalGetWindowText|HWND|__out wchar*|int
+bool|IntersectRect|__out RECT*|RECT*|RECT*
+bool|InvalidateRect|HWND|RECT*|bool
+bool|InvalidateRgn|HWND|HRGN|bool
+bool|InvertRect|HDC|RECT*
+bool|IsCharAlphaA|char
+bool|IsCharAlphaNumericA|char
+bool|IsCharAlphaNumericW|wchar
+bool|IsCharAlphaW|wchar
+bool|IsCharLowerA|char
+bool|IsCharLowerW|wchar
+bool|IsCharUpperA|char
+bool|IsCharUpperW|wchar
+bool|IsChild|HWND|HWND
+bool|IsClipboardFormatAvailable|uint
+bool|IsDialogMessageA|HWND|MSG*
+bool|IsDialogMessageW|HWND|MSG*
+uint|IsDlgButtonChecked|HWND|int
+bool|IsGUIThread|bool
+bool|IsHungAppWindow|HWND
+bool|IsIconic|HWND
+bool|IsMenu|HMENU
+bool|IsProcessDPIAware|VOID
+bool|IsRectEmpty|RECT*
+bool|IsTouchWindow|HWND|__out ULONG*
+bool|IsWinEventHookInstalled|DWORD
+bool|IsWindow|HWND
+bool|IsWindowEnabled|HWND
+bool|IsWindowUnicode|HWND
+bool|IsWindowVisible|HWND
+bool|IsWow64Message|VOID
+bool|IsZoomed|HWND
+bool|KillTimer|HWND|UINT_PTR
+HACCEL|LoadAcceleratorsA|HINSTANCE|char*
+HACCEL|LoadAcceleratorsW|HINSTANCE|wchar*
+HBITMAP|LoadBitmapA|HINSTANCE|char*
+HBITMAP|LoadBitmapW|HINSTANCE|wchar*
+HCURSOR|LoadCursorA|HINSTANCE|char*
+HCURSOR|LoadCursorFromFileA|char*
+HCURSOR|LoadCursorFromFileW|wchar*
+HCURSOR|LoadCursorW|HINSTANCE|wchar*
+HICON|LoadIconA|HINSTANCE|char*
+HICON|LoadIconW|HINSTANCE|wchar*
+HANDLE|LoadImageA|HINSTANCE|char*|uint|int|int|uint
+HANDLE|LoadImageW|HINSTANCE|wchar*|uint|int|int|uint
+HKL|LoadKeyboardLayoutA|char*|uint
+HKL|LoadKeyboardLayoutW|wchar*|uint
+HMENU|LoadMenuA|HINSTANCE|char*
+HMENU|LoadMenuIndirectA|MENUTEMPLATEA*
+HMENU|LoadMenuIndirectW|MENUTEMPLATEW*
+HMENU|LoadMenuW|HINSTANCE|wchar*
+int|LoadStringA|HINSTANCE|uint|__out char*|int
+int|LoadStringW|HINSTANCE|uint|__out wchar*|int
+bool|LockSetForegroundWindow|uint
+bool|LockWindowUpdate|HWND
+bool|LockWorkStation|VOID
+bool|LogicalToPhysicalPoint|HWND|__inout POINT*
+int|LookupIconIdFromDirectory|BYTE*|bool
+int|LookupIconIdFromDirectoryEx|BYTE*|bool|int|int|uint
+bool|MapDialogRect|HWND|__inout RECT*
+uint|MapVirtualKeyA|uint|uint
+uint|MapVirtualKeyExA|uint|uint|HKL
+uint|MapVirtualKeyExW|uint|uint|HKL
+uint|MapVirtualKeyW|uint|uint
+int|MapWindowPoints|HWND|HWND|__inout POINT*|uint
+int|MenuItemFromPoint|HWND|HMENU|POINT
+bool|MessageBeep|uint
+int|MessageBoxA|HWND|char*|char*|uint
+int|MessageBoxExA|HWND|char*|char*|uint|WORD
+int|MessageBoxExW|HWND|wchar*|wchar*|uint|WORD
+int|MessageBoxIndirectA|MSGBOXPARAMSA*
+int|MessageBoxIndirectW|MSGBOXPARAMSW*
+int|MessageBoxW|HWND|wchar*|wchar*|uint
+bool|ModifyMenuA|HMENU|uint|uint|UINT_PTR|char*
+bool|ModifyMenuW|HMENU|uint|uint|UINT_PTR|wchar*
+HMONITOR|MonitorFromPoint|POINT|DWORD
+HMONITOR|MonitorFromRect|RECT*|DWORD
+HMONITOR|MonitorFromWindow|HWND|DWORD
+bool|MoveWindow|HWND|int|int|int|int|bool
+DWORD|MsgWaitForMultipleObjects|DWORD|HANDLE*|bool|DWORD|DWORD
+DWORD|MsgWaitForMultipleObjectsEx|DWORD|HANDLE*|DWORD|DWORD|DWORD
+VOID|NotifyWinEvent|DWORD|HWND|long|long
+DWORD|OemKeyScan|WORD
+bool|OemToCharA|char*|__out char*
+bool|OemToCharBuffA|char*|__out char*|DWORD
+bool|OemToCharBuffW|char*|__out wchar*|DWORD
+bool|OemToCharW|char*|__out wchar*
+bool|OffsetRect|__inout RECT*|int|int
+bool|OpenClipboard|HWND
+HDESK|OpenDesktopA|char*|DWORD|bool|ACCESS_MASK
+HDESK|OpenDesktopW|wchar*|DWORD|bool|ACCESS_MASK
+bool|OpenIcon|HWND
+HDESK|OpenInputDesktop|DWORD|bool|ACCESS_MASK
+HWINSTA|OpenWindowStationA|char*|bool|ACCESS_MASK
+HWINSTA|OpenWindowStationW|wchar*|bool|ACCESS_MASK
+LPARAM|PackDDElParam|uint|UINT_PTR|UINT_PTR
+bool|PaintDesktop|HDC
+bool|PeekMessageA|__out MSG*|HWND|uint|uint|uint
+bool|PeekMessageW|__out MSG*|HWND|uint|uint|uint
+bool|PhysicalToLogicalPoint|HWND|__inout POINT*
+bool|PostMessageA|HWND|uint|WPARAM|LPARAM
+bool|PostMessageW|HWND|uint|WPARAM|LPARAM
+VOID|PostQuitMessage|int
+bool|PostThreadMessageA|DWORD|uint|WPARAM|LPARAM
+bool|PostThreadMessageW|DWORD|uint|WPARAM|LPARAM
+bool|PrintWindow|HWND|HDC|uint
+uint|PrivateExtractIconsA|char*|int|int|int|__out HICON*|__out uint*|uint|uint
+uint|PrivateExtractIconsW|wchar*|int|int|int|__out HICON*|__out uint*|uint|uint
+bool|PtInRect|RECT*|POINT
+long|QueryDisplayConfig|UINT32|__inout UINT32*|__out DISPLAYCONFIG_PATH_INFO*|__inout UINT32*|__out DISPLAYCONFIG_MODE_INFO*|__out DISPLAYCONFIG_TOPOLOGY_ID*
+HWND|RealChildWindowFromPoint|HWND|POINT
+uint|RealGetWindowClassA|HWND|__out char*|uint
+uint|RealGetWindowClassW|HWND|__out wchar*|uint
+bool|RedrawWindow|HWND|RECT*|HRGN|uint
+ATOM|RegisterClassA|WNDCLASSA*
+ATOM|RegisterClassExA|WNDCLASSEXA*
+ATOM|RegisterClassExW|WNDCLASSEXW*
+ATOM|RegisterClassW|WNDCLASSW*
+uint|RegisterClipboardFormatA|char*
+uint|RegisterClipboardFormatW|wchar*
+HDEVNOTIFY|RegisterDeviceNotificationA|HANDLE|VOID*|DWORD
+HDEVNOTIFY|RegisterDeviceNotificationW|HANDLE|VOID*|DWORD
+bool|RegisterHotKey|HWND|int|uint|uint
+HPOWERNOTIFY|RegisterPowerSettingNotification|HANDLE|GUID*|DWORD
+bool|RegisterRawInputDevices|CRAWINPUTDEVICE*|uint|uint
+bool|RegisterShellHookWindow|HWND
+bool|RegisterTouchWindow|HWND|ulong
+uint|RegisterWindowMessageA|char*
+uint|RegisterWindowMessageW|wchar*
+bool|ReleaseCapture|VOID
+int|ReleaseDC|HWND|HDC
+bool|RemoveClipboardFormatListener|HWND
+bool|RemoveMenu|HMENU|uint|uint
+HANDLE|RemovePropA|HWND|char*
+HANDLE|RemovePropW|HWND|wchar*
+bool|ReplyMessage|LRESULT
+LPARAM|ReuseDDElParam|LPARAM|uint|uint|UINT_PTR|UINT_PTR
+bool|ScreenToClient|HWND|__inout POINT*
+bool|ScrollDC|HDC|int|int|RECT*|RECT*|HRGN|__out RECT*
+bool|ScrollWindow|HWND|int|int|RECT*|RECT*
+int|ScrollWindowEx|HWND|int|int|RECT*|RECT*|HRGN|__out RECT*|uint
+LRESULT|SendDlgItemMessageA|HWND|int|uint|WPARAM|LPARAM
+LRESULT|SendDlgItemMessageW|HWND|int|uint|WPARAM|LPARAM
+LRESULT|SendIMEMessageExA|HWND|LPARAM
+LRESULT|SendIMEMessageExW|HWND|LPARAM
+uint|SendInput|uint|INPUT*|int
+LRESULT|SendMessageA|HWND|uint|WPARAM|LPARAM
+bool|SendMessageCallbackA|HWND|uint|WPARAM|LPARAM|SENDASYNCPROC|ULONG_PTR
+bool|SendMessageCallbackW|HWND|uint|WPARAM|LPARAM|SENDASYNCPROC|ULONG_PTR
+LRESULT|SendMessageTimeoutA|HWND|uint|WPARAM|LPARAM|uint|uint|__out DWORD_PTR*
+LRESULT|SendMessageTimeoutW|HWND|uint|WPARAM|LPARAM|uint|uint|__out DWORD_PTR*
+LRESULT|SendMessageW|HWND|uint|WPARAM|LPARAM
+bool|SendNotifyMessageA|HWND|uint|WPARAM|LPARAM
+bool|SendNotifyMessageW|HWND|uint|WPARAM|LPARAM
+HWND|SetActiveWindow|HWND
+HWND|SetCapture|HWND
+bool|SetCaretBlinkTime|uint
+bool|SetCaretPos|int|int
+DWORD|SetClassLongA|HWND|int|long
+DWORD|SetClassLongW|HWND|int|long
+WORD|SetClassWord|HWND|int|WORD
+HANDLE|SetClipboardData|uint|HANDLE
+HWND|SetClipboardViewer|HWND
+HCURSOR|SetCursor|HCURSOR
+bool|SetCursorPos|int|int
+VOID|SetDebugErrorLevel|DWORD
+long|SetDisplayConfig|UINT32|DISPLAYCONFIG_PATH_INFO*|UINT32|DISPLAYCONFIG_MODE_INFO*|UINT32
+bool|SetDlgItemInt|HWND|int|uint|bool
+bool|SetDlgItemTextA|HWND|int|char*
+bool|SetDlgItemTextW|HWND|int|wchar*
+bool|SetDoubleClickTime|uint
+HWND|SetFocus|HWND
+bool|SetForegroundWindow|HWND
+bool|SetGestureConfig|HWND|DWORD|uint|GESTURECONFIG*|uint
+bool|SetKeyboardState|BYTE*
+VOID|SetLastErrorEx|DWORD|DWORD
+bool|SetLayeredWindowAttributes|HWND|COLORREF|BYTE|DWORD
+bool|SetMenu|HWND|HMENU
+bool|SetMenuContextHelpId|HMENU|DWORD
+bool|SetMenuDefaultItem|HMENU|uint|uint
+bool|SetMenuInfo|HMENU|MENUINFO*
+bool|SetMenuItemBitmaps|HMENU|uint|uint|HBITMAP|HBITMAP
+bool|SetMenuItemInfoA|HMENU|uint|bool|MENUITEMINFOA*
+bool|SetMenuItemInfoW|HMENU|uint|bool|MENUITEMINFOW*
+LPARAM|SetMessageExtraInfo|LPARAM
+bool|SetMessageQueue|int
+HWND|SetParent|HWND|HWND
+bool|SetPhysicalCursorPos|int|int
+bool|SetProcessDPIAware|VOID
+bool|SetProcessDefaultLayout|DWORD
+bool|SetProcessWindowStation|HWINSTA
+bool|SetPropA|HWND|char*|HANDLE
+bool|SetPropW|HWND|wchar*|HANDLE
+bool|SetRect|__out RECT*|int|int|int|int
+bool|SetRectEmpty|__out RECT*
+int|SetScrollInfo|HWND|int|SCROLLINFO*|bool
+int|SetScrollPos|HWND|int|int|bool
+bool|SetScrollRange|HWND|int|int|int|bool
+bool|SetSysColors|int|int*|COLORREF*
+bool|SetSystemCursor|HCURSOR|DWORD
+bool|SetThreadDesktop|HDESK
+UINT_PTR|SetTimer|HWND|UINT_PTR|uint|TIMERPROC
+bool|SetUserObjectInformationA|HANDLE|int|VOID*|DWORD
+bool|SetUserObjectInformationW|HANDLE|int|VOID*|DWORD
+bool|SetUserObjectSecurity|HANDLE|SECURITY_INFORMATION*|SECURITY_DESCRIPTOR*
+HWINEVENTHOOK|SetWinEventHook|DWORD|DWORD|HMODULE|WINEVENTPROC|DWORD|DWORD|DWORD
+bool|SetWindowContextHelpId|HWND|DWORD
+bool|SetWindowDisplayAffinity|HWND|DWORD
+long|SetWindowLongA|HWND|int|long
+long|SetWindowLongW|HWND|int|long
+bool|SetWindowPlacement|HWND|WINDOWPLACEMENT*
+bool|SetWindowPos|HWND|HWND|int|int|int|int|uint
+int|SetWindowRgn|HWND|HRGN|bool
+bool|SetWindowTextA|HWND|char*
+bool|SetWindowTextW|HWND|wchar*
+WORD|SetWindowWord|HWND|int|WORD
+HHOOK|SetWindowsHookA|int|HOOKPROC
+HHOOK|SetWindowsHookExA|int|HOOKPROC|HINSTANCE|DWORD
+HHOOK|SetWindowsHookExW|int|HOOKPROC|HINSTANCE|DWORD
+HHOOK|SetWindowsHookW|int|HOOKPROC
+bool|ShowCaret|HWND
+int|ShowCursor|bool
+bool|ShowOwnedPopups|HWND|bool
+bool|ShowScrollBar|HWND|int|bool
+bool|ShowWindow|HWND|int
+bool|ShowWindowAsync|HWND|int
+bool|ShutdownBlockReasonCreate|HWND|wchar*
+bool|ShutdownBlockReasonDestroy|HWND
+bool|ShutdownBlockReasonQuery|HWND|__out wchar*|__inout DWORD*
+bool|SoundSentry|VOID
+bool|SubtractRect|__out RECT*|RECT*|RECT*
+bool|SwapMouseButton|bool
+bool|SwitchDesktop|HDESK
+VOID|SwitchToThisWindow|HWND|bool
+bool|SystemParametersInfoA|uint|uint|__inout VOID*|uint
+bool|SystemParametersInfoW|uint|uint|__inout VOID*|uint
+long|TabbedTextOutA|HDC|int|int|char*|int|int|int*|int
+long|TabbedTextOutW|HDC|int|int|wchar*|int|int|int*|int
+WORD|TileWindows|HWND|uint|RECT*|uint|HWND*
+int|ToAscii|uint|uint|BYTE*|__out WORD*|uint
+int|ToAsciiEx|uint|uint|BYTE*|__out WORD*|uint|HKL
+int|ToUnicode|uint|uint|BYTE*|__out wchar*|int|uint
+int|ToUnicodeEx|uint|uint|BYTE*|__out wchar*|int|uint|HKL
+bool|TrackMouseEvent|__inout TRACKMOUSEEVENT*
+bool|TrackPopupMenu|HMENU|uint|int|int|int|HWND|RECT*
+bool|TrackPopupMenuEx|HMENU|uint|int|int|HWND|TPMPARAMS*
+int|TranslateAcceleratorA|HWND|HACCEL|MSG*
+int|TranslateAcceleratorW|HWND|HACCEL|MSG*
+bool|TranslateMDISysAccel|HWND|MSG*
+bool|TranslateMessage|MSG*
+bool|UnhookWinEvent|HWINEVENTHOOK
+bool|UnhookWindowsHook|int|HOOKPROC
+bool|UnhookWindowsHookEx|HHOOK
+bool|UnionRect|__out RECT*|RECT*|RECT*
+bool|UnloadKeyboardLayout|HKL
+bool|UnpackDDElParam|uint|LPARAM|UINT_PTR*|UINT_PTR*
+bool|UnregisterClassA|char*|HINSTANCE
+bool|UnregisterClassW|wchar*|HINSTANCE
+bool|UnregisterDeviceNotification|HDEVNOTIFY
+bool|UnregisterHotKey|HWND|int
+bool|UnregisterPowerSettingNotification|HPOWERNOTIFY
+bool|UnregisterTouchWindow|HWND
+bool|UpdateLayeredWindow|HWND|HDC|POINT*|SIZE*|HDC|POINT*|COLORREF|BLENDFUNCTION*|DWORD
+bool|UpdateLayeredWindowIndirect|HWND|UPDATELAYEREDWINDOWINFO*
+bool|UpdateWindow|HWND
+bool|UserHandleGrantAccess|HANDLE|HANDLE|bool
+bool|ValidateRect|HWND|RECT*
+bool|ValidateRgn|HWND|HRGN
+SHORT|VkKeyScanA|char
+SHORT|VkKeyScanExA|char|HKL
+SHORT|VkKeyScanExW|wchar|HKL
+SHORT|VkKeyScanW|wchar
+bool|WINNLSEnableIME|HWND|bool
+bool|WINNLSGetEnableStatus|HWND
+uint|WINNLSGetIMEHotkey|HWND
+DWORD|WaitForInputIdle|HANDLE|DWORD
+bool|WaitMessage|VOID
+bool|WinHelpA|HWND|char*|uint|ULONG_PTR
+bool|WinHelpW|HWND|wchar*|uint|ULONG_PTR
+HWND|WindowFromDC|HDC
+HWND|WindowFromPhysicalPoint|POINT
+HWND|WindowFromPoint|POINT
+VOID|keybd_event|BYTE|BYTE|DWORD|ULONG_PTR
+VOID|mouse_event|DWORD|DWORD|DWORD|DWORD|ULONG_PTR
+int|wsprintfA|__out char*|char*
+int|wsprintfW|__out wchar*|wchar*
+int|wvsprintfA|__out char*|char*|va_list
+int|wvsprintfW|__out wchar*|wchar*|va_list
+
+# A group of exported functions from ntdll.dll
+bool|RtlAddFunctionTable|RUNTIME_FUNCTION*|DWORD|ULONGLONG|ULONGLONG
+VOID|RtlFreeOemString|OEM_STRING*
+bool|RtlGetProductInfo|DWORD|DWORD|DWORD|DWORD|__out DWORD*
+long|RtlIpv4AddressToStringExA|in_addr*|USHORT|__out char*|__inout ULONG*
+long|RtlIpv4AddressToStringExW|in_addr*|USHORT|__out wchar*|__inout ULONG*
+long|RtlIpv6AddressToStringExA|in6_addr*|ulong|USHORT|__out char*|__inout ULONG*
+long|RtlIpv6AddressToStringExW|in6_addr*|ulong|USHORT|__out wchar*|__inout ULONG*
+VOID*|RtlPcToFileHeader|VOID*|__out VOID**
+NTSTATUS|RtlUnicodeStringToOemString|OEM_STRING*|UNICODE_STRING*|bool
+NTSTATUS|RtlUnicodeToMultiByteSize|__out ULONG*|wchar*|ulong
+size_t|RtlCompareMemory|VOID*|VOID*|size_t
+NTSTATUS|RtlConvertSidToUnicodeString|UNICODE_STRING*|SID*|bool
+DWORD|RtlCopyExtendedContext|__out CONTEXT_EX*|DWORD|CONTEXT_EX*
+bool|RtlDeleteFunctionTable|RUNTIME_FUNCTION*
+char*|RtlEthernetAddressToStringA|DL_EUI48*|__out char*
+wchar*|RtlEthernetAddressToStringW|DL_EUI48*|__out wchar*
+long|RtlEthernetStringToAddressA|char*|__out char**|DL_EUI48*
+long|RtlEthernetStringToAddressW|wchar*|__out wchar**|DL_EUI48*
+SLIST_ENTRY*|RtlFirstEntrySList|SLIST_HEADER*
+void|RtlFreeAnsiString|ANSI_STRING*
+VOID|RtlFreeUnicodeString|UNICODE_STRING*
+DWORD64|RtlGetEnabledExtendedFeatures|DWORD64
+DWORD|RtlGetExtendedContextLength|DWORD|__out DWORD*
+DWORD64|RtlGetExtendedFeaturesMask|CONTEXT_EX*
+VOID|RtlInitAnsiString|ANSI_STRING*|char*
+VOID|RtlInitString|STRING*|char*
+VOID|RtlInitUnicodeString|UNICODE_STRING*|wchar*
+DWORD|RtlInitializeExtendedContext|__out VOID*|DWORD|__out CONTEXT_EX**
+VOID|RtlInitializeSListHead|__out SLIST_HEADER*
+bool|RtlInstallFunctionTableCallback|DWORD64|DWORD64|DWORD|GET_RUNTIME_FUNCTION_CALLBACK*|VOID*|wchar*
+SLIST_ENTRY*|RtlInterlockedFlushSList|__inout SLIST_HEADER*
+SLIST_ENTRY*|RtlInterlockedPopEntrySList|__inout SLIST_HEADER*
+SLIST_ENTRY*|RtlInterlockedPushEntrySList|__inout SLIST_HEADER*|__inout SLIST_ENTRY*
+char*|RtlIpv4AddressToStringA|in_addr*|__out char*
+wchar*|RtlIpv4AddressToStringW|in_addr*|__out wchar*
+long|RtlIpv4StringToAddressA|char*|bool|__out char**|__out in_addr*
+long|RtlIpv4StringToAddressExA|char*|bool|__out in_addr*|__out USHORT*
+long|RtlIpv4StringToAddressExW|wchar*|bool|__out in_addr*|__out USHORT*
+long|RtlIpv4StringToAddressW|wchar*|bool|__out wchar**|__out in_addr*
+char*|RtlIpv6AddressToStringA|in6_addr*|__out char*
+wchar*|RtlIpv6AddressToStringW|in6_addr*|__out wchar*
+long|RtlIpv6StringToAddressA|char*|__out char**|__out in6_addr*
+long|RtlIpv6StringToAddressExA|char*|__out in6_addr*|__out ULONG*|__out USHORT*
+long|RtlIpv6StringToAddressExW|wchar*|__out in6_addr*|__out ULONG*|__out USHORT*
+long|RtlIpv6StringToAddressW|wchar*|__out wchar**|__out in6_addr*
+bool|RtlIsNameLegalDOS8Dot3|UNICODE_STRING*|OEM_STRING*|BOOLEAN*
+NTSTATUS|RtlLocalTimeToSystemTime|LARGE_INTEGER*|LARGE_INTEGER*
+VOID*|RtlLocateExtendedFeature|CONTEXT_EX*|DWORD|__out DWORD*
+CONTEXT*|RtlLocateLegacyContext|CONTEXT_EX*|__out DWORD*
+RUNTIME_FUNCTION*|RtlLookupFunctionEntry|DWORD64|__out DWORD64*|__inout UNWIND_HISTORY_TABLE*
+ulong|RtlNtStatusToDosError|NTSTATUS
+WORD|RtlQueryDepthSList|SLIST_HEADER*
+VOID|RtlRestoreContext|CONTEXT*|_EXCEPTION_RECORD*
+DWORD|RtlRunOnceBeginInitialize|__inout RTL_RUN_ONCE*|DWORD|__out VOID**
+DWORD|RtlRunOnceComplete|__inout RTL_RUN_ONCE*|DWORD|VOID*
+DWORD|RtlRunOnceExecuteOnce|__inout RTL_RUN_ONCE*|RTL_RUN_ONCE_INIT_FN*|__inout VOID*|__out VOID**
+VOID|RtlRunOnceInitialize|__out RTL_RUN_ONCE*
+VOID|RtlSetExtendedFeaturesMask|__out CONTEXT_EX*|DWORD64
+bool|RtlTimeToSecondsSince1970|LARGE_INTEGER*|ULONG*
+NTSTATUS|RtlUnicodeStringToAnsiString|ANSI_STRING*|UNICODE_STRING*|bool
+ulong|RtlUniform|ULONG*
+VOID|RtlUnwindEx|VOID*|VOID*|EXCEPTION_RECORD*|VOID*|CONTEXT*|UNWIND_HISTORY_TABLE*
+EXCEPTION_ROUTINE*|RtlVirtualUnwind|DWORD|DWORD64|DWORD64|RUNTIME_FUNCTION*|__inout CONTEXT*|__out VOID**|__out DWORD64*|__inout KNONVOLATILE_CONTEXT_POINTERS*
+
+# A group of exported functions from wininet.dll
+bool|GetDiskInfoA|char*|__out DWORD*|__out DWORDLONG*|__out DWORDLONG*
+bool|PerformOperationOverUrlCacheA|char*|DWORD|DWORD|GROUPID|VOID*|DWORD*|VOID*|CACHE_OPERATOR|__inout VOID*
+bool|HttpCheckDavComplianceA|char*|char*|__inout bool*|HWND|VOID*
+bool|HttpCheckDavComplianceW|wchar*|wchar*|__inout bool*|HWND|VOID*
+bool|ImportCookieFileA|char*
+bool|ExportCookieFileA|char*|bool
+bool|ImportCookieFileW|wchar*
+bool|ExportCookieFileW|wchar*|bool
+int|FindP3PPolicySymbol|char*
+int|MapResourceToPolicy|P3PResource*|__out char*|long|P3PSignal*
+int|GetP3PPolicy|char*|HANDLE|BSTR|P3PSignal*
+int|FreeP3PObject|void*
+int|GetP3PRequestStatus|void*
+bool|CommitUrlCacheEntryA|char*|char*|FILETIME|FILETIME|DWORD|BYTE*|DWORD|char*|char*
+bool|CommitUrlCacheEntryW|wchar*|wchar*|FILETIME|FILETIME|DWORD|wchar*|DWORD|wchar*|wchar*
+bool|CreateUrlCacheContainerA|char*|char*|char*|DWORD|DWORD|DWORD|VOID*|DWORD*
+bool|CreateUrlCacheContainerW|wchar*|wchar*|wchar*|DWORD|DWORD|DWORD|VOID*|DWORD*
+bool|CreateUrlCacheEntryA|char*|DWORD|char*|__inout char*|DWORD
+bool|CreateUrlCacheEntryW|wchar*|DWORD|wchar*|__inout wchar*|DWORD
+GROUPID|CreateUrlCacheGroup|DWORD|VOID*
+DWORD|DeleteIE3Cache|HWND|HINSTANCE|char*|int
+bool|DeleteUrlCacheContainerA|char*|DWORD
+bool|DeleteUrlCacheContainerW|wchar*|DWORD
+bool|DeleteUrlCacheEntry|char*
+bool|DeleteUrlCacheEntryA|char*
+bool|DeleteUrlCacheEntryW|wchar*
+bool|DeleteUrlCacheGroup|GROUPID|DWORD|VOID*
+bool|DeleteWpadCacheForNetworks|WPAD_CACHE_DELETE
+bool|DetectAutoProxyUrl|__out char*|DWORD|DWORD
+bool|FindCloseUrlCache|HANDLE
+HANDLE|FindFirstUrlCacheContainerA|__inout DWORD*|__out INTERNET_CACHE_CONTAINER_INFOA*|__inout DWORD*|DWORD
+HANDLE|FindFirstUrlCacheContainerW|__inout DWORD*|__out INTERNET_CACHE_CONTAINER_INFOW*|__inout DWORD*|DWORD
+HANDLE|FindFirstUrlCacheEntryA|char*|__inout INTERNET_CACHE_ENTRY_INFOA*|__inout DWORD*
+HANDLE|FindFirstUrlCacheEntryExA|char*|DWORD|DWORD|GROUPID|__inout INTERNET_CACHE_ENTRY_INFOA*|__inout DWORD*|VOID*|DWORD*|VOID*
+HANDLE|FindFirstUrlCacheEntryExW|wchar*|DWORD|DWORD|GROUPID|__inout INTERNET_CACHE_ENTRY_INFOW*|__inout DWORD*|VOID*|DWORD*|VOID*
+HANDLE|FindFirstUrlCacheEntryW|wchar*|__inout INTERNET_CACHE_ENTRY_INFOW*|__inout DWORD*
+HANDLE|FindFirstUrlCacheGroup|DWORD|DWORD|VOID*|DWORD|__out GROUPID*|VOID*
+bool|FindNextUrlCacheContainerA|HANDLE|__out INTERNET_CACHE_CONTAINER_INFOA*|__inout DWORD*
+bool|FindNextUrlCacheContainerW|HANDLE|__out INTERNET_CACHE_CONTAINER_INFOW*|__inout DWORD*
+bool|FindNextUrlCacheEntryA|HANDLE|__inout INTERNET_CACHE_ENTRY_INFOA*|__inout DWORD*
+bool|FindNextUrlCacheEntryExA|HANDLE|__inout INTERNET_CACHE_ENTRY_INFOA*|__inout DWORD*|VOID*|DWORD*|VOID*
+bool|FindNextUrlCacheEntryExW|HANDLE|__inout INTERNET_CACHE_ENTRY_INFOW*|__inout DWORD*|VOID*|DWORD*|VOID*
+bool|FindNextUrlCacheEntryW|HANDLE|__inout INTERNET_CACHE_ENTRY_INFOW*|__inout DWORD*
+bool|FindNextUrlCacheGroup|HANDLE|__out GROUPID*|VOID*
+bool|FreeUrlCacheSpaceA|char*|DWORD|DWORD
+bool|FreeUrlCacheSpaceW|wchar*|DWORD|DWORD
+bool|FtpCommandA|HINTERNET|bool|DWORD|char*|DWORD_PTR|__out HINTERNET*
+bool|FtpCommandW|HINTERNET|bool|DWORD|wchar*|DWORD_PTR|__out HINTERNET*
+bool|FtpCreateDirectoryA|HINTERNET|char*
+bool|FtpCreateDirectoryW|HINTERNET|wchar*
+bool|FtpDeleteFileA|HINTERNET|char*
+bool|FtpDeleteFileW|HINTERNET|wchar*
+HINTERNET|FtpFindFirstFileA|HINTERNET|char*|__out WIN32_FIND_DATAA*|DWORD|DWORD_PTR
+HINTERNET|FtpFindFirstFileW|HINTERNET|wchar*|__out WIN32_FIND_DATAW*|DWORD|DWORD_PTR
+bool|FtpGetCurrentDirectoryA|HINTERNET|__out char*|__inout DWORD*
+bool|FtpGetCurrentDirectoryW|HINTERNET|__out wchar*|__inout DWORD*
+bool|FtpGetFileA|HINTERNET|char*|char*|bool|DWORD|DWORD|DWORD_PTR
+bool|FtpGetFileEx|HINTERNET|char*|wchar*|bool|DWORD|DWORD|DWORD_PTR
+DWORD|FtpGetFileSize|HINTERNET|__out DWORD*
+bool|FtpGetFileW|HINTERNET|wchar*|wchar*|bool|DWORD|DWORD|DWORD_PTR
+HINTERNET|FtpOpenFileA|HINTERNET|char*|DWORD|DWORD|DWORD_PTR
+HINTERNET|FtpOpenFileW|HINTERNET|wchar*|DWORD|DWORD|DWORD_PTR
+bool|FtpPutFileA|HINTERNET|char*|char*|DWORD|DWORD_PTR
+bool|FtpPutFileEx|HINTERNET|wchar*|char*|DWORD|DWORD_PTR
+bool|FtpPutFileW|HINTERNET|wchar*|wchar*|DWORD|DWORD_PTR
+bool|FtpRemoveDirectoryA|HINTERNET|char*
+bool|FtpRemoveDirectoryW|HINTERNET|wchar*
+bool|FtpRenameFileA|HINTERNET|char*|char*
+bool|FtpRenameFileW|HINTERNET|wchar*|wchar*
+bool|FtpSetCurrentDirectoryA|HINTERNET|char*
+bool|FtpSetCurrentDirectoryW|HINTERNET|wchar*
+bool|GetUrlCacheConfigInfoA|__inout INTERNET_CACHE_CONFIG_INFOA*|DWORD*|DWORD
+bool|GetUrlCacheConfigInfoW|__inout INTERNET_CACHE_CONFIG_INFOW*|DWORD*|DWORD
+bool|GetUrlCacheEntryInfoA|char*|__inout INTERNET_CACHE_ENTRY_INFOA*|__inout DWORD*
+bool|GetUrlCacheEntryInfoExA|char*|__inout INTERNET_CACHE_ENTRY_INFOA*|__inout DWORD*|char*|DWORD*|VOID*|DWORD
+bool|GetUrlCacheEntryInfoExW|wchar*|__inout INTERNET_CACHE_ENTRY_INFOW*|__inout DWORD*|wchar*|DWORD*|VOID*|DWORD
+bool|GetUrlCacheEntryInfoW|wchar*|__inout INTERNET_CACHE_ENTRY_INFOW*|__inout DWORD*
+bool|GetUrlCacheGroupAttributeA|GROUPID|DWORD|DWORD|__out INTERNET_CACHE_GROUP_INFOA*|__inout DWORD*|VOID*
+bool|GetUrlCacheGroupAttributeW|GROUPID|DWORD|DWORD|__out INTERNET_CACHE_GROUP_INFOW*|__inout DWORD*|VOID*
+bool|GetUrlCacheHeaderData|DWORD|__out DWORD*
+bool|GopherCreateLocatorA|char*|INTERNET_PORT|char*|char*|DWORD|__out char*|__inout DWORD*
+bool|GopherCreateLocatorW|wchar*|INTERNET_PORT|wchar*|wchar*|DWORD|__out wchar*|__inout DWORD*
+HINTERNET|GopherFindFirstFileA|HINTERNET|char*|char*|__out GOPHER_FIND_DATAA*|DWORD|DWORD_PTR
+HINTERNET|GopherFindFirstFileW|HINTERNET|wchar*|wchar*|__out GOPHER_FIND_DATAW*|DWORD|DWORD_PTR
+bool|GopherGetAttributeA|HINTERNET|char*|char*|__out BYTE*|DWORD|__out DWORD*|GOPHER_ATTRIBUTE_ENUMERATOR|DWORD_PTR
+bool|GopherGetAttributeW|HINTERNET|wchar*|wchar*|__out BYTE*|DWORD|__out DWORD*|GOPHER_ATTRIBUTE_ENUMERATOR|DWORD_PTR
+bool|GopherGetLocatorTypeA|char*|__out DWORD*
+bool|GopherGetLocatorTypeW|wchar*|__out DWORD*
+HINTERNET|GopherOpenFileA|HINTERNET|char*|char*|DWORD|DWORD_PTR
+HINTERNET|GopherOpenFileW|HINTERNET|wchar*|wchar*|DWORD|DWORD_PTR
+bool|HttpAddRequestHeadersA|HINTERNET|char*|DWORD|DWORD
+bool|HttpAddRequestHeadersW|HINTERNET|wchar*|DWORD|DWORD
+bool|HttpEndRequestA|HINTERNET|__out INTERNET_BUFFERSA*|DWORD|DWORD_PTR
+bool|HttpEndRequestW|HINTERNET|__out INTERNET_BUFFERSW*|DWORD|DWORD_PTR
+HINTERNET|HttpOpenRequestA|HINTERNET|char*|char*|char*|char*|char**|DWORD|DWORD_PTR
+HINTERNET|HttpOpenRequestW|HINTERNET|wchar*|wchar*|wchar*|wchar*|wchar**|DWORD|DWORD_PTR
+bool|HttpQueryInfoA|HINTERNET|DWORD|__out VOID*|__inout DWORD*|__inout DWORD*
+bool|HttpQueryInfoW|HINTERNET|DWORD|__out VOID*|__inout DWORD*|__inout DWORD*
+bool|HttpSendRequestA|HINTERNET|char*|DWORD|VOID*|DWORD
+bool|HttpSendRequestExA|HINTERNET|INTERNET_BUFFERSA*|__out INTERNET_BUFFERSA*|DWORD|DWORD_PTR
+bool|HttpSendRequestExW|HINTERNET|INTERNET_BUFFERSW*|__out INTERNET_BUFFERSW*|DWORD|DWORD_PTR
+bool|HttpSendRequestW|HINTERNET|wchar*|DWORD|VOID*|DWORD
+bool|IncrementUrlCacheHeaderData|DWORD|__out DWORD*
+bool|InternetAlgIdToStringA|ALG_ID|__out char*|__inout DWORD*|DWORD
+bool|InternetAlgIdToStringW|ALG_ID|__out wchar*|__inout DWORD*|DWORD
+DWORD|InternetAttemptConnect|DWORD
+bool|InternetAutodial|DWORD|HWND
+bool|InternetAutodialHangup|DWORD
+bool|InternetCanonicalizeUrlA|char*|__out char*|__inout DWORD*|DWORD
+bool|InternetCanonicalizeUrlW|wchar*|__out wchar*|__inout DWORD*|DWORD
+bool|InternetCheckConnectionA|char*|DWORD|DWORD
+bool|InternetCheckConnectionW|wchar*|DWORD|DWORD
+bool|InternetClearAllPerSiteCookieDecisions|VOID
+bool|InternetCloseHandle|HINTERNET
+bool|InternetCombineUrlA|char*|char*|__out char*|__inout DWORD*|DWORD
+bool|InternetCombineUrlW|wchar*|wchar*|__out wchar*|__inout DWORD*|DWORD
+DWORD|InternetConfirmZoneCrossing|HWND|char*|char*|bool
+DWORD|InternetConfirmZoneCrossingA|HWND|char*|char*|bool
+DWORD|InternetConfirmZoneCrossingW|HWND|wchar*|wchar*|bool
+HINTERNET|InternetConnectA|HINTERNET|char*|INTERNET_PORT|char*|char*|DWORD|DWORD|DWORD_PTR
+HINTERNET|InternetConnectW|HINTERNET|wchar*|INTERNET_PORT|wchar*|wchar*|DWORD|DWORD|DWORD_PTR
+bool|InternetCrackUrlA|char*|DWORD|DWORD|__inout URL_COMPONENTSA*
+bool|InternetCrackUrlW|wchar*|DWORD|DWORD|__inout URL_COMPONENTSW*
+bool|InternetCreateUrlA|URL_COMPONENTSA*|DWORD|__out char*|__inout DWORD*
+bool|InternetCreateUrlW|URL_COMPONENTSW*|DWORD|__out wchar*|__inout DWORD*
+DWORD|InternetDial|HWND|char*|DWORD|__out DWORD*|DWORD
+DWORD|InternetDialA|HWND|char*|DWORD|__out DWORD_PTR*|DWORD
+DWORD|InternetDialW|HWND|wchar*|DWORD|__out DWORD_PTR*|DWORD
+bool|InternetEnumPerSiteCookieDecisionA|__out char*|__inout long*|__out long*|long
+bool|InternetEnumPerSiteCookieDecisionW|__out wchar*|__inout long*|__out long*|long
+DWORD|InternetErrorDlg|HWND|__inout HINTERNET|DWORD|DWORD|__inout VOID**
+bool|InternetFindNextFileA|HINTERNET|__out VOID*
+bool|InternetFindNextFileW|HINTERNET|__out VOID*
+bool|InternetFortezzaCommand|DWORD|HWND|DWORD_PTR
+bool|InternetGetConnectedState|__out DWORD*|DWORD
+bool|InternetGetConnectedStateEx|__out DWORD*|__out char*|DWORD|DWORD
+bool|InternetGetConnectedStateExA|__out DWORD*|__out char*|DWORD|DWORD
+bool|InternetGetConnectedStateExW|__out DWORD*|__out wchar*|DWORD|DWORD
+bool|InternetGetCookieA|char*|char*|__out char*|__inout DWORD*
+bool|InternetGetCookieExA|char*|char*|char*|__inout DWORD*|DWORD|VOID*
+bool|InternetGetCookieExW|wchar*|wchar*|wchar*|__inout DWORD*|DWORD|VOID*
+bool|InternetGetCookieW|wchar*|wchar*|__out wchar*|__inout DWORD*
+bool|InternetGetLastResponseInfoA|__out DWORD*|__out char*|__inout DWORD*
+bool|InternetGetLastResponseInfoW|__out DWORD*|__out wchar*|__inout DWORD*
+bool|InternetGetPerSiteCookieDecisionA|char*|__out long*
+bool|InternetGetPerSiteCookieDecisionW|wchar*|__out long*
+bool|InternetGetSecurityInfoByURL|char*|__out CERT_CHAIN_CONTEXT**|__out DWORD*
+bool|InternetGetSecurityInfoByURLA|char*|__out CERT_CHAIN_CONTEXT**|__out DWORD*
+bool|InternetGetSecurityInfoByURLW|wchar*|__out CERT_CHAIN_CONTEXT**|__out DWORD*
+bool|InternetGoOnline|char*|HWND|DWORD
+bool|InternetGoOnlineA|char*|HWND|DWORD
+bool|InternetGoOnlineW|wchar*|HWND|DWORD
+DWORD|InternetHangUp|DWORD_PTR|DWORD
+bool|InternetInitializeAutoProxyDll|DWORD
+bool|InternetLockRequestFile|HINTERNET|__out HANDLE*
+HINTERNET|InternetOpenA|char*|DWORD|char*|char*|DWORD
+HINTERNET|InternetOpenUrlA|HINTERNET|char*|char*|DWORD|DWORD|DWORD_PTR
+HINTERNET|InternetOpenUrlW|HINTERNET|wchar*|wchar*|DWORD|DWORD|DWORD_PTR
+HINTERNET|InternetOpenW|wchar*|DWORD|wchar*|wchar*|DWORD
+bool|InternetQueryDataAvailable|HINTERNET|__out DWORD*|DWORD|DWORD_PTR
+bool|InternetQueryFortezzaStatus|__out DWORD*|DWORD_PTR
+bool|InternetQueryOptionA|HINTERNET|DWORD|__out VOID*|__inout DWORD*
+bool|InternetQueryOptionW|HINTERNET|DWORD|__out VOID*|__inout DWORD*
+bool|InternetReadFile|HINTERNET|__out VOID*|DWORD|__out DWORD*
+bool|InternetReadFileExA|HINTERNET|__out INTERNET_BUFFERSA*|DWORD|DWORD_PTR
+bool|InternetReadFileExW|HINTERNET|__out INTERNET_BUFFERSW*|DWORD|DWORD_PTR
+bool|InternetSecurityProtocolToStringA|DWORD|__out char*|__inout DWORD*|DWORD
+bool|InternetSecurityProtocolToStringW|DWORD|__out wchar*|__inout DWORD*|DWORD
+bool|InternetSetCookieA|char*|char*|char*
+DWORD|InternetSetCookieExA|char*|char*|char*|DWORD|DWORD_PTR
+DWORD|InternetSetCookieExW|wchar*|wchar*|wchar*|DWORD|DWORD_PTR
+bool|InternetSetCookieW|wchar*|wchar*|wchar*
+bool|InternetSetDialState|char*|DWORD|DWORD
+bool|InternetSetDialStateA|char*|DWORD|DWORD
+bool|InternetSetDialStateW|wchar*|DWORD|DWORD
+DWORD|InternetSetFilePointer|HINTERNET|long|__inout LONG*|DWORD|DWORD_PTR
+bool|InternetSetOptionA|HINTERNET|DWORD|VOID*|DWORD
+bool|InternetSetOptionExA|HINTERNET|DWORD|VOID*|DWORD|DWORD
+bool|InternetSetOptionExW|HINTERNET|DWORD|VOID*|DWORD|DWORD
+bool|InternetSetOptionW|HINTERNET|DWORD|VOID*|DWORD
+bool|InternetSetPerSiteCookieDecisionA|char*|DWORD
+bool|InternetSetPerSiteCookieDecisionW|wchar*|DWORD
+INTERNET_STATUS_CALLBACK|InternetSetStatusCallback|HINTERNET|INTERNET_STATUS_CALLBACK
+INTERNET_STATUS_CALLBACK|InternetSetStatusCallbackA|HINTERNET|INTERNET_STATUS_CALLBACK
+INTERNET_STATUS_CALLBACK|InternetSetStatusCallbackW|HINTERNET|INTERNET_STATUS_CALLBACK
+bool|InternetShowSecurityInfoByURL|char*|HWND
+bool|InternetShowSecurityInfoByURLA|char*|HWND
+bool|InternetShowSecurityInfoByURLW|wchar*|HWND
+DWORD|InternalInternetGetCookie|char*|__out char*|__inout DWORD*
+bool|InternetTimeFromSystemTime|SYSTEMTIME*|DWORD|__out char*|DWORD
+bool|InternetTimeFromSystemTimeA|SYSTEMTIME*|DWORD|__out char*|DWORD
+bool|InternetTimeFromSystemTimeW|SYSTEMTIME*|DWORD|__out wchar*|DWORD
+bool|InternetTimeToSystemTime|char*|__out SYSTEMTIME*|DWORD
+bool|InternetTimeToSystemTimeA|char*|__out SYSTEMTIME*|DWORD
+bool|InternetTimeToSystemTimeW|wchar*|__out SYSTEMTIME*|DWORD
+bool|InternetUnlockRequestFile|__inout HANDLE
+bool|InternetWriteFile|HINTERNET|VOID*|DWORD|__out DWORD*
+bool|InternetWriteFileExA|HINTERNET|INTERNET_BUFFERSA*|DWORD|DWORD_PTR
+bool|InternetWriteFileExW|HINTERNET|INTERNET_BUFFERSW*|DWORD|DWORD_PTR
+bool|IsHostInProxyBypassList|INTERNET_SCHEME|char*|DWORD
+bool|IsUrlCacheEntryExpiredA|char*|DWORD|__inout FILETIME*
+bool|IsUrlCacheEntryExpiredW|wchar*|DWORD|__inout FILETIME*
+DWORD|ParseX509EncodedCertificateForListBoxEntry|BYTE*|DWORD|__out char*|__inout DWORD*
+DWORD|PrivacyGetZonePreferenceW|DWORD|DWORD|__out DWORD*|__out wchar*|__inout DWORD*
+DWORD|PrivacySetZonePreferenceW|DWORD|DWORD|DWORD|wchar*
+bool|ReadUrlCacheEntryStream|HANDLE|DWORD|__out VOID*|__inout DWORD*|DWORD
+bool|ReadUrlCacheEntryStreamEx|HANDLE|DWORDLONG|__out VOID*|__inout DWORD*
+bool|RegisterUrlCacheNotification|HWND|uint|GROUPID|DWORD|DWORD
+bool|ResumeSuspendedDownload|HINTERNET|DWORD
+bool|RetrieveUrlCacheEntryFileA|char*|__inout INTERNET_CACHE_ENTRY_INFOA*|__inout DWORD*|DWORD
+bool|RetrieveUrlCacheEntryFileW|wchar*|__inout INTERNET_CACHE_ENTRY_INFOW*|__inout DWORD*|DWORD
+HANDLE|RetrieveUrlCacheEntryStreamA|char*|__inout INTERNET_CACHE_ENTRY_INFOA*|__inout DWORD*|bool|DWORD
+HANDLE|RetrieveUrlCacheEntryStreamW|wchar*|__inout INTERNET_CACHE_ENTRY_INFOW*|__inout DWORD*|bool|DWORD
+DWORD|RunOnceUrlCache|HWND|HINSTANCE|char*|int
+bool|SetUrlCacheConfigInfoA|INTERNET_CACHE_CONFIG_INFOA*|DWORD
+bool|SetUrlCacheConfigInfoW|INTERNET_CACHE_CONFIG_INFOW*|DWORD
+bool|SetUrlCacheEntryGroup|char*|DWORD|GROUPID|BYTE*|DWORD|VOID*
+bool|SetUrlCacheEntryGroupA|char*|DWORD|GROUPID|BYTE*|DWORD|VOID*
+bool|SetUrlCacheEntryGroupW|wchar*|DWORD|GROUPID|BYTE*|DWORD|VOID*
+bool|SetUrlCacheEntryInfoA|char*|INTERNET_CACHE_ENTRY_INFOA*|DWORD
+bool|SetUrlCacheEntryInfoW|wchar*|INTERNET_CACHE_ENTRY_INFOW*|DWORD
+bool|SetUrlCacheGroupAttributeA|GROUPID|DWORD|DWORD|INTERNET_CACHE_GROUP_INFOA*|VOID*
+bool|SetUrlCacheGroupAttributeW|GROUPID|DWORD|DWORD|INTERNET_CACHE_GROUP_INFOW*|VOID*
+bool|SetUrlCacheHeaderData|DWORD|DWORD
+bool|LoadUrlCacheContent|VOID
+DWORD|ShowClientAuthCerts|HWND
+DWORD|ShowSecurityInfo|HWND|INTERNET_SECURITY_INFO*
+DWORD|ShowX509EncodedCertificate|HWND|BYTE*|DWORD
+bool|UnlockUrlCacheEntryFile|char*|DWORD
+bool|UnlockUrlCacheEntryFileA|char*|DWORD
+bool|UnlockUrlCacheEntryFileW|wchar*|DWORD
+bool|UnlockUrlCacheEntryStream|HANDLE|DWORD
+bool|UpdateUrlCacheContentPath|char*
+bool|ReadGuidsForConnectedNetworks|__out DWORD*|__out wchar***|__out BSTR**|__out wchar***|__out DWORD*|__out DWORD*
+DWORD|_GetFileExtensionFromUrl|char*|DWORD|__inout char*|__inout DWORD*
+bool|CreateMD5SSOHash|wchar*|wchar*|wchar*|__out BYTE*
+
+# A group of exported functions from wsock32.dll
+SOCKET|accept|SOCKET|__out sockaddr*|__inout int*
+int|bind|SOCKET|sockaddr*|int
+int|closesocket|SOCKET
+int|connect|SOCKET|sockaddr*|int
+int|getpeername|SOCKET|__out sockaddr*|__inout int*
+int|getsockname|SOCKET|__out sockaddr*|__inout int*
+int|getsockopt|SOCKET|int|int|__out char*|__inout int*
+ulong|htonl|ulong
+ushort|htons|ushort
+ulong|inet_addr|char*
+char*|inet_ntoa|in_addr
+int|ioctlsocket|SOCKET|long|__inout ulong*
+int|listen|SOCKET|int
+ulong|ntohl|ulong
+ushort|ntohs|ushort
+int|recv|SOCKET|__out char*|int|int
+int|recvfrom|SOCKET|__out char*|int|int|__out sockaddr*|__inout int*
+int|select|int|__inout fd_set*|__inout fd_set*|__inout fd_set*|timeval*
+int|send|SOCKET|char*|int|int
+int|sendto|SOCKET|char*|int|int|sockaddr*|int
+int|setsockopt|SOCKET|int|int|char*|int
+int|shutdown|SOCKET|int
+SOCKET|socket|int|int|int
+hostent*|gethostbyaddr|char*|int|int
+hostent*|gethostbyname|char*
+protoent*|getprotobyname|char*
+protoent*|getprotobynumber|int
+servent*|getservbyname|char*|char*
+servent*|getservbyport|int|char*
+int|gethostname|__out char*|int
+int|WSAAsyncSelect|SOCKET|HWND|uint|long
+HANDLE|WSAAsyncGetHostByAddr|HWND|uint|char*|int|int|__out char*|int
+HANDLE|WSAAsyncGetHostByName|HWND|uint|char*|__out char*|int
+HANDLE|WSAAsyncGetProtoByNumber|HWND|uint|int|__out char*|int
+HANDLE|WSAAsyncGetProtoByName|HWND|uint|char*|__out char*|int
+HANDLE|WSAAsyncGetServByPort|HWND|uint|int|char*|__out char*|int
+HANDLE|WSAAsyncGetServByName|HWND|uint|char*|char*|__out char*|int
+int|WSACancelAsyncRequest|HANDLE
+FARPROC|WSASetBlockingHook|FARPROC
+int|WSAUnhookBlockingHook|void
+int|WSAGetLastError|void
+void|WSASetLastError|int
+int|WSACancelBlockingCall|void
+bool|WSAIsBlocking|void
+int|WSAStartup|WORD|__out LPWSADATA
+int|WSACleanup|void
+int|__WSAFDIsSet|SOCKET|fd_set*
+int|WSARecvEx|SOCKET|__out char*|int|__inout int*
+int|GetAddressByNameA|DWORD|GUID*|char*|int*|DWORD|SERVICE_ASYNC_INFO*|__out VOID*|__inout DWORD*|__inout char*|__inout DWORD*
+int|GetAddressByNameW|DWORD|GUID*|wchar*|int*|DWORD|SERVICE_ASYNC_INFO*|__out VOID*|__inout DWORD*|__inout wchar*|__inout DWORD*
+int|EnumProtocolsA|int*|__out VOID*|__inout DWORD*
+int|EnumProtocolsW|int*|__out VOID*|__inout DWORD*
+int|GetTypeByNameA|char*|__inout GUID*
+int|GetTypeByNameW|wchar*|__inout GUID*
+int|GetNameByTypeA|GUID*|__out char*|DWORD
+int|GetNameByTypeW|GUID*|__out wchar*|DWORD
+int|SetServiceA|DWORD|DWORD|DWORD|SERVICE_INFOA*|SERVICE_ASYNC_INFO*|__out DWORD*
+int|SetServiceW|DWORD|DWORD|DWORD|SERVICE_INFOW*|SERVICE_ASYNC_INFO*|__out DWORD*
+int|GetServiceA|DWORD|GUID*|char*|DWORD|__out VOID*|__inout DWORD*|SERVICE_ASYNC_INFO*
+int|GetServiceW|DWORD|GUID*|wchar*|DWORD|__out VOID*|__inout DWORD*|SERVICE_ASYNC_INFO*
+bool|TransmitFile|SOCKET|HANDLE|DWORD|DWORD|__inout OVERLAPPED*|TRANSMIT_FILE_BUFFERS*|DWORD
+bool|AcceptEx|SOCKET|SOCKET|__out VOID*|DWORD|DWORD|DWORD|__out DWORD*|__inout OVERLAPPED*
+VOID|GetAcceptExSockaddrs|VOID*|DWORD|DWORD|DWORD|__out sockaddr**|__out int*|__out sockaddr**|__out int*
+
+# A group of API calls from ws2_32.dll
+void|FreeAddrInfoEx|ADDRINFOEXA*
+void|FreeAddrInfoExW|ADDRINFOEXW*
+VOID|FreeAddrInfoW|ADDRINFOW*
+int|GetAddrInfoExA|char*|char*|DWORD|GUID*|ADDRINFOEXA*|__out ADDRINFOEXA**|timeval*|OVERLAPPED*|LOOKUPSERVICE_COMPLETION_ROUTINE*|__out HANDLE*
+int|GetAddrInfoExW|wchar*|wchar*|DWORD|GUID*|ADDRINFOEXW*|__out ADDRINFOEXW**|timeval*|OVERLAPPED*|LOOKUPSERVICE_COMPLETION_ROUTINE*|__out HANDLE*
+int|GetAddrInfoW|wchar*|wchar*|ADDRINFOW*|__out ADDRINFOW**
+int|GetNameInfoW|SOCKADDR*|socklen_t|__out wchar*|DWORD|__out wchar*|DWORD|int
+wchar*|InetNtopW|int|VOID*|__out wchar*|size_t
+int|InetPtonW|int|wchar*|__out VOID*
+int|SetAddrInfoExA|char*|char*|SOCKET_ADDRESS*|DWORD|BLOB*|DWORD|DWORD|GUID*|timeval*|OVERLAPPED*|LOOKUPSERVICE_COMPLETION_ROUTINE*|__out HANDLE*
+int|SetAddrInfoExW|wchar*|wchar*|SOCKET_ADDRESS*|DWORD|BLOB*|DWORD|DWORD|GUID*|timeval*|OVERLAPPED*|LOOKUPSERVICE_COMPLETION_ROUTINE*|__out HANDLE*
+int|WPUCompleteOverlappedRequest|SOCKET|__inout WSAOVERLAPPED*|DWORD|DWORD|__out int*
+SOCKET|WSAAccept|SOCKET|__out sockaddr*|__inout int*|CONDITIONPROC*|DWORD_PTR
+int|WSAAddressToStringA|SOCKADDR*|DWORD|WSAPROTOCOL_INFOA*|__out char*|__inout DWORD*
+int|WSAAddressToStringW|SOCKADDR*|DWORD|WSAPROTOCOL_INFOW*|__out wchar*|__inout DWORD*
+int|WSAAdvertiseProvider|GUID*|NSPV2_ROUTINE*
+bool|WSACloseEvent|WSAEVENT
+int|WSAConnect|SOCKET|sockaddr*|int|WSABUF*|__out WSABUF*|QOS*|QOS*
+bool|WSAConnectByList|SOCKET|SOCKET_ADDRESS_LIST*|__inout DWORD*|__out SOCKADDR*|__inout DWORD*|__out SOCKADDR*|timeval*|WSAOVERLAPPED*
+bool|WSAConnectByNameA|SOCKET|char*|char*|__inout DWORD*|__out SOCKADDR*|__inout DWORD*|__out SOCKADDR*|timeval*|WSAOVERLAPPED*
+bool|WSAConnectByNameW|SOCKET|wchar*|wchar*|__inout DWORD*|__out SOCKADDR*|__inout DWORD*|__out SOCKADDR*|timeval*|WSAOVERLAPPED*
+WSAEVENT|WSACreateEvent|void
+int|WSADuplicateSocketA|SOCKET|DWORD|__out WSAPROTOCOL_INFOA*
+int|WSADuplicateSocketW|SOCKET|DWORD|__out WSAPROTOCOL_INFOW*
+int|WSAEnumNameSpaceProvidersA|__inout DWORD*|__out WSANAMESPACE_INFOA*
+int|WSAEnumNameSpaceProvidersExA|__inout DWORD*|__out WSANAMESPACE_INFOEXA*
+int|WSAEnumNameSpaceProvidersExW|__inout DWORD*|__out WSANAMESPACE_INFOEXW*
+int|WSAEnumNameSpaceProvidersW|__inout DWORD*|__out WSANAMESPACE_INFOW*
+int|WSAEnumNetworkEvents|SOCKET|WSAEVENT|__out WSANETWORKEVENTS*
+int|WSAEnumProtocolsA|int*|__out WSAPROTOCOL_INFOA*|__inout DWORD*
+int|WSAEnumProtocolsW|int*|__out WSAPROTOCOL_INFOW*|__inout DWORD*
+int|WSAEventSelect|SOCKET|WSAEVENT|long
+bool|WSAGetOverlappedResult|SOCKET|WSAOVERLAPPED*|__out DWORD*|bool|__out DWORD*
+bool|WSAGetQOSByName|SOCKET|WSABUF*|__out QOS*
+int|WSAGetServiceClassInfoA|GUID*|GUID*|__inout DWORD*|__out WSASERVICECLASSINFOA*
+int|WSAGetServiceClassInfoW|GUID*|GUID*|__inout DWORD*|__out WSASERVICECLASSINFOW*
+int|WSAGetServiceClassNameByClassIdA|GUID*|__out char*|__inout DWORD*
+int|WSAGetServiceClassNameByClassIdW|GUID*|__out wchar*|__inout DWORD*
+int|WSAHtonl|SOCKET|ulong|__out ulong*
+int|WSAHtons|SOCKET|ushort|__out ushort*
+int|WSAInstallServiceClassA|WSASERVICECLASSINFOA*
+int|WSAInstallServiceClassW|WSASERVICECLASSINFOW*
+int|WSAIoctl|SOCKET|DWORD|VOID*|DWORD|__out VOID*|DWORD|__out DWORD*|__inout WSAOVERLAPPED*|WSAOVERLAPPED_COMPLETION_ROUTINE*
+SOCKET|WSAJoinLeaf|SOCKET|sockaddr*|int|WSABUF*|__out WSABUF*|QOS*|QOS*|DWORD
+int|WSALookupServiceBeginA|WSAQUERYSETA*|DWORD|__out HANDLE*
+int|WSALookupServiceBeginW|WSAQUERYSETW*|DWORD|__out HANDLE*
+int|WSALookupServiceEnd|HANDLE
+int|WSALookupServiceNextA|HANDLE|DWORD|__inout DWORD*|__out WSAQUERYSETA*
+int|WSALookupServiceNextW|HANDLE|DWORD|__inout DWORD*|__out WSAQUERYSETW*
+int|WSANSPIoctl|HANDLE|DWORD|VOID*|DWORD|__out VOID*|DWORD|__out DWORD*|WSACOMPLETION*
+int|WSANtohl|SOCKET|ulong|__out ulong*
+int|WSANtohs|SOCKET|ushort|__out ushort*
+int|WSAPoll|__inout WSAPOLLFD*|ulong|int
+int|WSAProviderCompleteAsyncCall|HANDLE|int
+int|WSAProviderConfigChange|HANDLE*|__inout WSAOVERLAPPED*|WSAOVERLAPPED_COMPLETION_ROUTINE*
+int|WSARecv|SOCKET|__out WSABUF*|DWORD|__out DWORD*|__inout DWORD*|__inout WSAOVERLAPPED*|WSAOVERLAPPED_COMPLETION_ROUTINE*
+int|WSARecvDisconnect|SOCKET|__out WSABUF*
+int|WSARecvFrom|SOCKET|__out WSABUF*|DWORD|__out DWORD*|__inout DWORD*|__out sockaddr*|__inout int*|__inout WSAOVERLAPPED*|WSAOVERLAPPED_COMPLETION_ROUTINE*
+int|WSARemoveServiceClass|GUID*
+bool|WSAResetEvent|WSAEVENT
+int|WSASend|SOCKET|WSABUF*|DWORD|__out DWORD*|DWORD|__inout WSAOVERLAPPED*|WSAOVERLAPPED_COMPLETION_ROUTINE*
+int|WSASendDisconnect|SOCKET|WSABUF*
+int|WSASendMsg|SOCKET|WSAMSG*|DWORD|__out DWORD*|__inout WSAOVERLAPPED*|WSAOVERLAPPED_COMPLETION_ROUTINE*
+int|WSASendTo|SOCKET|WSABUF*|DWORD|__out DWORD*|DWORD|sockaddr*|int|__inout WSAOVERLAPPED*|WSAOVERLAPPED_COMPLETION_ROUTINE*
+bool|WSASetEvent|WSAEVENT
+int|WSASetServiceA|WSAQUERYSETA*|WSAESETSERVICEOP|DWORD
+int|WSASetServiceW|WSAQUERYSETW*|WSAESETSERVICEOP|DWORD
+SOCKET|WSASocketA|int|int|int|WSAPROTOCOL_INFOA*|GROUP|DWORD
+SOCKET|WSASocketW|int|int|int|WSAPROTOCOL_INFOW*|GROUP|DWORD
+int|WSAStringToAddressA|char*|int|WSAPROTOCOL_INFOA*|__out SOCKADDR*|__inout int*
+int|WSAStringToAddressW|wchar*|int|WSAPROTOCOL_INFOW*|__out SOCKADDR*|__inout int*
+int|WSAUnadvertiseProvider|GUID*
+DWORD|WSAWaitForMultipleEvents|DWORD|WSAEVENT*|bool|DWORD|bool
+int|WSCDeinstallProvider|GUID*|__out int*
+int|WSCEnableNSProvider|GUID*|bool
+int|WSCEnumProtocols|int*|__out WSAPROTOCOL_INFOW*|__inout DWORD*|__out int*
+int|WSCGetApplicationCategory|wchar*|DWORD|wchar*|DWORD|__out DWORD*|__out int*
+int|WSCGetProviderInfo|GUID*|WSC_PROVIDER_INFO_TYPE|__out BYTE*|__inout size_t*|DWORD|__out int*
+int|WSCGetProviderPath|GUID*|__out wchar*|__inout int*|__out int*
+int|WSCInstallNameSpace|wchar*|wchar*|DWORD|DWORD|GUID*
+int|WSCInstallNameSpaceEx|wchar*|wchar*|DWORD|DWORD|GUID*|BLOB*
+int|WSCInstallProvider|GUID*|wchar*|WSAPROTOCOL_INFOW*|DWORD|__out int*
+int|WSCInstallProviderAndChains|GUID*|wchar*|wchar*|wchar*|DWORD|__inout WSAPROTOCOL_INFOW*|DWORD|__out DWORD*|__out int*
+int|WSCSetApplicationCategory|wchar*|DWORD|wchar*|DWORD|DWORD|__out DWORD*|__out int*
+int|WSCSetProviderInfo|GUID*|WSC_PROVIDER_INFO_TYPE|BYTE*|size_t|DWORD|__out int*
+int|WSCUnInstallNameSpace|GUID*
+int|WSCUpdateProvider|GUID*|wchar*|WSAPROTOCOL_INFOW*|DWORD|__out int*
+int|WSCWriteNameSpaceOrder|GUID*|DWORD
+int|WSCWriteProviderOrder|DWORD*|DWORD
+VOID|freeaddrinfo|ADDRINFOA*
+int|getaddrinfo|char*|char*|ADDRINFOA*|__out ADDRINFOA**
+int|getnameinfo|SOCKADDR*|socklen_t|__out char*|DWORD|__out char*|DWORD|int
+char*|inet_ntop|int|VOID*|__out char*|size_t
+int|inet_pton|int|char*|__out VOID*
+
+# A group of exported functions from oleaut32.dll
+BSTR|SysAllocString|OLECHAR*
+int|SysReAllocString|BSTR*|OLECHAR*
+BSTR|SysAllocStringLen|OLECHAR*|uint
+int|SysReAllocStringLen|BSTR*|OLECHAR*|int
+void|SysFreeString|BSTR
+uint|SysStringLen|BSTR
+void|VariantInit|__out VARIANTARG*
+HRESULT|VariantClear|__inout VARIANTARG*
+HRESULT|VariantCopy|__out VARIANTARG*|VARIANTARG*
+HRESULT|VariantCopyInd|__out VARIANT*|VARIANTARG*
+HRESULT|VariantChangeType|__out VARIANTARG*|VARIANTARG*|USHORT|VARTYPE
+int|VariantTimeToDosDateTime|double|__out USHORT*|__out USHORT*
+int|DosDateTimeToVariantTime|USHORT|USHORT|__out double*
+SAFEARRAY*|SafeArrayCreate|VARTYPE|uint|SAFEARRAYBOUND*
+HRESULT|SafeArrayDestroy|SAFEARRAY*
+uint|SafeArrayGetDim|SAFEARRAY*
+uint|SafeArrayGetElemsize|SAFEARRAY*
+HRESULT|SafeArrayGetUBound|SAFEARRAY*|uint|__out long*
+HRESULT|SafeArrayGetLBound|SAFEARRAY*|uint|__out long*
+HRESULT|SafeArrayLock|SAFEARRAY*
+HRESULT|SafeArrayUnlock|SAFEARRAY*
+HRESULT|SafeArrayAccessData|SAFEARRAY*|__out HUGEP**
+HRESULT|SafeArrayUnaccessData|SAFEARRAY*
+HRESULT|SafeArrayGetElement|SAFEARRAY*|long*|__out void*
+HRESULT|SafeArrayPutElement|SAFEARRAY*|long*|void*
+HRESULT|SafeArrayCopy|SAFEARRAY*|__out SAFEARRAY**
+HRESULT|DispGetParam|DISPPARAMS*|uint|VARTYPE|__out VARIANT*|__out uint*
+HRESULT|DispGetIDsOfNames|ITypeInfo*|OLECHAR**|uint|__out DISPID*
+HRESULT|DispInvoke|void*|ITypeInfo*|DISPID|WORD|DISPPARAMS*|VARIANT*|EXCEPINFO*|uint*
+HRESULT|CreateDispTypeInfo|INTERFACEDATA*|LCID|ITypeInfo**
+HRESULT|CreateStdDispatch|IUnknown*|void*|ITypeInfo*|IUnknown**
+HRESULT|RegisterActiveObject|IUnknown*|REFCLSID|DWORD|DWORD*
+HRESULT|RevokeActiveObject|DWORD|void*
+HRESULT|GetActiveObject|REFCLSID|void*|IUnknown**
+HRESULT|SafeArrayAllocDescriptor|uint|__out SAFEARRAY**
+HRESULT|SafeArrayAllocData|SAFEARRAY*
+HRESULT|SafeArrayDestroyDescriptor|SAFEARRAY*
+HRESULT|SafeArrayDestroyData|SAFEARRAY*
+HRESULT|SafeArrayRedim|__inout SAFEARRAY*|SAFEARRAYBOUND*
+HRESULT|SafeArrayAllocDescriptorEx|VARTYPE|uint|__out SAFEARRAY**
+SAFEARRAY*|SafeArrayCreateEx|VARTYPE|uint|SAFEARRAYBOUND*|VOID*
+SAFEARRAY*|SafeArrayCreateVectorEx|VARTYPE|long|ulong|VOID*
+HRESULT|SafeArraySetRecordInfo|SAFEARRAY*|IRecordInfo*
+HRESULT|SafeArrayGetRecordInfo|SAFEARRAY*|IRecordInfo**
+HRESULT|VarParseNumFromStr|wchar*|LCID|ulong|__out NUMPARSE*|__out BYTE*
+HRESULT|VarNumFromParseNum|NUMPARSE*|BYTE*|ulong|__out VARIANT*
+HRESULT|VarI2FromUI1|BYTE|__out SHORT*
+HRESULT|VarI2FromI4|long|__out SHORT*
+HRESULT|VarI2FromR4|FLOAT|__out SHORT*
+HRESULT|VarI2FromR8|double|__out SHORT*
+HRESULT|VarI2FromCy|CY|SHORT*
+HRESULT|VarI2FromDate|DATE|__out SHORT*
+HRESULT|VarI2FromStr|wchar*|LCID|ulong|__out SHORT*
+HRESULT|VarI2FromDisp|IDispatch*|LCID|__out SHORT*
+HRESULT|VarI2FromBool|VARIANT_BOOL|__out SHORT*
+HRESULT|SafeArraySetIID|SAFEARRAY*|REFGUID
+HRESULT|VarI4FromUI1|BYTE|__out long*
+HRESULT|VarI4FromI2|SHORT|__out long*
+HRESULT|VarI4FromR4|FLOAT|__out long*
+HRESULT|VarI4FromR8|double|__out long*
+HRESULT|VarI4FromCy|CY|__out long*
+HRESULT|VarI4FromDate|DATE|__out long*
+HRESULT|VarI4FromStr|wchar*|LCID|ulong|__out long*
+HRESULT|VarI4FromDisp|IDispatch*|LCID|__out long*
+HRESULT|VarI4FromBool|VARIANT_BOOL|__out long*
+HRESULT|SafeArrayGetIID|SAFEARRAY*|__out GUID*
+HRESULT|VarR4FromUI1|BYTE|__out FLOAT*
+HRESULT|VarR4FromI2|SHORT|__out FLOAT*
+HRESULT|VarR4FromI4|long|__out FLOAT*
+HRESULT|VarR4FromR8|double|__out FLOAT*
+HRESULT|VarR4FromCy|CY|FLOAT*
+HRESULT|VarR4FromDate|DATE|__out FLOAT*
+HRESULT|VarR4FromStr|wchar*|LCID|ulong|__out FLOAT*
+HRESULT|VarR4FromDisp|IDispatch*|LCID|__out FLOAT*
+HRESULT|VarR4FromBool|VARIANT_BOOL|__out FLOAT*
+HRESULT|SafeArrayGetVartype|SAFEARRAY*|__out VARTYPE*
+HRESULT|VarR8FromUI1|BYTE|__out double*
+HRESULT|VarR8FromI2|SHORT|__out double*
+HRESULT|VarR8FromI4|long|__out double*
+HRESULT|VarR8FromR4|FLOAT|__out double*
+HRESULT|VarR8FromCy|CY|double*
+HRESULT|VarR8FromDate|DATE|__out double*
+HRESULT|VarR8FromStr|wchar*|LCID|ulong|__out double*
+HRESULT|VarR8FromDisp|IDispatch*|LCID|__out double*
+HRESULT|VarR8FromBool|VARIANT_BOOL|__out double*
+HRESULT|VarFormat|VARIANT*|wchar*|int|int|ulong|__out BSTR*
+HRESULT|VarDateFromUI1|BYTE|__out DATE*
+HRESULT|VarDateFromI2|SHORT|__out DATE*
+HRESULT|VarDateFromI4|long|__out DATE*
+HRESULT|VarDateFromR4|FLOAT|__out DATE*
+HRESULT|VarDateFromR8|double|__out DATE*
+HRESULT|VarDateFromCy|CY|__out DATE*
+HRESULT|VarDateFromStr|wchar*|LCID|ulong|__out DATE*
+HRESULT|VarDateFromDisp|IDispatch*|LCID|__out DATE*
+HRESULT|VarDateFromBool|VARIANT_BOOL|__out DATE*
+HRESULT|VarFormatDateTime|VARIANT*|int|ulong|__out BSTR*
+HRESULT|VarCyFromUI1|BYTE|__out CY*
+HRESULT|VarCyFromI2|SHORT|__out CY*
+HRESULT|VarCyFromI4|long|__out CY*
+HRESULT|VarCyFromR4|FLOAT|__out CY*
+HRESULT|VarCyFromR8|double|__out CY*
+HRESULT|VarCyFromDate|DATE|__out CY*
+HRESULT|VarCyFromStr|wchar*|LCID|ulong|__out CY*
+HRESULT|VarCyFromDisp|IDispatch*|LCID|__out CY*
+HRESULT|VarCyFromBool|VARIANT_BOOL|__out CY*
+HRESULT|VarFormatNumber|VARIANT*|int|int|int|int|ulong|__out BSTR*
+HRESULT|VarBstrFromUI1|BYTE|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromI2|SHORT|LCID|ulong|BSTR*
+HRESULT|VarBstrFromI4|long|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromR4|FLOAT|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromR8|double|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromCy|CY|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromDate|DATE|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromDisp|IDispatch*|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromBool|VARIANT_BOOL|LCID|ulong|__out BSTR*
+HRESULT|VarFormatPercent|VARIANT*|int|int|int|int|ulong|__out BSTR*
+HRESULT|VarBoolFromUI1|BYTE|__out VARIANT_BOOL*
+HRESULT|VarBoolFromI2|SHORT|__out VARIANT_BOOL*
+HRESULT|VarBoolFromI4|long|__out VARIANT_BOOL*
+HRESULT|VarBoolFromR4|FLOAT|__out VARIANT_BOOL*
+HRESULT|VarBoolFromR8|double|__out VARIANT_BOOL*
+HRESULT|VarBoolFromDate|DATE|__out VARIANT_BOOL*
+HRESULT|VarBoolFromCy|CY|__out VARIANT_BOOL*
+HRESULT|VarBoolFromStr|wchar*|LCID|ulong|__out VARIANT_BOOL*
+HRESULT|VarBoolFromDisp|IDispatch*|LCID|__out VARIANT_BOOL*
+HRESULT|VarFormatCurrency|VARIANT*|int|int|int|int|ulong|__out BSTR*
+HRESULT|VarWeekdayName|int|int|int|ulong|__out BSTR*
+HRESULT|VarMonthName|int|int|ulong|__out BSTR*
+HRESULT|VarUI1FromI2|SHORT|__out BYTE*
+HRESULT|VarUI1FromI4|long|__out BYTE*
+HRESULT|VarUI1FromR4|FLOAT|BYTE*
+HRESULT|VarUI1FromR8|double|__out BYTE*
+HRESULT|VarUI1FromCy|CY|__out BYTE*
+HRESULT|VarUI1FromDate|DATE|__out BYTE*
+HRESULT|VarUI1FromStr|wchar*|LCID|ulong|__out BYTE*
+HRESULT|VarUI1FromDisp|IDispatch*|LCID|__out BYTE*
+HRESULT|VarUI1FromBool|VARIANT_BOOL|__out BYTE*
+HRESULT|VarFormatFromTokens|VARIANT*|wchar*|BYTE*|ulong|__out BSTR*|LCID
+HRESULT|VarTokenizeFormatString|wchar*|__inout BYTE*|int|int|int|LCID|int*
+HRESULT|VarAdd|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarAnd|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarDiv|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|DispCallFunc|void*|ULONG_PTR|CALLCONV|VARTYPE|uint|VARTYPE*|VARIANTARG**|VARIANT*
+HRESULT|VariantChangeTypeEx|__out VARIANTARG*|VARIANTARG*|LCID|USHORT|VARTYPE
+HRESULT|SafeArrayPtrOfIndex|SAFEARRAY*|long*|__out void**
+uint|SysStringByteLen|BSTR
+BSTR|SysAllocStringByteLen|char*|uint
+HRESULT|VarEqv|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarIdiv|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarImp|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarMod|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarMul|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarOr|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarPow|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarSub|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|CreateTypeLib|SYSKIND|wchar*|ICreateTypeLib**
+HRESULT|LoadTypeLib|wchar*|ITypeLib**
+HRESULT|LoadRegTypeLib|REFGUID|WORD|WORD|LCID|ITypeLib**
+HRESULT|RegisterTypeLib|ITypeLib*|wchar*|wchar*
+HRESULT|QueryPathOfRegTypeLib|REFGUID|USHORT|USHORT|LCID|__out BSTR*
+ulong|LHashValOfNameSys|SYSKIND|LCID|OLECHAR*
+ulong|LHashValOfNameSysA|SYSKIND|LCID|char*
+HRESULT|VarXor|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarAbs|VARIANT*|__out VARIANT*
+HRESULT|VarFix|VARIANT*|__out VARIANT*
+ulong|OaBuildVersion|void
+void|ClearCustData|CUSTDATA*
+HRESULT|VarInt|VARIANT*|__out VARIANT*
+HRESULT|VarNeg|VARIANT*|__out VARIANT*
+HRESULT|VarNot|VARIANT*|__out VARIANT*
+HRESULT|VarRound|VARIANT*|int|__out VARIANT*
+HRESULT|VarCmp|VARIANT*|VARIANT*|LCID|ulong
+HRESULT|VarDecAdd|DECIMAL*|DECIMAL*|__out DECIMAL*
+HRESULT|VarDecDiv|DECIMAL*|DECIMAL*|__out DECIMAL*
+HRESULT|VarDecMul|DECIMAL*|DECIMAL*|__out DECIMAL*
+HRESULT|CreateTypeLib2|SYSKIND|wchar*|ICreateTypeLib2**
+HRESULT|VarDecSub|DECIMAL*|DECIMAL*|__out DECIMAL*
+HRESULT|VarDecAbs|DECIMAL*|__out DECIMAL*
+HRESULT|LoadTypeLibEx|wchar*|REGKIND|ITypeLib**
+int|SystemTimeToVariantTime|SYSTEMTIME*|__out double*
+int|VariantTimeToSystemTime|double|__out SYSTEMTIME*
+HRESULT|UnRegisterTypeLib|REFGUID|WORD|WORD|LCID|SYSKIND
+HRESULT|VarDecFix|DECIMAL*|__out DECIMAL*
+HRESULT|VarDecInt|DECIMAL*|__out DECIMAL*
+HRESULT|VarDecNeg|DECIMAL*|__out DECIMAL*
+HRESULT|VarDecFromUI1|BYTE|__out DECIMAL*
+HRESULT|VarDecFromI2|SHORT|__out DECIMAL*
+HRESULT|VarDecFromI4|long|__out DECIMAL*
+HRESULT|VarDecFromR4|FLOAT|__out DECIMAL*
+HRESULT|VarDecFromR8|double|__out DECIMAL*
+HRESULT|VarDecFromDate|DATE|__out DECIMAL*
+HRESULT|VarDecFromCy|CY|__out DECIMAL*
+HRESULT|VarDecFromStr|wchar*|LCID|ulong|__out DECIMAL*
+HRESULT|VarDecFromDisp|IDispatch*|LCID|__out DECIMAL*
+HRESULT|VarDecFromBool|VARIANT_BOOL|__out DECIMAL*
+HRESULT|GetErrorInfo|ulong|IErrorInfo**
+HRESULT|SetErrorInfo|ulong|IErrorInfo**
+HRESULT|CreateErrorInfo|ICreateErrorInfo**
+HRESULT|VarDecRound|DECIMAL*|int|__out DECIMAL*
+HRESULT|VarDecCmp|DECIMAL*|DECIMAL*
+HRESULT|VarI2FromI1|char|__out SHORT*
+HRESULT|VarI2FromUI2|USHORT|__out SHORT*
+HRESULT|VarI2FromUI4|ulong|__out SHORT*
+HRESULT|VarI2FromDec|DECIMAL*|__out SHORT*
+HRESULT|VarI4FromI1|char|__out long*
+HRESULT|VarI4FromUI2|USHORT|__out long*
+HRESULT|VarI4FromUI4|ulong|__out long*
+HRESULT|VarI4FromDec|DECIMAL*|__out long*
+HRESULT|VarR4FromI1|char|__out FLOAT*
+HRESULT|VarR4FromUI2|USHORT|__out FLOAT*
+HRESULT|VarR4FromUI4|ulong|__out FLOAT*
+HRESULT|VarR4FromDec|DECIMAL*|__out FLOAT*
+HRESULT|VarR8FromI1|char|double*
+HRESULT|VarR8FromUI2|USHORT|__out double*
+HRESULT|VarR8FromUI4|ulong|__out double*
+HRESULT|VarR8FromDec|DECIMAL*|__out double*
+HRESULT|VarDateFromI1|char|__out DATE*
+HRESULT|VarDateFromUI2|USHORT|__out DATE*
+HRESULT|VarDateFromUI4|ulong|__out DATE*
+HRESULT|VarDateFromDec|DECIMAL*|__out DATE*
+HRESULT|VarCyFromI1|char|__out CY*
+HRESULT|VarCyFromUI2|USHORT|__out CY*
+HRESULT|VarCyFromUI4|ulong|__out CY*
+HRESULT|VarCyFromDec|DECIMAL*|__out CY*
+HRESULT|VarBstrFromI1|char|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromUI2|USHORT|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromUI4|ulong|LCID|ulong|__out BSTR*
+HRESULT|VarBstrFromDec|DECIMAL*|LCID|ulong|__out BSTR*
+HRESULT|VarBoolFromI1|char|__out VARIANT_BOOL*
+HRESULT|VarBoolFromUI2|USHORT|__out VARIANT_BOOL*
+HRESULT|VarBoolFromUI4|ulong|__out VARIANT_BOOL*
+HRESULT|VarBoolFromDec|DECIMAL*|__out VARIANT_BOOL*
+HRESULT|VarUI1FromI1|char|__out BYTE*
+HRESULT|VarUI1FromUI2|USHORT|__out BYTE*
+HRESULT|VarUI1FromUI4|ulong|__out BYTE*
+HRESULT|VarUI1FromDec|DECIMAL*|__out BYTE*
+HRESULT|VarDecFromI1|char|__out DECIMAL*
+HRESULT|VarDecFromUI2|USHORT|__out DECIMAL*
+HRESULT|VarDecFromUI4|ulong|__out DECIMAL*
+HRESULT|VarI1FromUI1|BYTE|__out char*
+HRESULT|VarI1FromI2|SHORT|__out char*
+HRESULT|VarI1FromI4|long|__out char*
+HRESULT|VarI1FromR4|FLOAT|__out char*
+HRESULT|VarI1FromR8|double|__out char*
+HRESULT|VarI1FromDate|DATE|__out char*
+HRESULT|VarI1FromCy|CY|__out char*
+HRESULT|VarI1FromStr|wchar*|LCID|ulong|__out char*
+HRESULT|VarI1FromDisp|IDispatch*|LCID|__out char*
+HRESULT|VarI1FromBool|VARIANT_BOOL|__out char*
+HRESULT|VarI1FromUI2|USHORT|__out char*
+HRESULT|VarI1FromUI4|ulong|__out char*
+HRESULT|VarI1FromDec|DECIMAL*|__out char*
+HRESULT|VarUI2FromUI1|BYTE|__out USHORT*
+HRESULT|VarUI2FromI2|SHORT|__out USHORT*
+HRESULT|VarUI2FromI4|long|__out USHORT*
+HRESULT|VarUI2FromR4|FLOAT|__out USHORT*
+HRESULT|VarUI2FromR8|double|USHORT*
+HRESULT|VarUI2FromDate|DATE|__out USHORT*
+HRESULT|VarUI2FromCy|CY|__out USHORT*
+HRESULT|VarUI2FromStr|wchar*|LCID|ulong|__out USHORT*
+HRESULT|VarUI2FromDisp|IDispatch*|LCID|__out USHORT*
+HRESULT|VarUI2FromBool|VARIANT_BOOL|__out USHORT*
+HRESULT|VarUI2FromI1|char|__out USHORT*
+HRESULT|VarUI2FromUI4|ulong|__out USHORT*
+HRESULT|VarUI2FromDec|DECIMAL*|__out USHORT*
+HRESULT|VarUI4FromUI1|BYTE|__out ulong*
+HRESULT|VarUI4FromI2|SHORT|__out ulong*
+HRESULT|VarUI4FromI4|long|__out ulong*
+HRESULT|VarUI4FromR4|FLOAT|__out ulong*
+HRESULT|VarUI4FromR8|double|__out ulong*
+HRESULT|VarUI4FromDate|DATE|__out ulong*
+HRESULT|VarUI4FromCy|CY|__out ulong*
+HRESULT|VarUI4FromStr|wchar*|LCID|ulong|__out ulong*
+HRESULT|VarUI4FromDisp|IDispatch*|LCID|__out ulong*
+HRESULT|VarUI4FromBool|VARIANT_BOOL|__out ulong*
+HRESULT|VarUI4FromI1|char|__out ulong*
+HRESULT|VarUI4FromUI2|USHORT|__out ulong*
+HRESULT|VarUI4FromDec|DECIMAL*|__out ulong*
+ulong|BSTR_UserSize|long*|long|BSTR*
+char*|BSTR_UserMarshal|long*|__inout char*|BSTR*
+char*|BSTR_UserUnmarshal|long*|char*|__out BSTR*
+void|BSTR_UserFree|long*|BSTR*
+ulong|VARIANT_UserSize|long*|long|VARIANT*
+char*|VARIANT_UserMarshal|long*|__inout char*|VARIANT*
+char*|VARIANT_UserUnmarshal|long*|char*|__out VARIANT*
+void|VARIANT_UserFree|long*|VARIANT*
+ulong|LPSAFEARRAY_UserSize|long*|long|SAFEARRAY**
+char*|LPSAFEARRAY_UserMarshal|long*|__inout char*|SAFEARRAY**
+char*|LPSAFEARRAY_UserUnmarshal|long*|char*|__out SAFEARRAY**
+void|LPSAFEARRAY_UserFree|long*|SAFEARRAY**
+HRESULT|VarDecCmpR8|DECIMAL*|double
+HRESULT|VarCyAdd|CY|CY|__out LPCY
+HRESULT|VarCyMul|CY|CY|__out LPCY
+HRESULT|VarCyMulI4|CY|long|__out LPCY
+HRESULT|VarCySub|CY|CY|__out LPCY
+HRESULT|VarCyAbs|CY|__out LPCY
+HRESULT|VarCyFix|CY|__out LPCY
+HRESULT|VarCyInt|CY|__out LPCY
+HRESULT|VarCyNeg|CY|__out LPCY
+HRESULT|VarCyRound|CY|int|__out LPCY
+HRESULT|VarCyCmp|CY|CY
+HRESULT|VarCyCmpR8|CY|double
+HRESULT|VarBstrCat|BSTR|BSTR|__out BSTR*
+HRESULT|VarR8Pow|double|double|__out double*
+HRESULT|VarR4CmpR8|float|double
+HRESULT|VarR8Round|double|int|__out double*
+HRESULT|VarCat|VARIANT*|VARIANT*|__out VARIANT*
+HRESULT|VarDateFromUdateEx|UDATE*|LCID|ulong|__out DATE*
+HRESULT|GetRecordInfoFromGuids|REFGUID|ulong|ulong|LCID|REFGUID|IRecordInfo**
+HRESULT|GetRecordInfoFromTypeInfo|ITypeInfo*|IRecordInfo**
+HRESULT|VarCyMulI8|CY|LONG64|__out LPCY
+HRESULT|VarDateFromUdate|UDATE*|ulong|__out DATE*
+HRESULT|VarUdateFromDate|DATE|ulong|__out UDATE*
+HRESULT|GetAltMonthNames|LCID|__out wchar***
+HRESULT|VarI8FromUI1|BYTE|__out LONG64*
+HRESULT|VarI8FromI2|SHORT|__out LONG64*
+HRESULT|VarI8FromR4|FLOAT|__out LONG64*
+HRESULT|VarI8FromR8|double|__out LONG64*
+HRESULT|VarI8FromCy|CY|__out LONG64*
+HRESULT|VarI8FromDate|DATE|__out LONG64*
+HRESULT|VarI8FromStr|wchar*|LCID|long|__out LONG64*
+HRESULT|VarI8FromDisp|IDispatch*|LCID|__out LONG64*
+HRESULT|VarI8FromBool|VARIANT_BOOL|__out LONG64*
+HRESULT|VarI8FromI1|char|__out LONG64*
+HRESULT|VarI8FromUI2|USHORT|__out LONG64*
+HRESULT|VarI8FromUI4|ulong|__out LONG64*
+HRESULT|VarI8FromDec|DECIMAL*|__out LONG64*
+HRESULT|VarI2FromI8|LONG64|__out SHORT*
+HRESULT|VarI2FromUI8|ULONG64|__out SHORT*
+HRESULT|VarI4FromI8|LONG64|__out long*
+HRESULT|VarI4FromUI8|ULONG64|__out long*
+HRESULT|VarR4FromI8|LONG64|__out FLOAT*
+HRESULT|VarR4FromUI8|ULONG64|__out FLOAT*
+HRESULT|VarR8FromI8|LONG64|__out double*
+HRESULT|VarR8FromUI8|ULONG64|__out double*
+HRESULT|VarDateFromI8|LONG64|__out DATE*
+HRESULT|VarDateFromUI8|ULONG64|__out DATE*
+HRESULT|VarCyFromI8|LONG64|__out CY*
+HRESULT|VarCyFromUI8|ULONG64|__out CY*
+HRESULT|VarBstrFromI8|LONG64|LCID|long|__out BSTR*
+HRESULT|VarBstrFromUI8|ULONG64|LCID|long|__out BSTR*
+HRESULT|VarBoolFromI8|LONG64|__out VARIANT_BOOL*
+HRESULT|VarBoolFromUI8|ULONG64|__out VARIANT_BOOL*
+HRESULT|VarUI1FromI8|LONG64|__out BYTE*
+HRESULT|VarUI1FromUI8|ULONG64|__out BYTE*
+HRESULT|VarDecFromI8|LONG64|__out DECIMAL*
+HRESULT|VarDecFromUI8|ULONG64|__out DECIMAL*
+HRESULT|VarI1FromI8|LONG64|__out char*
+HRESULT|VarI1FromUI8|ULONG64|__out char*
+HRESULT|VarUI2FromI8|LONG64|__out USHORT*
+HRESULT|VarUI2FromUI8|ULONG64|__out USHORT*
+HRESULT|OleLoadPictureEx|LPSTREAM|long|bool|REFIID|DWORD|DWORD|DWORD|VOID**
+HRESULT|OleLoadPictureFileEx|VARIANT|DWORD|DWORD|DWORD|DISPATCH**
+SAFEARRAY*|SafeArrayCreateVector|VARTYPE|long|ulong
+HRESULT|SafeArrayCopyData|SAFEARRAY*|SAFEARRAY*
+HRESULT|VectorFromBstr|BSTR|__out SAFEARRAY**
+HRESULT|BstrFromVector|SAFEARRAY*|__out BSTR*
+HCURSOR|OleIconToCursor|HINSTANCE|HICON
+HRESULT|OleCreatePropertyFrameIndirect|OCPFIPARAMS*
+HRESULT|OleCreatePropertyFrame|HWND|uint|uint|wchar*|ulong|UNKNOWN**|ulong|CLSID*|LCID|DWORD|VOID*
+HRESULT|OleLoadPicture|LPSTREAM|long|bool|REFIID|VOID**
+HRESULT|OleCreatePictureIndirect|PICTDESC*|REFIID|bool|VOID**
+HRESULT|OleCreateFontIndirect|FONTDESC*|REFIID|VOID**
+HRESULT|OleTranslateColor|OLE_COLOR|HPALETTE|COLORREF*
+HRESULT|OleLoadPictureFile|VARIANT|DISPATCH**
+HRESULT|OleSavePictureFile|DISPATCH*|BSTR
+HRESULT|OleLoadPicturePath|wchar*|UNKNOWN*|DWORD|OLE_COLOR|REFIID|VOID**
+HRESULT|VarUI4FromI8|LONG64|__out ulong*
+HRESULT|VarUI4FromUI8|ULONG64|__out ulong*
+HRESULT|VarI8FromUI8|ULONG64|__out LONG64*
+HRESULT|VarUI8FromI8|LONG64|__out ULONG64*
+HRESULT|VarUI8FromUI1|BYTE|__out ULONG64*
+HRESULT|VarUI8FromI2|SHORT|__out ULONG64*
+HRESULT|VarUI8FromR4|FLOAT|__out ULONG64*
+HRESULT|VarUI8FromR8|double|__out ULONG64*
+HRESULT|VarUI8FromCy|CY|__out ULONG64*
+HRESULT|VarUI8FromDate|DATE|__out ULONG64*
+HRESULT|VarUI8FromStr|wchar*|LCID|long|__out ULONG64*
+HRESULT|VarUI8FromDisp|IDispatch*|LCID|__out ULONG64*
+HRESULT|VarUI8FromBool|VARIANT_BOOL|__out ULONG64*
+HRESULT|VarUI8FromI1|char|__out ULONG64*
+HRESULT|VarUI8FromUI2|USHORT|__out ULONG64*
+HRESULT|VarUI8FromUI4|ulong|__out ULONG64*
+HRESULT|VarUI8FromDec|DECIMAL*|__out ULONG64*
+HRESULT|RegisterTypeLibForUser|ITypeLib*|OLECHAR*|OLECHAR*
+HRESULT|UnRegisterTypeLibForUser|REFGUID|WORD|WORD|LCID|SYSKIND
+void|OaEnablePerUserTLibRegistration|void
+
+# A group of exported functions from ole32.dll
+void|HRGN_UserFree|long*|HRGN*
+uchar*|HRGN_UserMarshal|long*|__inout char*|HRGN*
+ulong|HRGN_UserSize|long*|long|HRGN*
+uchar*|HRGN_UserUnmarshal|long*|char*|__out HRGN*
+HRESULT|PropVariantChangeType|__out PROPVARIANT*|REFPROPVARIANT|PROPVAR_CHANGE_FLAGS|VARTYPE
+HRESULT|BindMoniker|MONIKER*|DWORD|REFIID|__out VOID**
+void|CLIPFORMAT_UserFree|long*|CLIPFORMAT*
+uchar*|CLIPFORMAT_UserMarshal|long*|__inout char*|CLIPFORMAT*
+ulong|CLIPFORMAT_UserSize|long*|long|CLIPFORMAT*
+uchar*|CLIPFORMAT_UserUnmarshal|long*|char*|__out CLIPFORMAT*
+HRESULT|CLSIDFromProgID|wchar*|__out CLSID*
+HRESULT|CLSIDFromProgIDEx|wchar*|__out CLSID*
+HRESULT|CLSIDFromString|wchar*|__out CLSID*
+ulong|CoAddRefServerProcess|void
+HRESULT|CoAllowSetForegroundWindow|IUnknown*|VOID*
+DWORD|CoBuildVersion|VOID
+HRESULT|CoCancelCall|DWORD|ulong
+HRESULT|CoCopyProxy|IUnknown*|__out IUnknown**
+HRESULT|CoCreateFreeThreadedMarshaler|UNKNOWN*|__out UNKNOWN**
+HRESULT|CoCreateGuid|__out GUID*
+HRESULT|CoCreateInstance|REFCLSID|UNKNOWN*|DWORD|REFIID|__out VOID**
+HRESULT|CoCreateInstanceEx|REFCLSID|IUnknown*|DWORD|COSERVERINFO*|DWORD|__inout MULTI_QI*
+HRESULT|CoDisableCallCancellation|VOID*
+HRESULT|CoDisconnectContext|DWORD
+HRESULT|CoDisconnectObject|UNKNOWN*|DWORD
+bool|CoDosDateTimeToFileTime|WORD|WORD|__out FILETIME*
+HRESULT|CoEnableCallCancellation|VOID*
+HRESULT|CoFileTimeNow|__out FILETIME*
+bool|CoFileTimeToDosDateTime|FILETIME*|__out WORD*|__out WORD*
+void|CoFreeAllLibraries|void
+void|CoFreeLibrary|HINSTANCE
+void|CoFreeUnusedLibraries|void
+void|CoFreeUnusedLibrariesEx|DWORD|DWORD
+HRESULT|CoGetApartmentType|__out APTTYPE*|__out APTTYPEQUALIFIER*
+HRESULT|CoGetCallContext|REFIID|__out void**
+HRESULT|CoGetCallerTID|__out DWORD*
+HRESULT|CoGetCancelObject|DWORD|REFIID|__out void**
+HRESULT|CoGetClassObject|REFCLSID|DWORD|VOID*|REFIID|__out VOID**
+HRESULT|CoGetContextToken|__out ULONG_PTR*
+HRESULT|CoGetCurrentLogicalThreadId|__out GUID*
+DWORD|CoGetCurrentProcess|void
+HRESULT|CoGetInstanceFromFile|COSERVERINFO*|CLSID*|IUnknown*|DWORD|DWORD|OLECHAR*|DWORD|__inout MULTI_QI*
+HRESULT|CoGetInstanceFromIStorage|COSERVERINFO*|CLSID*|IUnknown*|DWORD|IStorage*|DWORD|__inout MULTI_QI*
+HRESULT|CoGetInterceptor|REFIID*|IUnknown*|REFIID*|void**
+HRESULT|CoGetInterceptorFromTypeInfo|REFIID*|IUnknown*|ITypeInfo*|REFIID*|void**
+HRESULT|CoGetInterfaceAndReleaseStream|STREAM*|REFIID|__out VOID**
+HRESULT|CoGetMalloc|DWORD|__out MALLOC**
+HRESULT|CoGetMarshalSizeMax|__out ulong*|REFIID|UNKNOWN*|DWORD|VOID*|DWORD
+HRESULT|CoGetObject|wchar*|BIND_OPTS*|REFIID|__out void**
+HRESULT|CoGetObjectContext|REFIID|__out VOID**
+HRESULT|CoGetPSClsid|REFIID|__out CLSID*
+HRESULT|CoGetStandardMarshal|REFIID|UNKNOWN*|DWORD|VOID*|DWORD|__out MARSHAL**
+HRESULT|CoGetStdMarshalEx|UNKNOWN*|DWORD|__out UNKNOWN**
+HRESULT|CoGetSystemSecurityPermissions|COMSD|SECURITY_DESCRIPTOR**
+HRESULT|CoGetTreatAsClass|REFCLSID|__out CLSID*
+HRESULT|CoImpersonateClient|void
+HRESULT|CoInitialize|VOID*
+HRESULT|CoInitializeEx|VOID*|DWORD
+HRESULT|CoInitializeSecurity|SECURITY_DESCRIPTOR*|long|SOLE_AUTHENTICATION_SERVICE*|void*|DWORD|DWORD|void*|DWORD|void*
+HRESULT|CoInstall|IBindCtx*|DWORD|uCLSSPEC*|QUERYCONTEXT*|wchar*
+HRESULT|CoInvalidateRemoteMachineBindings|wchar*
+bool|CoIsHandlerConnected|UNKNOWN*
+bool|CoIsOle1Class|REFCLSID
+HINSTANCE|CoLoadLibrary|wchar*|bool
+HRESULT|CoLockObjectExternal|UNKNOWN*|bool|bool
+HRESULT|CoMarshalHresult|STREAM*|HRESULT
+HRESULT|CoMarshalInterThreadInterfaceInStream|REFIID|UNKNOWN*|__out STREAM**
+HRESULT|CoMarshalInterface|STREAM*|REFIID|UNKNOWN*|DWORD|VOID*|DWORD
+HRESULT|CoQueryAuthenticationServices|__out DWORD*|__out SOLE_AUTHENTICATION_SERVICE**
+HRESULT|CoQueryClientBlanket|__out DWORD*|__out DWORD*|__out OLECHAR**|__out DWORD*|__out DWORD*|__out RPC_AUTHZ_HANDLE*|__inout DWORD*
+HRESULT|CoQueryProxyBlanket|IUnknown*|__out DWORD*|__out DWORD*|__out OLECHAR**|__out DWORD*|__out DWORD*|__out RPC_AUTH_IDENTITY_HANDLE*|__out DWORD*
+HRESULT|CoRegisterChannelHook|REFGUID|IChannelHook*
+HRESULT|CoRegisterClassObject|REFCLSID|UNKNOWN*|DWORD|DWORD|__out DWORD*
+HRESULT|CoRegisterInitializeSpy|INITIALIZESPY*|__out ULARGE_INTEGER*
+HRESULT|CoRegisterMallocSpy|MALLOCSPY*
+HRESULT|CoRegisterMessageFilter|MESSAGEFILTER*|__out MESSAGEFILTER**
+HRESULT|CoRegisterPSClsid|REFIID|REFCLSID
+HRESULT|CoRegisterSurrogate|SURROGATE*
+HRESULT|CoReleaseMarshalData|STREAM*
+ulong|CoReleaseServerProcess|void
+HRESULT|CoResumeClassObjects|void
+HRESULT|CoRevertToSelf|void
+HRESULT|CoRevokeClassObject|DWORD
+HRESULT|CoRevokeInitializeSpy|ULARGE_INTEGER
+HRESULT|CoRevokeMallocSpy|void
+HRESULT|CoSetCancelObject|IUnknown*
+HRESULT|CoSetProxyBlanket|IUnknown*|DWORD|DWORD|OLECHAR*|DWORD|DWORD|RPC_AUTH_IDENTITY_HANDLE|DWORD
+HRESULT|CoSuspendClassObjects|void
+HRESULT|CoSwitchCallContext|IUnknown*|__out IUnknown**
+void*|CoTaskMemAlloc|size_t
+void|CoTaskMemFree|VOID*
+void*|CoTaskMemRealloc|VOID*|size_t
+HRESULT|CoTestCancel|void
+HRESULT|CoTreatAsClass|REFCLSID|REFCLSID
+void|CoUninitialize|void
+HRESULT|CoUnmarshalHresult|STREAM*|__out HRESULT*
+HRESULT|CoUnmarshalInterface|STREAM*|REFIID|__out VOID**
+HRESULT|CoWaitForMultipleHandles|DWORD|DWORD|ulong|HANDLE*|__out DWORD*
+HRESULT|CreateAntiMoniker|__out MONIKER**
+HRESULT|CreateBindCtx|DWORD|__out LPBC*
+HRESULT|CreateClassMoniker|REFCLSID|__out MONIKER**
+HRESULT|CreateDataAdviseHolder|__out DATAADVISEHOLDER**
+HRESULT|CreateDataCache|UNKNOWN*|REFCLSID|REFIID|__out VOID**
+HRESULT|CreateFileMoniker|wchar*|__out MONIKER**
+HRESULT|CreateGenericComposite|MONIKER*|MONIKER*|__out MONIKER**
+HRESULT|CreateILockBytesOnHGlobal|HGLOBAL|bool|LOCKBYTES**
+HRESULT|CreateItemMoniker|wchar*|wchar*|__out MONIKER**
+HRESULT|CreateObjrefMoniker|UNKNOWN*|__out MONIKER**
+HRESULT|CreateOleAdviseHolder|OLEADVISEHOLDER**
+HRESULT|CreatePointerMoniker|UNKNOWN*|__out MONIKER**
+HRESULT|CreateStdProgressIndicator|HWND|wchar*|IBindStatusCallback*|IBindStatusCallback**
+HRESULT|CreateStreamOnHGlobal|HGLOBAL|bool|STREAM**
+HRESULT|DcomChannelSetHResult|VOID*|ulong*|HRESULT
+HRESULT|DoDragDrop|DATAOBJECT*|DROPSOURCE*|DWORD|DWORD*
+HRESULT|FmtIdToPropStgName|FMTID*|__out wchar*
+HRESULT|FreePropVariantArray|ulong|__inout PROPVARIANT*
+HRESULT|GetClassFile|wchar*|__out CLSID*
+HRESULT|GetConvertStg|STORAGE*
+HRESULT|GetHGlobalFromILockBytes|LOCKBYTES*|HGLOBAL*
+HRESULT|GetHGlobalFromStream|STREAM*|HGLOBAL*
+HRESULT|GetRunningObjectTable|DWORD|__out RUNNINGOBJECTTABLE**
+void|HACCEL_UserFree|long*|HACCEL*
+uchar*|HACCEL_UserMarshal|long*|__inout char*|HACCEL*
+ulong|HACCEL_UserSize|long*|long|HACCEL*
+uchar*|HACCEL_UserUnmarshal|long*|char*|__out HACCEL*
+void|HBITMAP_UserFree|long*|HBITMAP*
+uchar*|HBITMAP_UserMarshal|long*|__inout char*|HBITMAP*
+ulong|HBITMAP_UserSize|long*|long|HBITMAP*
+uchar*|HBITMAP_UserUnmarshal|long*|char*|__out HBITMAP*
+void|HDC_UserFree|long*|HDC*
+uchar*|HDC_UserMarshal|long*|__inout char*|HDC*
+ulong|HDC_UserSize|long*|long|HDC*
+uchar*|HDC_UserUnmarshal|long*|char*|__out HDC*
+void|HGLOBAL_UserFree|long*|HGLOBAL*
+uchar*|HGLOBAL_UserMarshal|long*|__inout char*|HGLOBAL*
+ulong|HGLOBAL_UserSize|long*|long|HGLOBAL*
+uchar*|HGLOBAL_UserUnmarshal|long*|char*|__out HGLOBAL*
+void|HICON_UserFree|long*|HICON*
+uchar*|HICON_UserMarshal|long*|__inout char*|HICON*
+ulong|HICON_UserSize|long*|long|HICON*
+uchar*|HICON_UserUnmarshal|long*|char*|__out HICON*
+void|HMENU_UserFree|long*|HMENU*
+uchar*|HMENU_UserMarshal|long*|__inout char*|HMENU*
+ulong|HMENU_UserSize|long*|long|HMENU*
+uchar*|HMENU_UserUnmarshal|long*|char*|__out HMENU*
+void|HPALETTE_UserFree|long*|HPALETTE*
+uchar*|HPALETTE_UserMarshal|long*|__inout char*|HPALETTE*
+ulong|HPALETTE_UserSize|long*|long|HPALETTE*
+uchar*|HPALETTE_UserUnmarshal|long*|char*|__out HPALETTE*
+void|HWND_UserFree|long*|HWND*
+uchar*|HWND_UserMarshal|long*|__inout char*|HWND*
+ulong|HWND_UserSize|long*|long|HWND*
+uchar*|HWND_UserUnmarshal|long*|char*|__out HWND*
+HRESULT|IIDFromString|wchar*|__out IID*
+bool|IsAccelerator|HACCEL|int|MSG*|WORD*
+HRESULT|MkParseDisplayName|LPBC|wchar*|__out ulong*|__out MONIKER**
+HRESULT|MonikerCommonPrefixWith|MONIKER*|MONIKER*|__out MONIKER**
+HRESULT|MonikerRelativePathTo|MONIKER*|MONIKER*|__out MONIKER**|bool
+void|NdrProxyForwardingFunction10|void
+void|NdrProxyForwardingFunction11|void
+void|NdrProxyForwardingFunction12|void
+void|NdrProxyForwardingFunction13|void
+void|NdrProxyForwardingFunction14|void
+void|NdrProxyForwardingFunction15|void
+void|NdrProxyForwardingFunction16|void
+void|NdrProxyForwardingFunction17|void
+void|NdrProxyForwardingFunction18|void
+void|NdrProxyForwardingFunction19|void
+void|NdrProxyForwardingFunction20|void
+void|NdrProxyForwardingFunction21|void
+void|NdrProxyForwardingFunction22|void
+void|NdrProxyForwardingFunction23|void
+void|NdrProxyForwardingFunction24|void
+void|NdrProxyForwardingFunction25|void
+void|NdrProxyForwardingFunction26|void
+void|NdrProxyForwardingFunction27|void
+void|NdrProxyForwardingFunction28|void
+void|NdrProxyForwardingFunction29|void
+void|NdrProxyForwardingFunction30|void
+void|NdrProxyForwardingFunction31|void
+void|NdrProxyForwardingFunction32|void
+void|NdrProxyForwardingFunction3|void
+void|NdrProxyForwardingFunction4|void
+void|NdrProxyForwardingFunction5|void
+void|NdrProxyForwardingFunction6|void
+void|NdrProxyForwardingFunction7|void
+void|NdrProxyForwardingFunction8|void
+void|NdrProxyForwardingFunction9|void
+void|ObjectStublessClient10|void
+void|ObjectStublessClient11|void
+void|ObjectStublessClient12|void
+void|ObjectStublessClient13|void
+void|ObjectStublessClient14|void
+void|ObjectStublessClient15|void
+void|ObjectStublessClient16|void
+void|ObjectStublessClient17|void
+void|ObjectStublessClient18|void
+void|ObjectStublessClient19|void
+void|ObjectStublessClient20|void
+void|ObjectStublessClient21|void
+void|ObjectStublessClient22|void
+void|ObjectStublessClient23|void
+void|ObjectStublessClient24|void
+void|ObjectStublessClient25|void
+void|ObjectStublessClient26|void
+void|ObjectStublessClient27|void
+void|ObjectStublessClient28|void
+void|ObjectStublessClient29|void
+void|ObjectStublessClient30|void
+void|ObjectStublessClient31|void
+void|ObjectStublessClient32|void
+void|ObjectStublessClient3|void
+void|ObjectStublessClient4|void
+void|ObjectStublessClient5|void
+void|ObjectStublessClient6|void
+void|ObjectStublessClient7|void
+void|ObjectStublessClient8|void
+void|ObjectStublessClient9|void
+DWORD|OleBuildVersion|VOID
+HRESULT|OleCreate|REFCLSID|REFIID|DWORD|FORMATETC*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateDefaultHandler|REFCLSID|UNKNOWN*|REFIID|VOID**
+HRESULT|OleCreateEmbeddingHelper|REFCLSID|UNKNOWN*|DWORD|CLASSFACTORY*|REFIID|VOID**
+HRESULT|OleCreateEx|REFCLSID|REFIID|DWORD|DWORD|ulong|DWORD*|FORMATETC*|IAdviseSink*|DWORD*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateFromData|DATAOBJECT*|REFIID|DWORD|FORMATETC*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateFromDataEx|DATAOBJECT*|REFIID|DWORD|DWORD|ulong|DWORD*|FORMATETC*|IAdviseSink*|DWORD*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateFromFile|REFCLSID|wchar*|REFIID|DWORD|FORMATETC*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateFromFileEx|REFCLSID|wchar*|REFIID|DWORD|DWORD|ulong|DWORD*|FORMATETC*|IAdviseSink*|DWORD*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateLink|MONIKER*|REFIID|DWORD|FORMATETC*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateLinkEx|MONIKER*|REFIID|DWORD|DWORD|ulong|DWORD*|FORMATETC*|IAdviseSink*|DWORD*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateLinkFromData|DATAOBJECT*|REFIID|DWORD|FORMATETC*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateLinkFromDataEx|DATAOBJECT*|REFIID|DWORD|DWORD|ulong|DWORD*|FORMATETC*|IAdviseSink*|DWORD*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateLinkToFile|wchar*|REFIID|DWORD|FORMATETC*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleCreateLinkToFileEx|wchar*|REFIID|DWORD|DWORD|ulong|DWORD*|FORMATETC*|IAdviseSink*|DWORD*|OLECLIENTSITE*|STORAGE*|VOID**
+HOLEMENU|OleCreateMenuDescriptor|HMENU|OLEMENUGROUPWIDTHS*
+HRESULT|OleCreateStaticFromData|DATAOBJECT*|REFIID|DWORD|FORMATETC*|OLECLIENTSITE*|STORAGE*|VOID**
+HRESULT|OleDestroyMenuDescriptor|HOLEMENU
+HRESULT|OleDoAutoConvert|STORAGE*|CLSID*
+OLESTATUS|OleDraw|OLEOBJECT*|HDC|RECT*|RECT*|HDC
+HANDLE|OleDuplicateData|HANDLE|CLIPFORMAT|uint
+HRESULT|OleFlushClipboard|void
+HRESULT|OleGetAutoConvert|REFCLSID|CLSID*
+HRESULT|OleGetClipboard|DATAOBJECT**
+HGLOBAL|OleGetIconOfClass|REFCLSID|wchar*|bool
+HGLOBAL|OleGetIconOfFile|wchar*|bool
+HRESULT|OleInitialize|VOID*
+HRESULT|OleIsCurrentClipboard|DATAOBJECT*
+bool|OleIsRunning|OLEOBJECT*
+HRESULT|OleLoad|STORAGE*|REFIID|OLECLIENTSITE*|VOID**
+OLESTATUS|OleLoadFromStream|OLESTREAM*|char*|OLECLIENT*|LHCLIENTDOC|char*|OLEOBJECT**
+HRESULT|OleLockRunning|UNKNOWN*|bool|bool
+HGLOBAL|OleMetafilePictFromIconAndLabel|HICON|wchar*|wchar*|uint
+HRESULT|OleNoteObjectVisible|UNKNOWN*|bool
+HRESULT|OleQueryCreateFromData|DATAOBJECT*
+HRESULT|OleQueryLinkFromData|DATAOBJECT*
+HRESULT|OleRegEnumFormatEtc|REFCLSID|DWORD|ENUMFORMATETC**
+HRESULT|OleRegEnumVerbs|REFCLSID|ENUMOLEVERB**
+HRESULT|OleRegGetMiscStatus|REFCLSID|DWORD|DWORD*
+HRESULT|OleRegGetUserType|REFCLSID|DWORD|__out wchar**
+HRESULT|OleRun|UNKNOWN*
+HRESULT|OleSave|PERSISTSTORAGE*|STORAGE*|bool
+OLESTATUS|OleSaveToStream|OLEOBJECT*|OLESTREAM*
+HRESULT|OleSetAutoConvert|REFCLSID|REFCLSID
+HRESULT|OleSetClipboard|DATAOBJECT*
+HRESULT|OleSetContainedObject|UNKNOWN*|bool
+HRESULT|OleSetMenuDescriptor|HOLEMENU|HWND|HWND|OLEINPLACEFRAME*|OLEINPLACEACTIVEOBJECT*
+HRESULT|OleTranslateAccelerator|OLEINPLACEFRAME*|OLEINPLACEFRAMEINFO*|MSG*
+void|OleUninitialize|void
+HRESULT|ProgIDFromCLSID|REFCLSID|__out wchar**
+HRESULT|PropStgNameToFmtId|wchar*|__out FMTID*
+HRESULT|PropVariantClear|__inout PROPVARIANT*
+HRESULT|PropVariantCopy|__out PROPVARIANT*|PROPVARIANT*
+HRESULT|ReadClassStg|STORAGE*|CLSID*
+HRESULT|ReadClassStm|STREAM*|CLSID*
+HRESULT|ReadFmtUserTypeStg|STORAGE*|CLIPFORMAT*|__out wchar**
+HRESULT|RegisterDragDrop|HWND|DROPTARGET*
+void|ReleaseStgMedium|STGMEDIUM*
+HRESULT|RevokeDragDrop|HWND
+void|SNB_UserFree|long*|SNB*
+uchar*|SNB_UserMarshal|long*|__inout char*|SNB*
+ulong|SNB_UserSize|long*|long|SNB*
+uchar*|SNB_UserUnmarshal|long*|char*|__out SNB*
+void|STGMEDIUM_UserFree|long*|STGMEDIUM*
+uchar*|STGMEDIUM_UserMarshal|long*|__inout char*|STGMEDIUM*
+ulong|STGMEDIUM_UserSize|long*|long|STGMEDIUM*
+uchar*|STGMEDIUM_UserUnmarshal|long*|char*|__out STGMEDIUM*
+HRESULT|SetConvertStg|STORAGE*|bool
+bool|StgConvertPropertyToVariant|SERIALIZEDPROPERTYVALUE*|USHORT|__out PROPVARIANT*|PMemoryAllocator*
+SERIALIZEDPROPERTYVALUE*|StgConvertVariantToProperty|PROPVARIANT*|USHORT|__out SERIALIZEDPROPERTYVALUE*|__inout ulong*|PROPID|bool|__inout ulong*
+HRESULT|StgCreateDocfile|wchar*|DWORD|DWORD|IStorage**
+HRESULT|StgCreateDocfileOnILockBytes|ILockBytes*|DWORD|DWORD|IStorage**
+HRESULT|StgCreatePropSetStg|IStorage*|DWORD|IPropertySetStorage**
+HRESULT|StgCreatePropStg|IUnknown*|REFFMTID|CLSID*|DWORD|DWORD|IPropertySetStorage**
+HRESULT|StgCreateStorageEx|wchar*|DWORD|DWORD|DWORD|__inout STGOPTIONS*|SECURITY_DESCRIPTOR*|REFIID|__out void**
+HRESULT|StgGetIFillLockBytesOnFile|OLECHAR*|IFillLockBytes**
+HRESULT|StgGetIFillLockBytesOnILockBytes|ILockBytes*|IFillLockBytes**
+HRESULT|StgIsStorageFile|wchar*
+HRESULT|StgIsStorageILockBytes|ILockBytes*
+HRESULT|StgOpenAsyncDocfileOnIFillLockBytes|IFillLockBytes*|DWORD|DWORD|IStorage**
+HRESULT|StgOpenPropStg|IUnknown*|REFFMTID|DWORD|DWORD|IPropertyStorage**
+HRESULT|StgOpenStorage|wchar*|IStorage*|DWORD|SNB|DWORD|IStorage**
+HRESULT|StgOpenStorageEx|wchar*|DWORD|DWORD|DWORD|__inout STGOPTIONS*|SECURITY_DESCRIPTOR*|REFIID|__out void**
+HRESULT|StgOpenStorageOnILockBytes|ILockBytes*|IStorage*|DWORD|SNB|DWORD|IStorage**
+ulong|StgPropertyLengthAsVariant|SERIALIZEDPROPERTYVALUE*|ulong|USHORT|BYTE
+HRESULT|StgSetTimes|wchar*|FILETIME*|FILETIME*|FILETIME*
+HRESULT|StringFromCLSID|REFCLSID|__out wchar**
+int|StringFromGUID2|REFGUID|__out wchar*|int
+HRESULT|StringFromIID|REFIID|__out wchar**
+HRESULT|WriteClassStg|STORAGE*|REFCLSID
+HRESULT|WriteClassStm|STREAM*|REFCLSID
+HRESULT|WriteFmtUserTypeStg|STORAGE*|CLIPFORMAT|wchar*
+
+# A group of exported functions from shell32.dll
+ulong|SHChangeNotifyRegister|HWND|int|long|uint|int|SHChangeNotifyEntry*
+HRESULT|SHDefExtractIconA|char*|int|uint|__out HICON*|__out HICON*|uint
+bool|SHChangeNotifyDeregister|long
+HRESULT|SHDefExtractIconW|wchar*|int|uint|__out HICON*|__out HICON*|uint
+HANDLE|PifMgr_OpenProperties|wchar*|wchar*|uint|uint
+int|PifMgr_GetProperties|HANDLE|char*|__out void*|int|uint
+int|PifMgr_SetProperties|HANDLE|char*|void*|int|uint
+HRESULT|SHStartNetConnectionDialogA|HWND|char*|DWORD
+HANDLE|PifMgr_CloseProperties|HANDLE|uint
+HRESULT|SHStartNetConnectionDialogW|HWND|wchar*|DWORD
+ITEMID_CHILD*|ILFindLastID|ITEMIDLIST_RELATIVE*
+bool|ILRemoveLastID|__inout IDLIST_RELATIVE*
+IDLIST_RELATIVE*|ILClone|ITEMIDLIST_RELATIVE*
+ITEMID_CHILD*|ILCloneFirst|ITEMIDLIST_RELATIVE*
+bool|ILIsEqual|ITEMIDLIST_ABSOLUTE*|ITEMIDLIST_ABSOLUTE*
+bool|DAD_DragEnterEx2|HWND|POINT|IDataObject*
+bool|ILIsParent|ITEMIDLIST_ABSOLUTE*|ITEMIDLIST_ABSOLUTE*|bool
+IDLIST_RELATIVE*|ILFindChild|ITEMIDLIST_ABSOLUTE*|ITEMIDLIST_ABSOLUTE*
+ITEMIDLIST_ABSOLUTE*|ILCombine|ITEMIDLIST_ABSOLUTE*|ITEMIDLIST_RELATIVE*
+HRESULT|ILSaveToStream|IStream*|ITEMIDLIST_RELATIVE*
+HRESULT|SHILCreateFromPath|wchar*|__out ITEMIDLIST_ABSOLUTE**|__inout DWORD*
+bool|IsLFNDriveA|char*
+bool|IsLFNDriveW|wchar*
+bool|PathIsExe|wchar*
+bool|PathMakeUniqueName|__out wchar*|uint|wchar*|wchar*|wchar*
+void|PathQualify|__inout wchar*
+int|PathResolve|__inout wchar*|wchar**|uint
+int|RestartDialog|HWND|wchar*|DWORD
+int|PickIconDlg|HWND|__inout wchar*|uint|__inout int*
+bool|GetFileNameFromBrowse|HWND|__inout wchar*|uint|wchar*|wchar*|wchar*|wchar*
+int|DriveType|int
+int|IsNetDrive|int
+uint|Shell_MergeMenus|HMENU|HMENU|uint|uint|uint|ulong
+void|SHGetSetSettings|__inout SHELLSTATE*|DWORD|bool
+bool|Shell_GetImageLists|__out HIMAGELIST*|__out HIMAGELIST*
+int|Shell_GetCachedImageIndex|wchar*|int|uint
+LRESULT|SHShellFolderView_Message|HWND|uint|LPARAM
+HRESULT|SHCreateStdEnumFmtEtc|uint|FORMATETC|__out IEnumFORMATETC**
+bool|PathYetAnotherMakeUniqueName|__out wchar*|wchar*|wchar*|wchar*
+int|SHMapPIDLToSystemImageListIndex|IShellFolder*|ITEMID_CHILD*|__out int*
+bool|SHOpenPropSheetW|wchar*|HKEY|uint|CLSID*|IDataObject*|IShellBrowser*|wchar*
+HRESULT|CIDLData_CreateFromIDArray|ITEMIDLIST_ABSOLUTE*|uint|IDLIST_RELATIVE_ARRAY*|__out IDataObject**
+IStream*|OpenRegStream|HKEY|wchar*|wchar*|DWORD
+HRESULT|SHDoDragDrop|HWND|IDataObject*|IDropSource*|DWORD|__out DWORD*
+ITEMIDLIST_ABSOLUTE*|SHCloneSpecialIDList|HWND|int|bool
+bool|SHFindFiles|ITEMIDLIST_ABSOLUTE*|ITEMIDLIST_ABSOLUTE*
+void|PathGetShortPath|__inout wchar*
+HRESULT|SHGetRealIDL|IShellFolder*|HRESULT*|ITEMID_CHILD*|__out ITEMID_CHILD**
+DWORD|SHRestricted|RESTRICTIONS
+HRESULT|SHCoCreateInstance|wchar*|CLSID*|IUnknown*|REFIID|__out void**
+bool|SignalFileOpen|ITEMIDLIST_ABSOLUTE*
+bool|DAD_AutoScroll|HWND|AUTO_SCROLL_DATA*|POINT*
+bool|DAD_DragEnterEx|HWND|POINT
+bool|DAD_DragLeave|void
+bool|DAD_DragMove|POINT
+bool|DAD_SetDragImage|HIMAGELIST|POINT*
+bool|DAD_ShowDragImage|bool
+HRESULT|SHCLSIDFromString|wchar*|__out CLSID*
+IContextMenu*|SHFind_InitMenuPopup|HMENU|HWND|uint|uint
+uint|ILGetSize|ITEMIDLIST_RELATIVE*
+IDLIST_RELATIVE*|ILGetNext|ITEMIDLIST_RELATIVE*
+IDLIST_RELATIVE*|ILAppendID|IDLIST_RELATIVE*|SHITEMID*|bool
+void|ILFree|IDLIST_RELATIVE*
+ITEMIDLIST_ABSOLUTE*|ILCreateFromPath|TCHAR*
+ITEMIDLIST_ABSOLUTE*|SHSimpleIDListFromPath|wchar*
+bool|Win32DeleteFile|wchar*
+int|SHCreateDirectory|HWND|wchar*
+uint|SHAddFromPropSheetExtArray|HPSXA|FNADDPROPSHEETPAGE*|LPARAM
+HPSXA|SHCreatePropSheetExtArray|HKEY|wchar*|uint
+void|SHDestroyPropSheetExtArray|HPSXA
+uint|SHReplaceFromPropSheetExtArray|HPSXA|uint|FNADDPROPSHEETPAGE*|LPARAM
+int|PathCleanupSpec|wchar*|__inout wchar*
+bool|SHValidateUNC|HWND|__inout wchar*|uint
+HRESULT|SHCreateShellFolderViewEx|CSFV*|__out IShellView**
+bool|SHGetSpecialFolderPathW|HWND|__out wchar*|int|bool
+void|SHSetInstanceExplorer|IUnknown*
+bool|SHObjectProperties|HWND*|DWORD|wchar*|wchar*
+bool|SHGetNewLinkInfoA|char*|char*|__out char*|__out bool*|uint
+bool|SHGetNewLinkInfoW|wchar*|wchar*|__out wchar*|__out bool*|uint
+int|ShellMessageBoxW|HINSTANCE|HWND|wchar*|wchar*|uint|None # , ...
+int|ShellMessageBoxA|HINSTANCE|HWND|char*|char*|uint|None #, ...
+ITEMIDLIST_ABSOLUTE*|ILCreateFromPathA|char*
+ITEMIDLIST_ABSOLUTE*|ILCreateFromPathW|wchar*
+void|SHUpdateImageA|char*|int|uint|int
+void|SHUpdateImageW|wchar*|int|uint|int
+int|SHHandleUpdateImage|ITEMIDLIST_ABSOLUTE*
+HRESULT|AssocCreateForClasses|ASSOCIATIONELEMENT*|ulong|REFIID|__out void**
+HRESULT|AssocGetDetailsOfPropKey|IShellFolder*|ITEMID_CHILD*|PROPERTYKEY*|__out VARIANT*|__out bool*
+HRESULT|SHSetFolderPathA|int|HANDLE|DWORD|char*
+HRESULT|SHSetFolderPathW|int|HANDLE|DWORD|wchar*
+wchar**|CommandLineToArgvW|wchar*|__out int*
+bool|PathIsSlowW|wchar*|DWORD
+bool|PathIsSlowA|char*|DWORD
+bool|SHTestTokenMembership|HANDLE|ulong
+HRESULT|SHCreateShellFolderView|SFV_CREATE*|__out IShellView**
+DWORD|DoEnvironmentSubstA|__inout char*|uint
+DWORD|DoEnvironmentSubstW|__inout wchar*|uint
+void|DragAcceptFiles|HWND|bool
+void|DragFinish|HDROP
+uint|DragQueryFileA|HDROP|uint|__out char*|uint
+uint|DragQueryFileW|HDROP|uint|__out wchar*|uint
+bool|DragQueryPoint|HDROP|__out POINT*
+HICON|DuplicateIcon|HINSTANCE|HICON
+HICON|ExtractAssociatedIconA|HINSTANCE|__inout char*|__inout WORD*
+HICON|ExtractAssociatedIconExA|HINSTANCE|__inout char*|__inout WORD*|__inout WORD*
+HICON|ExtractAssociatedIconExW|HINSTANCE|__inout wchar*|__inout WORD*|__inout WORD*
+HICON|ExtractAssociatedIconW|HINSTANCE|__inout wchar*|__inout WORD*
+HICON|ExtractIconA|HINSTANCE|char*|uint
+uint|ExtractIconExA|char*|int|__out HICON*|__out HICON*|uint
+uint|ExtractIconExW|wchar*|int|__out HICON*|__out HICON*|uint
+HICON|ExtractIconW|HINSTANCE|wchar*|uint
+HINSTANCE|FindExecutableA|char*|char*|__out char*
+HINSTANCE|FindExecutableW|wchar*|wchar*|__out wchar*
+HRESULT|GetCurrentProcessExplicitAppUserModelID|__out wchar**
+bool|InitNetworkAddressControl|void
+HRESULT|SHAddDefaultPropertiesByExt|wchar*|IPropertyStore*
+void|SHAddToRecentDocs|uint|VOID*
+UINT_PTR|SHAppBarMessage|DWORD|__inout APPBARDATA*
+HRESULT|SHAssocEnumHandlers|wchar*|ASSOC_FILTER|__out IEnumAssocHandlers**
+HRESULT|SHAssocEnumHandlersForProtocolByApplication|wchar*|REFIID|__out void**
+HRESULT|SHBindToFolderIDListParent|IShellFolder*|ITEMIDLIST_RELATIVE*|REFIID|__out void**|__out ITEMID_CHILD**
+HRESULT|SHBindToFolderIDListParentEx|IShellFolder*|ITEMIDLIST_RELATIVE*|IBindCtx*|REFIID|__out void**|__out ITEMID_CHILD**
+HRESULT|SHBindToObject|IShellFolder*|ITEMIDLIST_RELATIVE*|IBindCtx*|REFIID|__out void**
+HRESULT|SHBindToParent|ITEMIDLIST_ABSOLUTE*|REFIID|__out void**|__out ITEMID_CHILD**
+ITEMIDLIST_ABSOLUTE*|SHBrowseForFolderA|BROWSEINFOA*
+ITEMIDLIST_ABSOLUTE*|SHBrowseForFolderW|BROWSEINFOW*
+void|SHChangeNotify|long|uint|VOID*|VOID*
+void|SHChangeNotifyRegisterThread|SCNRT_STATUS
+HRESULT|SHCreateAssociationRegistration|REFIID|__out void**
+HRESULT|SHCreateDataObject|ITEMIDLIST_ABSOLUTE*|uint|ITEMID_CHILD_ARRAY*|IDataObject*|REFIID|__out void**
+HRESULT|SHCreateDefaultContextMenu|DEFCONTEXTMENU*|REFIID|__out void**
+HRESULT|SHCreateDefaultExtractIcon|REFIID|__out void**
+HRESULT|SHCreateDefaultPropertiesOp|IShellItem*|__out IFileOperation**
+int|SHCreateDirectoryExA|HWND|char*|SECURITY_ATTRIBUTES*
+int|SHCreateDirectoryExW|HWND|wchar*|SECURITY_ATTRIBUTES*
+HRESULT|SHCreateItemFromIDList|ITEMIDLIST_ABSOLUTE*|REFIID|__out void**
+HRESULT|SHCreateItemFromParsingName|wchar*|IBindCtx*|REFIID|__out void**
+HRESULT|SHCreateItemFromRelativeName|IShellItem*|wchar*|IBindCtx*|REFIID|__out void**
+HRESULT|SHCreateItemInKnownFolder|REFKNOWNFOLDERID|DWORD|wchar*|REFIID|__out void**
+HRESULT|SHCreateItemWithParent|ITEMIDLIST_ABSOLUTE*|IShellFolder*|ITEMID_CHILD*|REFIID|__out void**
+bool|SHCreateProcessAsUserW|__inout SHCREATEPROCESSINFOW*
+HRESULT|SHCreateShellItem|ITEMIDLIST_ABSOLUTE*|IShellFolder*|ITEMID_CHILD*|__out IShellItem**
+HRESULT|SHCreateShellItemArray|ITEMIDLIST_ABSOLUTE*|IShellFolder*|uint|ITEMID_CHILD_ARRAY*|__out IShellItemArray**
+HRESULT|SHCreateShellItemArrayFromDataObject|IDataObject*|REFIID|__out void**
+HRESULT|SHCreateShellItemArrayFromIDLists|uint|LPCITEMIDLIST*|__out IShellItemArray**
+HRESULT|SHCreateShellItemArrayFromShellItem|IShellItem*|REFIID|__out void**
+HRESULT|SHEmptyRecycleBinA|HWND|char*|DWORD
+HRESULT|SHEmptyRecycleBinW|HWND|wchar*|DWORD
+HRESULT|SHEnumerateUnreadMailAccountsW|HKEY|DWORD|__out wchar*|int
+HRESULT|SHEvaluateSystemCommandTemplate|wchar*|__out wchar**|__out wchar**|__out wchar**
+int|SHFileOperationA|__inout SHFILEOPSTRUCTA*
+int|SHFileOperationW|__inout SHFILEOPSTRUCTW*
+DWORD|SHFormatDrive|HWND|uint|uint|uint
+void|SHFreeNameMappings|HANDLE
+HRESULT|SHGetDataFromIDListA|IShellFolder*|ITEMID_CHILD*|int|__out void*|int
+HRESULT|SHGetDataFromIDListW|IShellFolder*|ITEMID_CHILD*|int|__out void*|int
+HRESULT|SHGetDesktopFolder|__out IShellFolder**
+bool|SHGetDiskFreeSpaceExA|char*|__out ULARGE_INTEGER*|__out ULARGE_INTEGER*|__out ULARGE_INTEGER*
+bool|SHGetDiskFreeSpaceExW|wchar*|__out ULARGE_INTEGER*|__out ULARGE_INTEGER*|__out ULARGE_INTEGER*
+HRESULT|SHGetDriveMedia|wchar*|__out DWORD*
+DWORD_PTR|SHGetFileInfoA|char*|DWORD|__inout SHFILEINFOA*|uint|uint
+DWORD_PTR|SHGetFileInfoW|wchar*|DWORD|__inout SHFILEINFOW*|uint|uint
+HRESULT|SHGetFolderLocation|HWND|int|HANDLE|DWORD|__out ITEMIDLIST_ABSOLUTE**
+HRESULT|SHGetFolderPathA|HWND|int|HANDLE|DWORD|__out char*
+HRESULT|SHGetFolderPathAndSubDirA|HWND|int|HANDLE|DWORD|char*|__out char*
+HRESULT|SHGetFolderPathAndSubDirW|HWND|int|HANDLE|DWORD|wchar*|__out wchar*
+HRESULT|SHGetFolderPathW|HWND|int|HANDLE|DWORD|__out wchar*
+HRESULT|SHGetIDListFromObject|IUnknown*|__out ITEMIDLIST_ABSOLUTE**
+int|SHGetIconOverlayIndexA|char*|int
+int|SHGetIconOverlayIndexW|wchar*|int
+HRESULT|SHGetInstanceExplorer|__out IUnknown**
+HRESULT|SHGetItemFromDataObject|IDataObject*|DATAOBJ_GET_ITEM_FLAGS|REFIID|__out void**
+HRESULT|SHGetItemFromObject|IUnknown*|REFIID|__out void**
+HRESULT|SHGetKnownFolderIDList|REFKNOWNFOLDERID|DWORD*|HANDLE|__out ITEMIDLIST_ABSOLUTE**
+HRESULT|SHGetKnownFolderItem|REFKNOWNFOLDERID|KNOWN_FOLDER_FLAG|HANDLE|REFIID|__out void**
+HRESULT|SHGetKnownFolderPath|REFKNOWNFOLDERID|DWORD*|HANDLE|__out wchar**
+HRESULT|SHGetLocalizedName|wchar*|__out wchar*|uint|__out int*
+HRESULT|SHGetNameFromIDList|ITEMIDLIST_ABSOLUTE*|SIGDN|__out wchar**
+bool|SHGetPathFromIDListA|ITEMIDLIST_ABSOLUTE*|__out char*
+bool|SHGetPathFromIDListEx|ITEMIDLIST_ABSOLUTE*|__out wchar*|DWORD|int
+bool|SHGetPathFromIDListW|ITEMIDLIST_ABSOLUTE*|__out wchar*
+bool|SHGetPropertyStoreForWindow|HWND|REFIID|__out void**
+bool|SHGetPropertyStoreFromIDList|ITEMIDLIST_ABSOLUTE*|GETPROPERTYSTOREFLAGS|REFIID|__out void**
+HRESULT|SHGetPropertyStoreFromParsingName|wchar*|IBindCtx*|GETPROPERTYSTOREFLAGS|REFIID|__out void**
+void|SHGetSettings|__out SHELLFLAGSTATE*|DWORD
+HRESULT|SHGetSpecialFolderLocation|HWND|int|__out ITEMIDLIST_ABSOLUTE**
+bool|SHGetSpecialFolderPathA|HWND|__out char*|int|bool
+HRESULT|SHGetStockIconInfo|SHSTOCKICONID|uint|__inout SHSTOCKICONINFO*
+HRESULT|SHGetTemporaryPropertyForItem|IShellItem*|REFPROPERTYKEY|__out PROPVARIANT*
+HRESULT|SHGetUnreadMailCountW|HKEY|wchar*|__out DWORD*|__out FILETIME*|__out wchar*|int
+bool|SHInvokePrinterCommandA|HWND|uint|char*|char*|bool
+bool|SHInvokePrinterCommandW|HWND|uint|wchar*|wchar*|bool
+bool|SHIsFileAvailableOffline|wchar*|__out DWORD*
+HRESULT|SHLoadInProc|REFCLSID
+HRESULT|SHLoadNonloadedIconOverlayIdentifiers|HRESULT
+HRESULT|SHOpenFolderAndSelectItems|ITEMIDLIST_ABSOLUTE*|uint|ITEMID_CHILD_ARRAY*|DWORD
+HRESULT|SHOpenWithDialog|HWND|OPENASINFO*
+HRESULT|SHParseDisplayName|wchar*|IBindCtx*|__out ITEMIDLIST_ABSOLUTE**|SFGAOF|__out SFGAOF*
+HRESULT|SHPathPrepareForWriteA|HWND|IUnknown*|char*|DWORD
+HRESULT|SHPathPrepareForWriteW|HWND|IUnknown*|wchar*|DWORD
+HRESULT|SHQueryRecycleBinA|char*|__inout SHQUERYRBINFO*
+HRESULT|SHQueryRecycleBinW|wchar*|__inout SHQUERYRBINFO*
+HRESULT|SHQueryUserNotificationState|__out QUERY_USER_NOTIFICATION_STATE*
+HRESULT|SHRemoveLocalizedName|wchar*
+HRESULT|SHResolveLibrary|IShellItem*
+HRESULT|SHSetDefaultProperties|HWND|IShellItem*|DWORD|IFileOperationProgressSink*
+HRESULT|SHSetKnownFolderPath|REFKNOWNFOLDERID|DWORD*|HANDLE|wchar*
+HRESULT|SHSetLocalizedName|wchar*|wchar*|int
+HRESULT|SHSetTemporaryPropertyForItem|IShellItem*|REFPROPERTYKEY|REFPROPVARIANT
+HRESULT|SHSetUnreadMailCountW|wchar*|DWORD|wchar*
+HRESULT|SHShowManageLibraryUI|IShellItem*|HWND|wchar*|wchar*|LIBRARYMANAGEDIALOGOPTIONS
+HRESULT|SetCurrentProcessExplicitAppUserModelID|wchar*
+int|ShellAboutA|HWND|char*|char*|HICON
+int|ShellAboutW|HWND|wchar*|wchar*|HICON
+HINSTANCE|ShellExecuteA|HWND|char*|char*|char*|char*|int
+bool|ShellExecuteExA|__inout SHELLEXECUTEINFOA*
+bool|ShellExecuteExW|__inout SHELLEXECUTEINFOW*
+HINSTANCE|ShellExecuteW|HWND|wchar*|wchar*|wchar*|wchar*|int
+int|Shell_GetCachedImageIndexA|char*|int|uint
+int|Shell_GetCachedImageIndexW|wchar*|int|uint
+bool|Shell_NotifyIconA|DWORD|NOTIFYICONDATAA*
+HRESULT|Shell_NotifyIconGetRect|NOTIFYICONIDENTIFIER*|__out RECT*
+bool|Shell_NotifyIconW|DWORD|NOTIFYICONDATAW*
+char*|StrChrA|char*|WORD
+char*|StrChrIA|char*|WORD
+wchar*|StrChrIW|wchar*|wchar
+wchar*|StrChrW|wchar*|wchar
+int|StrCmpNA|char*|char*|int
+int|StrCmpNIA|char*|char*|int
+int|StrCmpNIW|wchar*|wchar*|int
+int|StrCmpNW|wchar*|wchar*|int
+char*|StrRChrA|char*|char*|WORD
+char*|StrRChrIA|char*|char*|WORD
+wchar*|StrRChrIW|wchar*|wchar*|wchar
+wchar*|StrRChrW|wchar*|wchar*|wchar
+char*|StrRStrIA|char*|char*|char*
+wchar*|StrRStrIW|wchar*|wchar*|wchar*
+char*|StrStrA|char*|char*
+char*|StrStrIA|char*|char*
+wchar*|StrStrIW|wchar*|wchar*
+wchar*|StrStrW|wchar*|wchar*
+int|RealDriveType|int|bool
+void|SHFlushSFCache|void
+HANDLE|SHChangeNotification_Lock|HANDLE|DWORD|__out ITEMIDLIST_ABSOLUTE***|__out long*
+bool|SHChangeNotification_Unlock|HANDLE
+bool|WriteCabinetState|CABINETSTATE*
+bool|ReadCabinetState|__out CABINETSTATE*|int
+bool|IsUserAnAdmin|void
+HRESULT|StgMakeUniqueName|IStorage*|wchar*|DWORD|REFIID|__out void**
+HRESULT|SHPropStgCreate|IPropertySetStorage*|REFFMTID|CLSID*|DWORD|DWORD|DWORD|__out IPropertyStorage**|__out uint*
+HRESULT|SHPropStgReadMultiple|IPropertyStorage*|uint|ulong|PROPSPEC|__out PROPVARIANT
+HRESULT|SHPropStgWriteMultiple|IPropertyStorage*|__inout uint*|ulong|PROPSPEC|__inout PROPVARIANT|PROPID
+HRESULT|CDefFolderMenu_Create2|ITEMIDLIST_ABSOLUTE*|HWND|uint|ITEMID_CHILD_ARRAY*|IShellFolder*|FNDFMCALLBACK*|uint|HKEY*|__out IContextMenu**
+HRESULT|SHGetSetFolderCustomSettings|__inout SHFOLDERCUSTOMSETTINGS*|wchar*|DWORD
+HRESULT|SHMultiFileProperties|HRESULT*|DWORD
+HRESULT|SHGetImageList|int|REFIID|__out void**
+int|RestartDialogEx|HWND|wchar*|DWORD|DWORD
+HRESULT|SHCreateFileExtractIconW|wchar*|DWORD|REFIID|__out void**
+HRESULT|SHLimitInputEdit|HWND|IShellFolder*
+HRESULT|SHGetAttributesFromDataObject|IDataObject*|DWORD|__out DWORD*|__out uint*
+HRESULT|ILLoadFromStreamEx|IStream*|__out IDLIST_RELATIVE**
+
+# A group of exported functions from shlwapi.dll
+HRESULT|ParseURLA|char*|__inout PARSEDURLA*
+HRESULT|ParseURLW|wchar*|__inout PARSEDURLW*
+HANDLE|SHAllocShared|void*|DWORD|DWORD
+void*|SHLockShared|HANDLE|DWORD
+bool|SHUnlockShared|void*
+bool|SHFreeShared|HANDLE|DWORD
+IStream*|SHCreateMemStream|BYTE*|uint
+HRESULT|GetAcceptLanguagesA|__out char*|__inout DWORD*
+HRESULT|GetAcceptLanguagesW|__out wchar*|__inout DWORD*
+bool|SHCreateThread|THREAD_START_ROUTINE*|void*|SHCT_FLAGS|THREAD_START_ROUTINE*
+bool|IsCharSpaceW|wchar
+int|StrCmpNCA|char*|char*|int
+int|StrCmpNCW|wchar*|wchar*|int
+int|StrCmpNICA|char*|char*|int
+int|StrCmpNICW|wchar*|wchar*|int
+int|StrCmpCA|char*|char*
+int|StrCmpCW|wchar*|wchar*
+int|StrCmpICA|char*|char*
+int|StrCmpICW|wchar*|wchar*
+HRESULT|ConnectToConnectionPoint|IUnknown*|REFIID|bool|IUnknown*|__out DWORD*|__out IConnectionPoint**
+void|IUnknown_AtomicRelease|void**
+HRESULT|IUnknown_GetWindow|IUnknown*|__out HWND*
+HRESULT|IUnknown_SetSite|IUnknown*|IUnknown*
+HRESULT|IUnknown_QueryService|IUnknown*|REFGUID|REFIID|__out void**
+HRESULT|IStream_Read|IStream*|__out void*|ulong
+int|SHMessageBoxCheckA|HWND|char*|char*|uint|int|char*
+int|SHMessageBoxCheckW|HWND|wchar*|wchar*|uint|int|wchar*
+void|IUnknown_Set|IUnknown**|IUnknown*
+char|SHStripMneumonicA|__inout char*
+HRESULT|IStream_Write|IStream*|void*|ulong
+HRESULT|IStream_Reset|IStream*
+HRESULT|IStream_Size|IStream*|__out ULARGE_INTEGER*
+int|SHAnsiToUnicode|char*|__out wchar*|int
+int|SHUnicodeToAnsi|wchar*|__out char*|int
+HRESULT|QISearch|__inout void*|QITAB*|REFIID|__out void**
+wchar|SHStripMneumonicW|__inout wchar*
+HRESULT|IUnknown_GetSite|IUnknown*|REFIID|__out void**
+uint|WhichPlatform|void
+int|SHRegGetIntW|HKEY|wchar*|int
+int|SHAnsiToAnsi|char*|__out char*|int
+int|SHUnicodeToUnicode|wchar*|__out wchar*|int
+int|SHFormatDateTimeA|FILETIME*|__inout DWORD*|__out char*|uint
+int|SHFormatDateTimeW|FILETIME*|__inout DWORD*|__out wchar*|uint
+LRESULT|SHSendMessageBroadcastA|uint|WPARAM|LPARAM
+LRESULT|SHSendMessageBroadcastW|uint|WPARAM|LPARAM
+bool|IsOS|DWORD
+HRESULT|UrlFixupW|wchar*|__out wchar*|DWORD
+HRESULT|SHLoadIndirectString|wchar*|__out wchar*|uint|void**
+HRESULT|AssocCreate|CLSID|REFIID|__out void**
+HRESULT|AssocGetPerceivedType|wchar*|__out PERCEIVED*|__out PERCEIVEDFLAG*|__out wchar**
+bool|AssocIsDangerous|wchar*
+HRESULT|AssocQueryKeyA|ASSOCF|ASSOCKEY|char*|char*|__out HKEY*
+HRESULT|AssocQueryKeyW|ASSOCF|ASSOCKEY|wchar*|wchar*|__out HKEY*
+HRESULT|IStream_ReadPidl|IStream*|__out IDLIST_RELATIVE**
+HRESULT|IStream_WritePidl|IStream*|ITEMIDLIST_RELATIVE*
+HRESULT|SHGetViewStatePropertyBag|ITEMIDLIST_ABSOLUTE*|wchar*|DWORD|REFIID|__out void**
+bool|IsInternetESCEnabled|void
+HRESULT|IStream_Copy|IStream*|IStream*|DWORD
+HRESULT|AssocQueryStringA|ASSOCF|ASSOCSTR|char*|char*|__out char*|__inout DWORD*
+HRESULT|AssocQueryStringByKeyA|ASSOCF|ASSOCSTR|HKEY|char*|__out char*|__inout DWORD*
+HRESULT|AssocQueryStringByKeyW|ASSOCF|ASSOCSTR|HKEY|wchar*|__out wchar*|__inout DWORD*
+HRESULT|AssocQueryStringW|ASSOCF|ASSOCSTR|wchar*|wchar*|__out wchar*|__inout DWORD*
+bool|ChrCmpIA|WORD|WORD
+bool|ChrCmpIW|wchar|wchar
+COLORREF|ColorAdjustLuma|COLORREF|int|bool
+COLORREF|ColorHLSToRGB|WORD|WORD|WORD
+void|ColorRGBToHLS|COLORREF|__out WORD*|__out WORD*|__out WORD*
+int|GetMenuPosFromID|HMENU|uint
+HRESULT|HashData|BYTE*|DWORD|__out BYTE*|DWORD
+bool|IntlStrEqWorkerA|bool|char*|char*|int
+HRESULT|IStream_ReadStr|IStream*|__out wchar**
+HRESULT|IStream_WriteStr|IStream*|wchar*
+bool|IntlStrEqWorkerW|bool|wchar*|wchar*|int
+bool|IsCharSpaceA|char
+char*|PathAddBackslashA|__inout char*
+wchar*|PathAddBackslashW|__inout wchar*
+bool|PathAddExtensionA|__inout char*|char*
+bool|SHCreateThreadWithHandle|THREAD_START_ROUTINE*|void*|SHCT_FLAGS|THREAD_START_ROUTINE*|__out HANDLE*
+bool|PathAddExtensionW|__inout wchar*|wchar*
+bool|PathAppendA|__inout char*|char*
+bool|PathAppendW|__inout wchar*|wchar*
+char*|PathBuildRootA|__out char*|int
+wchar*|PathBuildRootW|__out wchar*|int
+bool|PathCanonicalizeA|__out char*|char*
+LSTATUS|SHRegGetValueFromHKCUHKLM|wchar*|wchar*|SRRF|__out DWORD*|__out void*|__inout DWORD*
+bool|SHRegGetBoolValueFromHKCUHKLM|wchar*|wchar*|bool
+LSTATUS|SHRegSetValue|HKEY|wchar*|wchar*|SRRF|DWORD|VOID*|DWORD
+long|SHGlobalCounterGetValue|SHGLOBALCOUNTER
+long|SHGlobalCounterIncrement|SHGLOBALCOUNTER
+long|SHGlobalCounterDecrement|SHGLOBALCOUNTER
+bool|PathCanonicalizeW|__out wchar*|wchar*
+char*|PathCombineA|__out char*|char*|char*
+wchar*|PathCombineW|__out wchar*|wchar*|wchar*
+int|PathCommonPrefixA|char*|char*|__out char*
+int|PathCommonPrefixW|wchar*|wchar*|__out wchar*
+bool|PathCompactPathA|HDC|__inout char*|uint
+bool|PathCompactPathExA|__out char*|char*|uint|DWORD
+bool|PathCompactPathExW|__out wchar*|wchar*|uint|DWORD
+bool|PathCompactPathW|HDC|__inout wchar*|uint
+HRESULT|PathCreateFromUrlA|char*|__out char*|__inout DWORD*|DWORD
+HRESULT|PathCreateFromUrlAlloc|wchar*|__out wchar**|DWORD
+HRESULT|PathCreateFromUrlW|wchar*|__out wchar*|__inout DWORD*|DWORD
+bool|PathFileExistsA|char*
+bool|PathFileExistsW|wchar*
+char*|PathFindExtensionA|char*
+wchar*|PathFindExtensionW|wchar*
+char*|PathFindFileNameA|char*
+wchar*|PathFindFileNameW|wchar*
+char*|PathFindNextComponentA|char*
+wchar*|PathFindNextComponentW|wchar*
+bool|PathFindOnPathA|__inout char*|char**
+bool|PathFindOnPathW|__inout wchar*|wchar**
+char*|PathFindSuffixArrayA|char*|char**|int
+wchar*|PathFindSuffixArrayW|wchar*|wchar**|int
+char*|PathGetArgsA|char*
+wchar*|PathGetArgsW|wchar*
+uint|PathGetCharTypeA|uchar
+uint|PathGetCharTypeW|wchar
+int|PathGetDriveNumberA|char*
+int|PathGetDriveNumberW|wchar*
+bool|PathIsContentTypeA|char*|char*
+bool|PathIsContentTypeW|wchar*|wchar*
+bool|PathIsDirectoryA|char*
+bool|PathIsDirectoryEmptyA|char*
+bool|PathIsDirectoryEmptyW|wchar*
+bool|PathIsDirectoryW|wchar*
+bool|PathIsFileSpecA|char*
+bool|PathIsFileSpecW|wchar*
+bool|PathIsLFNFileSpecA|char*
+bool|PathIsLFNFileSpecW|wchar*
+bool|PathIsNetworkPathA|char*
+bool|PathIsNetworkPathW|wchar*
+bool|PathIsPrefixA|char*|char*
+bool|PathIsPrefixW|wchar*|wchar*
+bool|PathIsRelativeA|char*
+bool|PathIsRelativeW|wchar*
+bool|PathIsRootA|char*
+bool|PathIsRootW|wchar*
+bool|PathIsSameRootA|char*|char*
+bool|PathIsSameRootW|wchar*|wchar*
+bool|PathIsSystemFolderA|char*|DWORD
+bool|PathIsSystemFolderW|wchar*|DWORD
+bool|PathIsUNCA|char*
+bool|PathIsUNCServerA|char*
+bool|PathIsUNCServerShareA|char*
+bool|PathIsUNCServerShareW|wchar*
+bool|PathIsUNCServerW|wchar*
+bool|PathIsUNCW|wchar*
+bool|PathIsURLA|char*
+bool|PathIsURLW|wchar*
+bool|PathMakePrettyA|__inout char*
+bool|PathMakePrettyW|__inout wchar*
+bool|PathMakeSystemFolderA|char*
+bool|PathMakeSystemFolderW|wchar*
+bool|PathMatchSpecA|char*|char*
+HRESULT|PathMatchSpecExA|char*|char*|DWORD
+HRESULT|PathMatchSpecExW|wchar*|wchar*|DWORD
+bool|PathMatchSpecW|wchar*|wchar*
+int|PathParseIconLocationA|__inout char*
+int|PathParseIconLocationW|__inout wchar*
+bool|PathQuoteSpacesA|__inout char*
+bool|PathQuoteSpacesW|__inout wchar*
+bool|PathRelativePathToA|__out char*|char*|DWORD|char*|DWORD
+bool|PathRelativePathToW|__out wchar*|wchar*|DWORD|wchar*|DWORD
+void|PathRemoveArgsA|__inout char*
+void|PathRemoveArgsW|__inout wchar*
+char*|PathRemoveBackslashA|__inout char*
+wchar*|PathRemoveBackslashW|__inout wchar*
+void|PathRemoveBlanksA|__inout char*
+void|PathRemoveBlanksW|__inout wchar*
+void|PathRemoveExtensionA|__inout char*
+void|PathRemoveExtensionW|__inout wchar*
+bool|PathRemoveFileSpecA|__inout char*
+bool|PathRemoveFileSpecW|__inout wchar*
+bool|PathRenameExtensionA|__inout char*|char*
+bool|PathRenameExtensionW|__inout wchar*|wchar*
+bool|PathSearchAndQualifyA|char*|__out char*|uint
+bool|PathSearchAndQualifyW|wchar*|__out wchar*|uint
+void|PathSetDlgItemPathA|HWND|int|char*
+void|PathSetDlgItemPathW|HWND|int|wchar*
+char*|PathSkipRootA|char*
+wchar*|PathSkipRootW|wchar*
+void|PathStripPathA|__inout char*
+void|PathStripPathW|__inout wchar*
+bool|PathStripToRootA|__inout char*
+bool|PathStripToRootW|__inout wchar*
+bool|PathUnExpandEnvStringsA|char*|__out char*|uint
+bool|PathUnExpandEnvStringsW|wchar*|__out wchar*|uint
+void|PathUndecorateA|__inout char*
+void|PathUndecorateW|__inout wchar*
+bool|PathUnmakeSystemFolderA|char*
+bool|PathUnmakeSystemFolderW|wchar*
+bool|PathUnquoteSpacesA|__inout char*
+bool|PathUnquoteSpacesW|__inout wchar*
+HRESULT|SHAutoComplete|HWND|DWORD
+LSTATUS|SHCopyKeyA|HKEY|char*|HKEY|DWORD
+LSTATUS|SHCopyKeyW|HKEY|wchar*|HKEY|DWORD
+HPALETTE|SHCreateShellPalette|HDC
+HRESULT|SHCreateStreamOnFileA|char*|DWORD|__out IStream**
+HRESULT|SHCreateStreamOnFileEx|wchar*|DWORD|DWORD|bool|IStream*|__out IStream**
+HRESULT|SHCreateStreamOnFileW|wchar*|DWORD|__out IStream**
+HRESULT|SHCreateThreadRef|__inout long*|__out IUnknown**
+LSTATUS|SHDeleteEmptyKeyA|HKEY|char*
+LSTATUS|SHDeleteEmptyKeyW|HKEY|wchar*
+LSTATUS|SHDeleteKeyA|HKEY|char*
+LSTATUS|SHDeleteKeyW|HKEY|wchar*
+LSTATUS|SHDeleteValueA|HKEY|char*|char*
+LSTATUS|SHDeleteValueW|HKEY|wchar*|wchar*
+LSTATUS|SHEnumKeyExA|HKEY|DWORD|__out char*|__inout DWORD*
+LSTATUS|SHEnumKeyExW|HKEY|DWORD|__out wchar*|__inout DWORD*
+LSTATUS|SHEnumValueA|HKEY|DWORD|__out char*|__inout DWORD*|__out DWORD*|__out void*|__inout DWORD*
+LSTATUS|SHEnumValueW|HKEY|DWORD|__out wchar*|__inout DWORD*|__out DWORD*|__out void*|__inout DWORD*
+HRESULT|SHGetInverseCMAP|__out BYTE*|ulong
+HRESULT|SHGetThreadRef|__out IUnknown**
+LSTATUS|SHGetValueA|HKEY|char*|char*|__out DWORD*|__out void*|__inout DWORD*
+LSTATUS|SHGetValueW|HKEY|wchar*|wchar*|__out DWORD*|__out void*|__inout DWORD*
+bool|SHIsLowMemoryMachine|DWORD
+IStream*|SHOpenRegStream2A|HKEY|char*|char*|DWORD
+IStream*|SHOpenRegStream2W|HKEY|wchar*|wchar*|DWORD
+IStream*|SHOpenRegStreamA|HKEY|char*|char*|DWORD
+IStream*|SHOpenRegStreamW|HKEY|wchar*|wchar*|DWORD
+LSTATUS|SHQueryInfoKeyA|HKEY|__out DWORD*|__out DWORD*|__out DWORD*|__out DWORD*
+LSTATUS|SHQueryInfoKeyW|HKEY|__out DWORD*|__out DWORD*|__out DWORD*|__out DWORD*
+LSTATUS|SHQueryValueExA|HKEY|char*|DWORD*|__out DWORD*|__out void*|__inout DWORD*
+LSTATUS|SHQueryValueExW|HKEY|wchar*|DWORD*|__out DWORD*|__out void*|__inout DWORD*
+LSTATUS|SHRegCloseUSKey|HUSKEY
+LSTATUS|SHRegCreateUSKeyA|char*|REGSAM|HUSKEY|__out HUSKEY*|DWORD
+LSTATUS|SHRegCreateUSKeyW|wchar*|REGSAM|HUSKEY|__out HUSKEY*|DWORD
+LSTATUS|SHRegDeleteEmptyUSKeyA|HUSKEY|char*|SHREGDEL_FLAGS
+LSTATUS|SHRegDeleteEmptyUSKeyW|HUSKEY|wchar*|SHREGDEL_FLAGS
+LSTATUS|SHRegDeleteUSValueA|HUSKEY|char*|SHREGDEL_FLAGS
+LSTATUS|SHRegDeleteUSValueW|HUSKEY|wchar*|SHREGDEL_FLAGS
+HKEY|SHRegDuplicateHKey|HKEY
+LSTATUS|SHRegEnumUSKeyA|HUSKEY|DWORD|__out char*|__inout DWORD*|SHREGENUM_FLAGS
+LSTATUS|SHRegEnumUSKeyW|HUSKEY|DWORD|__out wchar*|__inout DWORD*|SHREGENUM_FLAGS
+LSTATUS|SHRegEnumUSValueA|HUSKEY|DWORD|__out char*|__inout DWORD*|__out DWORD*|__out void*|__inout DWORD*|SHREGENUM_FLAGS
+LSTATUS|SHRegEnumUSValueW|HUSKEY|DWORD|__out wchar*|__inout DWORD*|__out DWORD*|__out void*|__inout DWORD*|SHREGENUM_FLAGS
+bool|SHRegGetBoolUSValueA|char*|char*|bool|bool
+bool|SHRegGetBoolUSValueW|wchar*|wchar*|bool|bool
+LSTATUS|SHRegGetPathA|HKEY|char*|char*|__out char*|DWORD
+LSTATUS|SHRegGetPathW|HKEY|wchar*|wchar*|__out wchar*|DWORD
+LSTATUS|SHRegGetUSValueA|char*|char*|__inout DWORD*|__out void*|__inout DWORD*|bool|void*|DWORD
+LSTATUS|SHRegGetUSValueW|wchar*|wchar*|__inout DWORD*|__out void*|__inout DWORD*|bool|void*|DWORD
+LSTATUS|SHRegGetValueA|HKEY|char*|char*|SRRF|__out DWORD*|__out void*|__inout DWORD*
+LSTATUS|SHRegGetValueW|HKEY|wchar*|wchar*|SRRF|__out DWORD*|__out void*|__inout DWORD*
+LSTATUS|SHRegOpenUSKeyA|char*|REGSAM|HUSKEY|__out HUSKEY*|bool
+LSTATUS|SHRegOpenUSKeyW|wchar*|REGSAM|HUSKEY|__out HUSKEY*|bool
+LSTATUS|SHRegQueryInfoUSKeyA|HUSKEY|__out DWORD*|__out DWORD*|__out DWORD*|__out DWORD*|SHREGENUM_FLAGS
+LSTATUS|SHRegQueryInfoUSKeyW|HUSKEY|__out DWORD*|__out DWORD*|__out DWORD*|__out DWORD*|SHREGENUM_FLAGS
+LSTATUS|SHRegQueryUSValueA|HUSKEY|char*|__inout DWORD*|__out void*|__inout DWORD*|bool|void*|DWORD
+LSTATUS|SHRegQueryUSValueW|HUSKEY|wchar*|__inout DWORD*|__out void*|__inout DWORD*|bool|void*|DWORD
+LSTATUS|SHRegSetPathA|HKEY|char*|char*|char*|DWORD
+LSTATUS|SHRegSetPathW|HKEY|wchar*|wchar*|wchar*|DWORD
+LSTATUS|SHRegSetUSValueA|char*|char*|DWORD|void*|DWORD|DWORD
+LSTATUS|SHRegSetUSValueW|wchar*|wchar*|DWORD|void*|DWORD|DWORD
+LSTATUS|SHRegWriteUSValueA|HUSKEY|char*|DWORD|void*|DWORD|DWORD
+LSTATUS|SHRegWriteUSValueW|HUSKEY|wchar*|DWORD|void*|DWORD|DWORD
+HRESULT|SHSetThreadRef|IUnknown*
+LSTATUS|SHSetValueA|HKEY|char*|char*|DWORD|VOID*|DWORD
+LSTATUS|SHSetValueW|HKEY|wchar*|wchar*|DWORD|VOID*|DWORD
+bool|SHSkipJunction|IBindCtx*|CLSID*
+HRESULT|SHStrDupA|char*|__out wchar**
+HRESULT|SHStrDupW|wchar*|__out wchar**
+int|StrCSpnA|char*|char*
+int|StrCSpnIA|char*|char*
+int|StrCSpnIW|wchar*|wchar*
+int|StrCSpnW|wchar*|wchar*
+char*|StrCatBuffA|__inout char*|char*|int
+wchar*|StrCatBuffW|__inout wchar*|wchar*|int
+DWORD|StrCatChainW|__out wchar*|DWORD|DWORD|wchar*
+wchar*|StrCatW|__inout wchar*|wchar*
+wchar*|StrChrNIW|wchar*|wchar|uint
+wchar*|StrChrNW|wchar*|wchar|uint
+int|StrCmpIW|wchar*|wchar*
+int|StrCmpLogicalW|wchar*|wchar*
+int|StrCmpW|wchar*|wchar*
+wchar*|StrCpyNW|__out wchar*|wchar*|int
+wchar*|StrCpyW|__out wchar*|wchar*
+char*|StrDupA|char*
+wchar*|StrDupW|wchar*
+char*|StrFormatByteSize64A|LONGLONG|__out char*|uint
+char*|StrFormatByteSizeA|DWORD|__out char*|uint
+HRESULT|StrFormatByteSizeEx|ULONGLONG|SFBS_FLAGS|__out wchar*|uint
+wchar*|StrFormatByteSizeW|LONGLONG|__out wchar*|uint
+char*|StrFormatKBSizeA|LONGLONG|__out char*|uint
+wchar*|StrFormatKBSizeW|LONGLONG|__out wchar*|uint
+int|StrFromTimeIntervalA|__out char*|uint|DWORD|int
+int|StrFromTimeIntervalW|__out wchar*|uint|DWORD|int
+bool|StrIsIntlEqualA|bool|char*|char*|int
+bool|StrIsIntlEqualW|bool|wchar*|wchar*|int
+char*|StrNCatA|__inout char*|char*|int
+wchar*|StrNCatW|__inout wchar*|wchar*|int
+char*|StrPBrkA|char*|char*
+wchar*|StrPBrkW|wchar*|wchar*
+HRESULT|StrRetToBSTR|__inout STRRET*|ITEMID_CHILD*|__out BSTR*
+HRESULT|StrRetToBufA|__inout STRRET*|ITEMID_CHILD*|__out char*|uint
+HRESULT|StrRetToBufW|__inout STRRET*|ITEMID_CHILD*|__out wchar*|uint
+HRESULT|StrRetToStrA|__inout STRRET*|ITEMID_CHILD*|__out char**
+HRESULT|StrRetToStrW|__inout STRRET*|ITEMID_CHILD*|__out wchar**
+int|StrSpnA|char*|char*
+int|StrSpnW|wchar*|wchar*
+wchar*|StrStrNIW|wchar*|wchar*|uint
+wchar*|StrStrNW|wchar*|wchar*|uint
+bool|StrToInt64ExA|char*|STIF_FLAGS|__out LONGLONG*
+bool|StrToInt64ExW|wchar*|STIF_FLAGS|__out LONGLONG*
+int|StrToIntA|char*
+bool|StrToIntExA|char*|STIF_FLAGS|__out int*
+bool|StrToIntExW|wchar*|STIF_FLAGS|__out int*
+int|StrToIntW|wchar*
+bool|StrTrimA|__inout char*|char*
+bool|StrTrimW|__inout wchar*|wchar*
+HRESULT|UrlApplySchemeA|char*|__out char*|__inout DWORD*|DWORD
+HRESULT|UrlApplySchemeW|wchar*|__out wchar*|__inout DWORD*|DWORD
+HRESULT|UrlCanonicalizeA|char*|__out char*|__inout DWORD*|DWORD
+HRESULT|UrlCanonicalizeW|wchar*|__out wchar*|__inout DWORD*|DWORD
+HRESULT|UrlCombineA|char*|char*|__out char*|__inout DWORD*|DWORD
+HRESULT|UrlCombineW|wchar*|wchar*|__out wchar*|__inout DWORD*|DWORD
+int|UrlCompareA|char*|char*|bool
+int|UrlCompareW|wchar*|wchar*|bool
+HRESULT|UrlCreateFromPathA|char*|__out char*|__inout DWORD*|DWORD
+HRESULT|UrlCreateFromPathW|wchar*|__out wchar*|__inout DWORD*|DWORD
+HRESULT|UrlEscapeA|char*|__out char*|__inout DWORD*|DWORD
+HRESULT|UrlEscapeW|wchar*|__out wchar*|__inout DWORD*|DWORD
+char*|UrlGetLocationA|char*
+wchar*|UrlGetLocationW|wchar*
+HRESULT|UrlGetPartA|char*|__out char*|__inout DWORD*|DWORD|DWORD
+HRESULT|UrlGetPartW|wchar*|__out wchar*|__inout DWORD*|DWORD|DWORD
+HRESULT|UrlHashA|char*|__out BYTE*|DWORD
+HRESULT|UrlHashW|wchar*|__out BYTE*|DWORD
+bool|UrlIsA|char*|URLIS
+bool|UrlIsNoHistoryA|char*
+bool|UrlIsNoHistoryW|wchar*
+bool|UrlIsOpaqueA|char*
+bool|UrlIsOpaqueW|wchar*
+bool|UrlIsW|wchar*|URLIS
+HRESULT|UrlUnescapeA|__inout char*|__out char*|__inout DWORD*|DWORD
+HRESULT|UrlUnescapeW|__inout wchar*|__out wchar*|__inout DWORD*|DWORD
+int|wnsprintfA|__out char*|int|char*|None # TODO: handle ...
+int|wnsprintfW|__out wchar*|int|wchar*|None # TODO: handle ...
+int|wvnsprintfA|__out char*|int|char*|va_list
+int|wvnsprintfW|__out wchar*|int|wchar*|va_list

--- a/drltrace/scripts/drltrace_test_expected.log
+++ b/drltrace/scripts/drltrace_test_expected.log
@@ -1,0 +1,94 @@
+~~~~ ADVAPI32.dll!RegOpenKeyExW
+    arg 0: type=<unknown>
+    arg 1: SOFTWARE\Microsoft\Windows\CurrentVersion\Run type=wchar_t*
+    arg 2: 0x0 type=DWORD
+    arg 3: type=<unknown>
+~~~~ ADVAPI32.dll!RegQueryValueExW
+    arg 0: type=<unknown>
+    arg 1: TestKey type=wchar_t*
+    arg 2: 0x00000000 type=DWORD*
+    arg 5: => 0x400 type=DWORD*
+~~~~ ADVAPI32.dll!RegCloseKey
+    arg 0: type=<unknown>
+~~~~ USER32.dll!RegisterClassW
+    arg 0: type=<unknown>*
+~~~~ USER32.dll!CreateWindowExW
+    arg 0: 0x0 type=DWORD
+    arg 1: Sample Window Class type=wchar_t*
+    arg 2: Test Window type=wchar_t*
+    arg 3: type=DWORD
+    arg 4: type=int
+    arg 5: type=int
+~~~~ USER32.dll!BeginPaint
+    arg 0: type=<unknown>
+~~~~ GDI32.dll!CreateFontA
+    arg 0: 0x30 type=int
+    arg 1: 0x0 type=int
+    arg 2: 0x0 type=int
+    arg 3: 0x0 type=int
+    arg 4: 0x0 type=int
+    arg 5: 0x0 type=DWORD
+    arg 6: 0x1 type=DWORD
+    arg 7: 0x0 type=DWORD
+    arg 8: 0x1 type=DWORD
+    arg 9: 0x8 type=DWORD
+    arg 10: type=DWORD
+    arg 11: 0x5 type=DWORD
+    arg 12: 0x2 type=DWORD
+    arg 13: Test CreateFont type=char*
+~~~~ GDI32.dll!SelectObject
+    arg 0: type=<unknown>
+    arg 1: type=<unknown>
+~~~~ USER32.dll!SetRect
+    arg 1: 0x64 type=int
+    arg 2: 0x64 type=int
+    arg 3: 0x2bc type=int
+    arg 4: 0xc8 type=int
+~~~~ GDI32.dll!SetTextColor
+    arg 0: type=<unknown>
+    arg 1: type=<unknown>
+~~~~ USER32.dll!DrawTextW
+    arg 0: type=<unknown>
+    arg 1: Test Text type=wchar_t*
+    arg 2: 0xffffffff type=int
+    arg 3: type=<unknown>*
+    arg 4: type=uint
+~~~~ GDI32.dll!DeleteObject
+    arg 0: type=<unknown>
+~~~~ USER32.dll!DestroyWindow
+    arg 0: type=<unknown>
+~~~~ USER32.dll!UnregisterClassW
+    arg 0: Sample Window Class type=wchar_t*
+    arg 1: type=<unknown>
+~~~~ WININET.dll!InternetCreateUrlW
+    arg 0: type=<unknown>*
+    arg 1: type=DWORD
+    arg 3: => 0x400 type=DWORD*
+~~~~ WININET.dll!InternetCanonicalizeUrlW
+    arg 0: http://drmemory.org/ docs type=wchar_t*
+    arg 2: => 0x400 type=DWORD*
+    arg 3: 0x80000000 type=DWORD
+~~~~ WS2_32.dll!gethostbyname
+    arg 0: http://drmemory.org type=char*
+~~~~ WS2_32.dll!WSAGetLastError
+    arg 0: type=void size=0x0
+~~~~ MSWSOCK.dll!GetTypeByNameA
+    arg 0: TEST SERVER type=char*
+    arg 1: type=<unknown>*
+~~~~ KERNEL32.dll!GetThreadLocale
+    arg 0: type=void size=0x0
+~~~~ OLEAUT32.dll!VarI4FromStr
+    arg 0: 01453 type=wchar_t*
+    arg 1: type=LCID
+    arg 2: type=<unknown>
+~~~~ ole32.dll!OleInitialize
+    arg 0: 0x00000000 => 0x00000000 type=void*
+~~~~ ole32.dll!OleSetClipboard
+    arg 0: <null> type=<unknown>*
+~~~~ ole32.dll!OleUninitialize
+    arg 0: 0x00000000 type=void
+~~~~ SHELL32.dll!PathIsExe
+    arg 0: C:\Windows\System32\calc.exe type=wchar_t*
+~~~~ SHLWAPI.dll!ParseURLW
+    arg 0: http://drmemory.org/docs type=wchar_t*
+    arg 1: type=<unknown>*

--- a/drltrace/scripts/gen_drltrace_config.py
+++ b/drltrace/scripts/gen_drltrace_config.py
@@ -40,6 +40,7 @@ import sys
 from os import listdir
 from os.path import isfile, join
 import argparse
+import operator
 
 types_map = {"BYTE":"BYTE",
 "WORD":"WORD",
@@ -613,12 +614,512 @@ types_map = {"BYTE":"BYTE",
 "FONTINFO":"FONTINFO",
 "EXTTEXTMETRIC":"EXTTEXTMETRIC",
 "CLIPLINE":"CLIPLINE",
-"BLENDOBJ":"BLENDOBJ",}
+"BLENDOBJ":"BLENDOBJ",
+"LRESULT":"LRESULT",
+"HSZ":"HSZ",
+"INT_PTR":"int",
+"DLGPROC":"DLGPROC",
+"LPMSG":"MSG*",
+"HCURSOR":"HCURSOR",
+"HCONV":"HCONV",
+"PUINT":"UINT*",
+"HOOKPROC":"HOOKPROC",
+"HDDEDATA":"HDDEDATA",
+"QS_INPUT":"QS_INPUT",
+"SHORT":"SHORT",
+"LPACCEL":"ACCEL*",
+"WNDENUMPROC":"WNDENUMPROC",
+"HGESTUREINFO":"HGESTUREINFO",
+"HCONVLIST":"HCONVLIST",
+"MSG":"MSG",
+"TIMERPROC":"TIMERPROC",
+"LPIMEPROA":"IMEPROA*",
+"LPIMEPROW":"IMEPROW*",
+"HDEVNOTIFY":"HDEVNOTIFY",
+"PBSMINFO":"BSMINFO*",
+"SIZE":"SIZE",
+"WNDPROC":"WNDPROC",
+"FARPROC":"FARPROC",
+"PCHANGEFILTERSTRUCT":"CHANGEFILTERSTRUCT*",
+"HTOUCHINPUT":"HTOUCHINPUT",
+"LPCDLGTEMPLATEA":"DLGTEMPLATEA*",
+"LPCDLGTEMPLATEW":"DLGTEMPLATEW*",
+"PICONINFO":"ICONINFO*",
+"PCONVCONTEXT":"CONVCONTEXT*",
+"PFNCALLBACK":"FNCALLBACK*",
+"PRAWINPUT":"RAWINPUT*",
+"DISPLAYCONFIG_DEVICE_INFO_HEADER":"DISPLAYCONFIG_DEVICE_INFO_HEADER",
+"DRAWSTATEPROC":"DRAWSTATEPROC",
+"LPDRAWTEXTPARAMS":"DRAWTEXTPARAMS*",
+"LPCRECT":"RECT*",
+"PALTTABINFO":"ALTTABINFO*",
+"PGESTURECONFIG":"GESTURECONFIG*",
+"LPMONITORINFO":"MONITORINFO*",
+"LPMOUSEMOVEPOINT":"MOUSEMOVEPOINT*",
+"PSECURITY_INFORMATION":"SECURITY_INFORMATION*",
+"WINDOWPLACEMENT":"WINDOWPLACEMENT",
+"GRAYSTRINGPROC":"GRAYSTRINGPROC",
+"LPCMENUITEMINFOA":"MENUITEMINFOA*",
+"LPCMENUITEMINFOW":"MENUITEMINFOW*",
+"DISPLAYCONFIG_PATH_INFO":"DISPLAYCONFIG_PATH_INFO",
+"DISPLAYCONFIG_MODE_INFO":"DISPLAYCONFIG_MODE_INFO",
+"HPOWERNOTIFY":"HPOWERNOTIFY",
+"SENDASYNCPROC":"SENDASYNCPROC",
+"HWINEVENTHOOK":"HWINEVENTHOOK",
+"PUINT_PTR":"UINT_PTR*",
+"LPPAINTSTRUCT":"PAINTSTRUCT*",
+"PCONVINFO":"CONVINFO*",
+"SECURITY_QUALITY_OF_SERVICE":"SECURITY_QUALITY_OF_SERVICE",
+"PSECURITY_QUALITY_OF_SERVICE":"SECURITY_QUALITY_OF_SERVICE*",
+"PAINTSTRUCT":"PAINTSTRUCT",
+"DESKTOPENUMPROCA":"DESKTOPENUMPROCA",
+"DESKTOPENUMPROCW":"DESKTOPENUMPROCW",
+"PDISPLAY_DEVICEA":"DISPLAY_DEVICEA*",
+"PDISPLAY_DEVICEW":"DISPLAY_DEVICEW*",
+"MONITORENUMPROC":"MONITORENUMPROC",
+"PROPENUMPROCA":"PROPENUMPROCA",
+"PROPENUMPROCEXA":"PROPENUMPROCEXA",
+"PROPENUMPROCEXW":"PROPENUMPROCEXW",
+"PROPENUMPROCW":"PROPENUMPROCW",
+"WINSTAENUMPROCA":"WINSTAENUMPROCA",
+"WINSTAENUMPROCW":"WINSTAENUMPROCW",
+"PFLASHWINFO":"FLASHWINFO*",
+"LPWNDCLASSA":"WNDCLASSA*",
+"LPWNDCLASSEXA":"WNDCLASSEXA*",
+"LPWNDCLASSEXW":"WNDCLASSEXW*",
+"LPWNDCLASSW":"WNDCLASSW*",
+"PCOMBOBOXINFO":"COMBOBOXINFO*",
+"PCURSORINFO":"CURSORINFO*",
+"PGUITHREADINFO":"GUITHREADINFO*",
+"PGESTUREINFO":"GESTUREINFO*",
+"PICONINFOEXA":"ICONINFOEXA*",
+"PICONINFOEXW":"ICONINFOEXW*",
+"PLASTINPUTINFO":"LASTINPUTINFO*",
+"PMENUBARINFO":"MENUBARINFO*",
+"LPMENUINFO":"MENUINFO*",
+"LPMENUITEMINFOA":"MENUITEMINFOA*",
+"LPMENUITEMINFOW":"MENUITEMINFOW*",
+"HRAWINPUT":"HRAWINPUT",
+"PRAWINPUTDEVICELIST":"RAWINPUTDEVICELIST*",
+"PRAWINPUTDEVICE":"RAWINPUTDEVICE*",
+"PSCROLLBARINFO":"SCROLLBARINFO*",
+"LPSCROLLINFO":"SCROLLINFO*",
+"PTITLEBARINFO":"TITLEBARINFO*",
+"PWINDOWINFO":"WINDOWINFO*",
+"MENUTEMPLATEA":"MENUTEMPLATEA",
+"MENUTEMPLATEW":"MENUTEMPLATEW",
+"MSGBOXPARAMSA":"MSGBOXPARAMSA",
+"MSGBOXPARAMSW":"MSGBOXPARAMSW",
+"DISPLAYCONFIG_TOPOLOGY_ID":"DISPLAYCONFIG_TOPOLOGY_ID",
+"WNDCLASSA":"WNDCLASSA",
+"WNDCLASSEXA":"WNDCLASSEXA",
+"WNDCLASSEXW":"WNDCLASSEXW",
+"WNDCLASSW":"WNDCLASSW",
+"PCRAWINPUTDEVICE":"CRAWINPUTDEVICE*",
+"LPINPUT":"INPUT*",
+"LPCMENUINFO":"MENUINFO*",
+"LPCSCROLLINFO":"SCROLLINFO*",
+"WINEVENTPROC":"WINEVENTPROC",
+"LPTRACKMOUSEEVENT":"TRACKMOUSEEVENT*",
+"LPTPMPARAMS":"TPMPARAMS*",
+"UPDATELAYEREDWINDOWINFO":"UPDATELAYEREDWINDOWINFO",
+"PRUNTIME_FUNCTION": "RUNTIME_FUNCTION*",
+"POEM_STRING": "OEM_STRING*",
+"in_addr": "in_addr",
+"in6_addr": "in6_addr",
+"PCUNICODE_STRING": "UNICODE_STRING*",
+"PWCH": "wchar*",
+"BOOLAPI": "bool",
+"HINTERNET":"HINTERNET",
+"GROUPID":"GROUPID",
+"LPINTERNET_CACHE_ENTRY_INFOA":"INTERNET_CACHE_ENTRY_INFOA*",
+"LPINTERNET_CACHE_ENTRY_INFOW":"INTERNET_CACHE_ENTRY_INFOW*",
+"LPINTERNET_BUFFERSA":"INTERNET_BUFFERSA*",
+"LPINTERNET_BUFFERSW":"INTERNET_BUFFERSW*",
+"INTERNET_PORT":"INTERNET_PORT",
+"PCCERT_CHAIN_CONTEXT":"CERT_CHAIN_CONTEXT*",
+"INTERNET_STATUS_CALLBACK":"INTERNET_STATUS_CALLBACK",
+"PDWORDLONG":"DWORDLONG*",
+"P3PHANDLE":"void*",
+"LPINTERNET_CACHE_CONTAINER_INFOA":"INTERNET_CACHE_CONTAINER_INFOA*",
+"LPINTERNET_CACHE_CONTAINER_INFOW":"INTERNET_CACHE_CONTAINER_INFOW*",
+"LPINTERNET_CACHE_CONFIG_INFOA":"INTERNET_CACHE_CONFIG_INFOA*",
+"LPINTERNET_CACHE_CONFIG_INFOW":"INTERNET_CACHE_CONFIG_INFOW*",
+"LPINTERNET_CACHE_GROUP_INFOA":"INTERNET_CACHE_GROUP_INFOA*",
+"LPINTERNET_CACHE_GROUP_INFOW":"INTERNET_CACHE_GROUP_INFOW*",
+"GOPHER_ATTRIBUTE_ENUMERATOR":"GOPHER_ATTRIBUTE_ENUMERATOR",
+"LPURL_COMPONENTSA":"URL_COMPONENTSA*",
+"LPURL_COMPONENTSW":"URL_COMPONENTSW*",
+"CACHE_OPERATOR":"CACHE_OPERATOR",
+"P3PURL":"char*",
+"P3PCURL":"char*",
+"P3PCXSL":"BSTR",
+"WPAD_CACHE_DELETE":"WPAD_CACHE_DELETE",
+"CLSID":"CLSID",
+"LPGOPHER_FIND_DATAA":"GOPHER_FIND_DATAA*",
+"LPGOPHER_FIND_DATAW":"GOPHER_FIND_DATAW*",
+"INTERNET_SCHEME":"INTERNET_SCHEME",
+"LPINTERNET_SECURITY_INFO":"INTERNET_SECURITY_INFO*",
+"BSTR":"BSTR",
+"SOCKET":"SOCKET",
+"SOCK_STREAM":"SOCK_STREAM",
+"SOCK_SEQPACKET":"SOCK_SEQPACKET",
+"SOCK_DGRAM":"SOCK_DGRAM",
+"IPV6STRICT":"IPV6STRICT",
+"SOCKADDR":"SOCKADDR",
+"MIDL":"MIDL",
+"LPWSADATA":"LPWSADATA",
+"FRAME_POINTERS":"FRAME_POINTERS",
+"fd_set": "fd_set",
+"sockaddr": "sockaddr",
+"u_long": "ulong",
+"u_short": "ushort",
+"u_int": "uint",
+"hostent": "hostent",
+"protoent": "protoent",
+"servent": "servent",
+"LPSERVICE_ASYNC_INFO": "SERVICE_ASYNC_INFO*",
+"LPSERVICE_INFOA": "SERVICE_INFOA*",
+"LPSERVICE_INFOW": "SERVICE_INFOW*",
+"LPTRANSMIT_FILE_BUFFERS": "TRANSMIT_FILE_BUFFERS*",
+"PCONTEXT_EX":"CONTEXT_EX*",
+"PUNICODE_STRING":"UNICODE_STRING*",
+"PRTL_RUN_ONCE":"RTL_RUN_ONCE*",
+"PIO_STATUS_BLOCK":"IO_STATUS_BLOCK*",
+"PCSZ":"char*",
+"PANSI_STRING":"ANSI_STRING*",
+"PUNWIND_HISTORY_TABLE":"UNWIND_HISTORY_TABLE*",
+"POBJECT_ATTRIBUTES":"OBJECT_ATTRIBUTES*",
+"PGET_RUNTIME_FUNCTION_CALLBACK":"GET_RUNTIME_FUNCTION_CALLBACK*",
+"PDWORD64":"DWORD64*",
+"_EXCEPTION_RECORD":"_EXCEPTION_RECORD",
+"PKNONVOLATILE_CONTEXT_POINTERS":"KNONVOLATILE_CONTEXT_POINTERS*",
+"PIO_APC_ROUTINE":"IO_APC_ROUTINE*",
+"PROCESSINFOCLASS":"PROCESSINFOCLASS",
+"THREADINFOCLASS":"THREADINFOCLASS",
+"OBJECT_INFORMATION_CLASS":"OBJECT_INFORMATION_CLASS",
+"SYSTEM_INFORMATION_CLASS":"SYSTEM_INFORMATION_CLASS",
+"PCANSI_STRING":"ANSI_STRING*",
+"SLIST_HEADER":"SLIST_HEADER",
+"PSTRING":"STRING*",
+"PRTL_RUN_ONCE_INIT_FN":"RTL_RUN_ONCE_INIT_FN*",
+"PEXCEPTION_ROUTINE":"EXCEPTION_ROUTINE*",
+"PFRAME_POINTERS":"FRAME_POINTERS*",
+"DL_EUI48":"DL_EUI48",
+"LPWSABUF":"WSABUF*",
+"LPWSAOVERLAPPED":"WSAOVERLAPPED*",
+"LPSOCKADDR":"SOCKADDR*",
+"LPWSAPROTOCOL_INFOW":"WSAPROTOCOL_INFOW*",
+"LPQOS":"QOS*",
+"LPWSAOVERLAPPED_COMPLETION_ROUTINE":"WSAOVERLAPPED_COMPLETION_ROUTINE*",
+"LPWSAPROTOCOL_INFOA":"WSAPROTOCOL_INFOA*",
+"LPLOOKUPSERVICE_COMPLETION_ROUTINE":"LOOKUPSERVICE_COMPLETION_ROUTINE*",
+"LPBLOB":"BLOB*",
+"LPWSAQUERYSETA":"WSAQUERYSETA*",
+"LPWSAQUERYSETW":"WSAQUERYSETW*",
+"PADDRINFOEXA":"ADDRINFOEXA*",
+"PADDRINFOEXW":"ADDRINFOEXW*",
+"PADDRINFOW":"ADDRINFOW*",
+"SOCKET_ADDRESS":"SOCKET_ADDRESS",
+"LPWSASERVICECLASSINFOA":"WSASERVICECLASSINFOA*",
+"LPWSASERVICECLASSINFOW":"WSASERVICECLASSINFOW*",
+"WSC_PROVIDER_INFO_TYPE":"WSC_PROVIDER_INFO_TYPE",
+"PADDRINFOA":"ADDRINFOA*",
+"PCHAR":"char*",
+"PMIB_IPNET_ROW2":"MIB_IPNET_ROW2*",
+"ADDRINFOEXA":"ADDRINFOEXA",
+"ADDRINFOEXW":"ADDRINFOEXW",
+"ADDRINFOW":"ADDRINFOW",
+"LPCONDITIONPROC":"CONDITIONPROC*",
+"LPCNSPV2_ROUTINE":"NSPV2_ROUTINE*",
+"PSOCKET_ADDRESS_LIST":"SOCKET_ADDRESS_LIST*",
+"LPWSANAMESPACE_INFOA":"WSANAMESPACE_INFOA*",
+"LPWSANAMESPACE_INFOEXA":"WSANAMESPACE_INFOEXA*",
+"LPWSANAMESPACE_INFOEXW":"WSANAMESPACE_INFOEXW*",
+"LPWSANAMESPACE_INFOW":"WSANAMESPACE_INFOW*",
+"LPWSANETWORKEVENTS":"WSANETWORKEVENTS*",
+"ADDRINFOA":"ADDRINFOA",
+"timeval": "timeval",
+"socklen_t": "socklen_t",
+"size_t": "size_t",
+"WSAEVENT": "WSAEVENT",
+"LPWSACOMPLETION": "WSACOMPLETION*",
+"LPWSAPOLLFD": "WSAPOLLFD*",
+"LPWSAMSG": "WSAMSG*",
+"WSAESETSERVICEOP": "WSAESETSERVICEOP",
+"GROUP": "GROUP",
+"VARIANT":"VARIANT",
+"LPSAFEARRAY":"SAFEARRAY*",
+"LPVARIANT":"VARIANT*",
+"DATE":"DATE",
+"LONG64":"LONG64",
+"SAFEARRAY":"SAFEARRAY",
+"VARIANT_BOOL":"VARIANT_BOOL",
+"DECIMAL":"DECIMAL",
+"LPDECIMAL":"DECIMAL*",
+"VARTYPE":"VARTYPE",
+"VARIANTARG":"VARIANTARG",
+"LPCY":"LPCY",
+"CY":"CY",
+"OLECHAR":"OLECHAR",
+"REFGUID":"REFGUID",
+"SYSKIND":"SYSKIND",
+"REFIID":"REFIID",
+"SAFEARRAYBOUND":"SAFEARRAYBOUND",
+"UDATE":"UDATE",
+"LPDISPATCH":"DISPATCH*",
+"DISPPARAMS":"DISPPARAMS",
+"DISPID":"DISPID",
+"REFCLSID":"REFCLSID",
+"NUMPARSE":"NUMPARSE",
+"LPBSTR":"BSTR*",
+"LPSTREAM":"STREAM*",
+"LPUNKNOWN":"UNKNOWN*",
+"OLE_COLOR":"OLE_COLOR",
+"HUGEP":"HUGEP",
+"EXCEPINFO":"EXCEPINFO",
+"INTERFACEDATA":"INTERFACEDATA",
+"CALLCONV":"CALLCONV",
+"LPCUSTDATA":"CUSTDATA*",
+"REGKIND":"REGKIND",
+"LPOCPFIPARAMS":"OCPFIPARAMS*",
+"LPCLSID":"CLSID*",
+"LPPICTDESC":"PICTDESC*",
+"LPFONTDESC":"FONTDESC*",
+"WINOLEAUTAPI":"HRESULT",
+"WINOLECTLAPI":"HRESULT",
+"STDAPI":"HRESULT",
+"float":"float",
+"double":"double",
+"IDispatch":"IDispatch",
+"ulong": "ulong",
+"uchar": "uchar",
+"ITypeInfo":"ITypeInfo",
+"IUnknown":"IUnknown",
+"IRecordInfo":"IRecordInfo",
+"ICreateTypeLib":"ICreateTypeLib",
+"ITypeLib":"ITypeLib",
+"ICreateTypeLib2":"ICreateTypeLib2",
+"IErrorInfo":"IErrorInfo",
+"ICreateErrorInfo":"ICreateErrorInfo",
+"CLIPFORMAT":"CLIPFORMAT",
+"LPSTORAGE":"STORAGE*",
+"LPMONIKER":"MONIKER*",
+"STGMEDIUM":"STGMEDIUM",
+"LPOLECLIENTSITE":"OLECLIENTSITE*",
+"LPFORMATETC":"FORMATETC*",
+"LPDATAOBJECT":"DATAOBJECT*",
+"PROPVARIANT":"PROPVARIANT",
+"LPOLEOBJECT":"OLEOBJECT*",
+"SNB":"SNB",
+"OLESTATUS":"OLESTATUS",
+"COSERVERINFO":"COSERVERINFO",
+"MULTI_QI":"MULTI_QI",
+"LPDATAADVISEHOLDER":"DATAADVISEHOLDER*",
+"LPOLECLIENT":"OLECLIENT*",
+"LHCLIENTDOC":"LHCLIENTDOC",
+"SERIALIZEDPROPERTYVALUE":"SERIALIZEDPROPERTYVALUE",
+"SOLE_AUTHENTICATION_SERVICE":"SOLE_AUTHENTICATION_SERVICE",
+"RPC_AUTH_IDENTITY_HANDLE":"RPC_AUTH_IDENTITY_HANDLE",
+"LPMESSAGEFILTER":"MESSAGEFILTER*",
+"LPBC":"LPBC",
+"LPLOCKBYTES":"LOCKBYTES*",
+"FMTID":"FMTID",
+"OLEOPT_RENDER":"OLEOPT_RENDER",
+"OLECLIPFORMAT":"OLECLIPFORMAT",
+"HOLEMENU":"HOLEMENU",
+"LPOLESTREAM":"OLESTREAM*",
+"LPOLEINPLACEFRAME":"OLEINPLACEFRAME*",
+"REFFMTID":"REFFMTID",
+"STGOPTIONS":"STGOPTIONS",
+"REFPROPVARIANT":"REFPROPVARIANT",
+"PROPVAR_CHANGE_FLAGS":"PROPVAR_CHANGE_FLAGS",
+"DDERR_NOTINITIALIZED":"DDERR_NOTINITIALIZED",
+"CO_E_NOTINITIALIZED":"CO_E_NOTINITIALIZED",
+"CLSCTX_INPROC_SERVER":"CLSCTX_INPROC_SERVER",
+"APTTYPE":"APTTYPE",
+"APTTYPEQUALIFIER":"APTTYPEQUALIFIER",
+"LPMALLOC":"MALLOC*",
+"BIND_OPTS":"BIND_OPTS",
+"LPMARSHAL":"MARSHAL*",
+"COMSD":"COMSD",
+"QUERYCONTEXT":"QUERYCONTEXT",
+"RPC_AUTHZ_HANDLE":"RPC_AUTHZ_HANDLE",
+"LPINITIALIZESPY":"INITIALIZESPY*",
+"LPMALLOCSPY":"MALLOCSPY*",
+"LPSURROGATE":"SURROGATE*",
+"LPOLEADVISEHOLDER":"OLEADVISEHOLDER*",
+"LPDROPSOURCE":"DROPSOURCE*",
+"LPRUNNINGOBJECTTABLE":"RUNNINGOBJECTTABLE*",
+"LPIID":"IID*",
+"LPCLASSFACTORY":"CLASSFACTORY*",
+"LPOLEMENUGROUPWIDTHS":"OLEMENUGROUPWIDTHS*",
+"LPENUMFORMATETC":"ENUMFORMATETC*",
+"LPENUMOLEVERB":"ENUMOLEVERB*",
+"LPPERSISTSTORAGE":"PERSISTSTORAGE*",
+"LPPERSISTSTREAM":"PERSISTSTREAM*",
+"LPOLEINPLACEACTIVEOBJECT":"OLEINPLACEACTIVEOBJECT*",
+"LPOLEINPLACEFRAMEINFO":"OLEINPLACEFRAMEINFO*",
+"LPDROPTARGET":"DROPTARGET*",
+"LPSTGMEDIUM":"STGMEDIUM*",
+"PROPID":"PROPID",
+"WINOLEAPI":"HRESULT",
+"uchar*":"uchar*",
+"PSSTDAPI":"HRESULT",
+"IBindCtx":"IBindCtx",
+"uCLSSPEC":"uCLSSPEC",
+"IChannelHook":"IChannelHook",
+"IBindStatusCallback":"IBindStatusCallback",
+"IAdviseSink":"IAdviseSink",
+"PMemoryAllocator":"PMemoryAllocator*",
+"IPropertySetStorage":"IPropertySetStorage",
+"IStorage":"IStorage",
+"SERIALIZEDPROPERTYVALUE":"SERIALIZEDPROPERTYVALUE",
+"IFillLockBytes":"IFillLockBytes",
+"SHSTDAPI":"HRESULT",
+"PCIDLIST_ABSOLUTE":"ITEMIDLIST_ABSOLUTE*",
+"PIDLIST_ABSOLUTE":"ITEMIDLIST_ABSOLUTE*",
+"PCUIDLIST_RELATIVE":"ITEMIDLIST_RELATIVE*",
+"PCUITEMID_CHILD":"ITEMID_CHILD*",
+"PIDLIST_RELATIVE":"IDLIST_RELATIVE*",
+"REFKNOWNFOLDERID":"REFKNOWNFOLDERID",
+"HDROP":"HDROP",
+"PCUITEMID_CHILD_ARRAY":"ITEMID_CHILD_ARRAY*",
+"SHFOLDERAPI":"HRESULT",
+"PUIDLIST_RELATIVE":"IDLIST_RELATIVE*",
+"HIMAGELIST":"HIMAGELIST",
+"HPSXA":"HPSXA",
+"PITEMID_CHILD":"ITEMID_CHILD*",
+"LPFNADDPROPSHEETPAGE":"FNADDPROPSHEETPAGE*",
+"GETPROPERTYSTOREFLAGS":"GETPROPERTYSTOREFLAGS",
+"REFPROPERTYKEY":"REFPROPERTYKEY",
+"SFGAOF":"SFGAOF",
+"LPSHQUERYRBINFO":"SHQUERYRBINFO*",
+"CABINETSTATE":"CABINETSTATE",
+"PROPSPEC":"PROPSPEC",
+"PUITEMID_CHILD":"ITEMID_CHILD*",
+"PZPCWSTR":"wchar**",
+"LPSHELLSTATE":"SHELLSTATE*",
+"SFVM_SETITEMPOS":"SFVM_SETITEMPOS",
+"FORMATETC":"FORMATETC",
+"PCUIDLIST_RELATIVE_ARRAY":"IDLIST_RELATIVE_ARRAY*",
+"RESTRICTIONS":"RESTRICTIONS",
+"AUTO_SCROLL_DATA":"AUTO_SCROLL_DATA",
+"LPCSHITEMID":"SHITEMID*",
+"LPCTSTR":"TCHAR*",
+"LPCSFV":"CSFV*",
+"ASSOCIATIONELEMENT":"ASSOCIATIONELEMENT",
+"PROPERTYKEY":"PROPERTYKEY",
+"LPWSTR*":"wchar**",
+"SFV_CREATE":"SFV_CREATE",
+"PAPPBARDATA":"APPBARDATA*",
+"ASSOC_FILTER":"ASSOC_FILTER",
+"LPBROWSEINFOA":"BROWSEINFOA*",
+"LPBROWSEINFOW":"BROWSEINFOW*",
+"DEFCONTEXTMENU":"DEFCONTEXTMENU",
+"PSHCREATEPROCESSINFOW":"SHCREATEPROCESSINFOW*",
+"PCIDLIST_ABSOLUTE_ARRAY":"LPCITEMIDLIST*",
+"LPSHFILEOPSTRUCTA":"SHFILEOPSTRUCTA*",
+"LPSHFILEOPSTRUCTW":"SHFILEOPSTRUCTW*",
+"SHFILEINFOA":"SHFILEINFOA",
+"SHFILEINFOW":"SHFILEINFOW",
+"DATAOBJ_GET_ITEM_FLAGS":"DATAOBJ_GET_ITEM_FLAGS",
+"SIGDN":"SIGDN",
+"GPFIDL_FLAGS":"int",
+"SHELLFLAGSTATE":"SHELLFLAGSTATE",
+"SHSTOCKICONID":"SHSTOCKICONID",
+"SHSTOCKICONINFO":"SHSTOCKICONINFO",
+"OPENASINFO":"OPENASINFO",
+"DEFINE_GUID":"DEFINE_GUID",
+"CLSID_WPD_NAMESPACE_EXTENSION":"CLSID_WPD_NAMESPACE_EXTENSION",
+"QUERY_USER_NOTIFICATION_STATE":"QUERY_USER_NOTIFICATION_STATE",
+"LIBRARYMANAGEDIALOGOPTIONS":"LIBRARYMANAGEDIALOGOPTIONS",
+"SHELLEXECUTEINFOA":"SHELLEXECUTEINFOA",
+"SHELLEXECUTEINFOW":"SHELLEXECUTEINFOW",
+"PNOTIFYICONDATAA":"NOTIFYICONDATAA*",
+"NOTIFYICONIDENTIFIER":"NOTIFYICONIDENTIFIER",
+"PNOTIFYICONDATAW":"NOTIFYICONDATAW*",
+"LPFNDFMCALLBACK":"FNDFMCALLBACK*",
+"LPSHFOLDERCUSTOMSETTINGS":"SHFOLDERCUSTOMSETTINGS*",
+"IShellFolder":"IShellFolder",
+"IShellItem":"IShellItem",
+"IDataObject":"IDataObject",
+"IPropertyStorage":"IPropertyStorage",
+"IStream":"IStream",
+"IShellView":"IShellView",
+"IShellItemArray":"IShellItemArray",
+"IEnumFORMATETC":"IEnumFORMATETC",
+"IShellBrowser":"IShellBrowser",
+"IStream*":"IStream*",
+"IDropSource":"IDropSource",
+"IContextMenu*":"IContextMenu*",
+"IPropertyStore":"IPropertyStore",
+"IEnumAssocHandlers":"IEnumAssocHandlers",
+"IFileOperation":"IFileOperation",
+"IFileOperationProgressSink":"IFileOperationProgressSink",
+"IContextMenu":"IContextMenu",
+"SHChangeNotifyEntry":"SHChangeNotifyEntry",
+"SHGetPathFromIDListEx":"SHGetPathFromIDListEx",
+"IShellFolder":"IShellFolder",
+"SCNRT_STATUS": "SCNRT_STATUS",
+"LWSTDAPI":"HRESULT",
+"HUSKEY":"HUSKEY",
+"ASSOCF":"ASSOCF",
+"SHREGENUM_FLAGS":"SHREGENUM_FLAGS",
+"STRRET":"STRRET",
+"ASSOCSTR":"ASSOCSTR",
+"SRRF":"SRRF",
+"PHUSKEY":"HUSKEY*",
+"SHREGDEL_FLAGS":"SHREGDEL_FLAGS",
+"STIF_FLAGS":"STIF_FLAGS",
+"SHGLOBALCOUNTER":"SHGLOBALCOUNTER",
+"SHCT_FLAGS":"SHCT_FLAGS",
+"ASSOCKEY":"ASSOCKEY",
+"URLIS":"URLIS",
+"PARSEDURLA":"PARSEDURLA",
+"PARSEDURLW":"PARSEDURLW",
+"IConnectionPoint":"IConnectionPoint",
+"LPCQITAB":"QITAB*",
+"IQueryAssociations":"IQueryAssociations",
+"PERCEIVED":"PERCEIVED",
+"PERCEIVEDFLAG":"PERCEIVEDFLAG",
+"PZPCSTR":"char**",
+"SFBS_FLAGS":"SFBS_FLAGS",
+"PFNALLOC":"FNALLOC*",
+"PFNFREE":"FNFREE*",
+"FNFREE":"FNFREE",
+"FNALLOC":"FNALLOC",
+"LPTSTR":"LPTSTR",
+"PERF":"PERF",
+"PFNWRITE":"FNWRITE*",
+"LPALLOCATEBUFFER":"ALLOCATEBUFFER*",
+"LPFREEBUFFER":"FREEBUFFER*",
+"PFNFCIFILEPLACED":"FNFCIFILEPLACED*",
+"PFNFCIALLOC":"FNFCIALLOC*",
+"PFNFCIFREE":"FNFCIFREE*",
+"PFNFCIOPEN":"FNFCIOPEN*",
+"PFNFCIREAD":"FNFCIREAD*",
+"PFNFCIWRITE":"FNFCIWRITE*",
+"PFNFCICLOSE":"FNFCICLOSE*",
+"PFNFCISEEK":"FNFCISEEK*",
+"PFNFCIDELETE":"FNFCIDELETE*",
+"PFNFCIGETTEMPFILE":"FNFCIGETTEMPFILE*",
+"PCCAB":"CCAB*",
+"PFNOPEN":"FNOPEN*",
+"PFNREAD":"FNREAD*",
+"PFNCLOSE":"FNCLOSE*",
+"PFNSEEK":"FNSEEK*",
+"uint":"uint"
+}
 
 
 tokens_ignore_prefix = {"APIENTRY", "virtual", "DECLSPEC_NORETURN", "__kernel_entry",
 "W32KAPI", "WINGDIAPI", "__gdi_entry", "WMIAPI", "EXTERN_C", "WINADVAPI", "extern",
-"D2D1FORCEINLINE", "__kernel_entry"}
+"D2D1FORCEINLINE", "__kernel_entry", "WINUSERAPI",  "WSAAPI", "__checkReturn",
+"WINSOCK_API_LINKAGE", "WINGDIPAPI", "WINAPI", "PASCAL", "FAR", "NTAPI",
+"WSPAPI", "__RPC_USER", "WINSHELLAPI", "UNALIGNED"}
+
+types_in_parentheses = {"SHSTDAPI_", "LWSTDAPIV_", "STDAPI_"}
 
 unknown_types = dict() # We use this dictionary to save and print a list of unknown types.
 
@@ -645,22 +1146,37 @@ def parse_return_type(line):
     @in line - a string with a type to find.
     @out - returning type.
     '''
+    # There are return types that defined in parentheses (e.g. SHSTDAPI_(BOOL)).
+    for type_in_parentheses in types_in_parentheses:
+        if type_in_parentheses in line:
+            line = line[line.find('_')+1:]
+            line = line.replace("(", "")
+            line = line.replace(")", "")
+            break
+
     if ")" in line:
         line = remove_internal_parentheses(line)
 
     line = line.split(" ")
     func_type = None
     type_token_count = 0
+    uprefix = ""
     for element in line:
         if element in tokens_ignore_prefix or element == "" or "__" in element\
-           or (("WIN" in element or "NT" in element) and "API" in element):
+           or "//" in element or "/*" in element or "*\\" in element:
+            continue
+        if get_type(element) == None and ("WIN" in element or "NT" in element)\
+           and "API" in element:
+            continue
+        if "unsigned" in element:
+            uprefix = 'u'
             continue
         # Let's return "None" if we have more than 2 tokens that look like candidates for
         # the return type.
         if type_token_count >= 1:
-            print "Warning. Failed to parse line %s (%s)" % (line, element)
+            print("Warning. Failed to parse line %s (%s)" % (line, element))
             return "None"
-        func_type = element
+        func_type = uprefix + element
         type_token_count += 1
 
     if func_type != None:
@@ -738,7 +1254,7 @@ def parse_line(line, name):
     @in name - a name of WinAPI function.
     @out - a string with a function return type, name and arguments separated by |.
     '''
-
+    line = line.replace(" *", "*")
     prefix = line[:line.find(name)]
     suffix = line[line.find(name)+len(name) + 1:]
     new_prefix = parse_return_type(prefix)
@@ -756,10 +1272,24 @@ def check_api_exist(api_name, prototype_line):
     prototype_line = prototype_line[:-1]
     prototype_line = prototype_line.split(" ")
     for element in prototype_line:
-        element = element[:element.find("(")]
-        if element == api_name or element == "NtGdi" + api_name:
+        if element.find("(") != -1:
+            element = element[:element.find("(")]
+        if element == api_name or element == "NtGdi" + api_name or \
+        element == "NtUser" + api_name:
             return 1
     return 0
+
+def api_already_added(api_name, apis_added):
+    return api_name in apis_added
+
+
+def str2bool(v):
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description = "The script is used for searching of"
@@ -769,19 +1299,29 @@ if __name__ == "__main__":
     default = "results\\")
     parser.add_argument('-parse_specific_file', help = "The option is used to specify for"
 " the script only a single file")
-
+    parser.add_argument("--skip_duplicates", type=str2bool, nargs='?', const=True, default=False,
+                        help="If specified the script will not parse API calls that exist in the config.")
     args = parser.parse_args()
 
     export_files = list()
     if args.parse_specific_file == None:
-        print "Parsing all files from %s" % args.results_path
+        print("Parsing all files from %s" % args.results_path)
         export_files = [f for f in listdir(args.results_path) if isfile(join(args.results_path, f))]
     else:
-        print "Parsing %s from %s" % (args.parse_specific_file, args.results_path)
+        print("Parsing %s from %s" % (args.parse_specific_file, args.results_path))
         if not args.parse_specific_file.endswith(".headers_out"):
-            print "File should end with *.headers_out"
+            print("File should end with *.headers_out")
             sys.exit(-1)
         export_files.append(args.parse_specific_file)
+
+    apis_added = list()
+    if args.skip_duplicates == True:
+        config = open("drltrace_win.config" , 'r').readlines()
+
+        for line in config:
+            if "|" not in line or line.startswith("#"):
+                continue
+            apis_added.append(line.split("|")[1])
 
     for file in export_files:
         if not file.endswith(".headers_out"): # parse only output of headers_parser.py
@@ -811,14 +1351,19 @@ if __name__ == "__main__":
             # check_api_entries function.
             if check_api_exist(name, function_str) == 0:
                 continue
+            # There are exported functions that were already added in the config. The user has
+            # option to skip parsing and outputing of such entries.
+            if args.skip_duplicates == True and api_already_added(name, apis_added):
+                print("Skipping duplicate %s" % name)
+                continue
             final_str = parse_line(function_str, name)
             file_write.write(line + "\n")
             file_write.write(final_str + "\n\n")
 
-    result = sorted( ((v,k) for k,v in unknown_types.iteritems()), reverse=True)
+    result = sorted(unknown_types.items(), key=operator.itemgetter(1), reverse = True)
     final_line = ""
-    for count, element in result:
-        if element.isupper(): # Types in Windows are usually in uppercase.
+    for element, count in result:
+        if element.isupper() or element.startswith("I") or element.startswith("SH"): # Types in Windows are usually in uppercase.
             final_line += "\"%s\":\"%s\", " % (element, element)
     file_write.write(final_line + "\n")
     file_write.close()

--- a/drltrace/scripts/test_drltrace_out.py
+++ b/drltrace/scripts/test_drltrace_out.py
@@ -1,0 +1,164 @@
+# ***************************************************************************
+# Copyright (c) 2017 Google, Inc.  All rights reserved.
+# ***************************************************************************
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Google, Inc. nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+#
+# ******************************************************************************
+# The script is used to search for expected API calls and their arguments in the
+# output of drltrace. The script uses an external file which contains a list of
+# strings for checking. Each string should have only constant elements that do
+# not change from run to run or depend on machine architecture.
+# For example:
+# ~~6048~~ ADVAPI32.dll!RegQueryValueExW => ~~~~ ADVAPI32.dll!RegQueryValueExW
+# arg 5: 0x001df390 => 0x400 (type=DWORD*, size=0x4) => arg 5: => 0x400 type=DWORD*
+
+import os
+import sys
+import subprocess
+
+def parse_drltrace_log(log_content, allow_api_duplicates):
+    '''
+    The function is used to parse drltrace output format and represents it as
+    a dictionary in the following way: {API name: [list of arguments]}.
+
+    @in log_content - drltrace output (or expected results) to parse.
+    @in allow_api_duplicates - if True, the function will add unique id for
+                               each duplicate and save them in a dictionary.
+                               if False, the function will print error and exit
+                               in case when duplicates exist.
+    @out - dictionary, where a key is API call name and value is a list of its
+           arguments.
+    '''
+
+    log_dict = dict()
+    api_call_to_add = ""
+    for i, line_to_check in enumerate(log_content):
+        # search for API calls
+        if line_to_check.startswith("~~") and "!" in line_to_check:
+            line_to_check = line_to_check.replace("~","")
+            api_call_to_add = line_to_check
+            api_call_exist_name = log_dict.get(api_call_to_add, None)
+            if api_call_exist_name != None:
+                if allow_api_duplicates == True:
+                    # append unique id (line number)
+                    api_call_to_add = api_call_to_add + "_" + str(i)
+                else:
+                    print("Found duplicates while parsing the log file, exit.")
+                    sys.exit(-1)
+
+            log_dict[api_call_to_add] = list() # List will store arguments.
+            continue
+        if api_call_to_add != '':
+             # It means that we are parsing arguments of API call found above.
+            log_dict[api_call_to_add].append(line_to_check)
+    return log_dict
+
+def check_args(args_expected, args_log):
+    '''
+    The function is used to compare expected arguments with arguments printed
+    by drltrace.
+    @in args_expected - expected arguments.
+    @in args_log - arguments printed by drltrace.
+    @out - True, if arguments are the same.
+           False, otherwise.
+    '''
+
+    for i, arg_expected in enumerate(args_expected):
+        arg_expected = arg_expected[:-1]
+        # First, take "arg x" string as a separate element.
+        arg_expected = arg_expected.split(":")
+        arg_id = arg_expected[0]
+        arg_expected = arg_expected[1] # the rest
+        arg_element = arg_expected.split(" ")
+        arg_element.append(arg_id)
+        for element in arg_element:
+            if element == "":
+                continue
+            if element not in args_log[i]:
+                print "Failed to find %s" % element
+                # It doesn't mean that the whole test is failed, probably, we
+                # pick an API call with different set arguments.
+                return False
+    return True
+
+def check_log_file(log_output, expected_log_path):
+    '''
+    The main function for expected results checking.
+
+    @in log_output - content of the drltrace log.
+    @in expected_log_path - a path where expected log file located.
+    @out -1, if the function failed to find at least one string from expected log.
+          0, otherwise.
+    '''
+    api_calls_found_not_found = dict()
+    has_errors = 0
+
+    # read and parse expected log file and drltrace output
+    expected_log_content = open(expected_log_path, 'r').readlines()
+    expected_log_dict = parse_drltrace_log(expected_log_content, False)
+    log_dict = parse_drltrace_log(log_output.split("\n"), True)
+
+    print("Comparing log with expected results")
+    for key_expected, args_expected in expected_log_dict.iteritems():
+        key_expected = key_expected[:-1] # remove "\n"
+        for key_log, args_log in log_dict.iteritems():
+            if key_expected in key_log:
+                # We managed to find API call, let's check its arguments.
+                if check_args(args_expected, args_log) == True:
+                    api_calls_found_not_found[key_expected] = 1
+                    break
+        if api_calls_found_not_found.get(key_expected, None) == None:
+            api_calls_found_not_found[key_expected] = 0
+
+    # print results and setup return value accordingly
+    for key, value in api_calls_found_not_found.iteritems():
+        if value == 1:
+            print("Found %s" % key)
+        else:
+            print("Not found %s" % key)
+            has_errors = -1
+    return has_errors
+
+def main():
+    expected_log_path = sys.argv[1]
+    drltrace_bin_path = sys.argv[2]
+    drltrace_test_app_path = sys.argv[3]
+    command = "%s -logdir - -num_max_args 15 -- %s" %\
+             (drltrace_bin_path, drltrace_test_app_path)
+    print("Running the following command %s" % command)
+    p = subprocess.Popen(command,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err = p.communicate() # Wait while the child process finished.
+    if p.returncode != 0:
+        print("drltrace finished with error %d" % p.returncode)
+        sys.exit(p.returncode)
+    # Drltrace prints output in STDERR when symbol '-' is specified.
+    res = check_log_file(err, expected_log_path)
+    sys.exit(res)
+if __name__ == "__main__":
+    main()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -527,7 +527,9 @@ if (UNIX)
           VERBATIM)
       add_custom_target("${kmod_name}"
           DEPENDS "${kmod_bin}")
-      add_dependencies(syscalls_unix "${kmod_name}")
+      if (NOT X64) # FIXME i#111: failing on Travis
+        add_dependencies(syscalls_unix "${kmod_name}")
+      endif ()
       set(kmod_build_files "${kmod_bin_dir}/modules.order"
           "${kmod_bin_dir}/Module.symvers"
           "${kmod_bin_dir}/${kmod_name}.c"

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -124,6 +124,11 @@ add_drmf_test(drsyscall_test drsyscall_app drsyscall_client.c
 add_drmf_test(strace_test drsyscall_app strace_client.c
   drsyscall "" "done\n.*TEST PASSED")
 
+# drltrace tests
+if (WIN32)
+  add_drmf_test_app(drltrace_test_app drltrace_test_app.cpp)
+endif ()
+
 # drfuzz tests
 add_drmf_test_app(drfuzz_app_empty drfuzz_app_empty.c)
 add_drmf_test(drfuzz_test_empty drfuzz_app_empty drfuzz_client_empty.c

--- a/tests/framework/drltrace_test_app.cpp
+++ b/tests/framework/drltrace_test_app.cpp
@@ -1,0 +1,289 @@
+/* ***************************************************************************
+ * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * ***************************************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <Windows.h>
+#include <Wininet.h>
+#include <Nspapi.h>
+#include <shlobj.h>
+#include <atlbase.h>
+#include <shlobj.h>
+
+#pragma comment(lib, "wininet.lib")
+#pragma comment(lib, "ws2_32.lib")
+#pragma comment(lib, "Mswsock.lib")
+
+#define MAX_KEY_VALUE_LEN 512
+#define TEST_VALUE_TO_CONVERT 1453
+#define TEST_STR_TO_CONVERT L"01453"
+
+LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+void exit(unsigned int exit_code)
+{
+    TerminateProcess(GetCurrentProcess(), exit_code);
+}
+
+void print_error_and_exit(const char *msg)
+{
+    printf("%s, GetLastError = %d", msg, GetLastError());
+    exit(-1);
+}
+
+void call_advapi32()
+{
+    /* functions from advapi32.dll */
+    HKEY hKey;
+    WCHAR szBuffer[MAX_KEY_VALUE_LEN];
+    DWORD dwBufferSize = sizeof(szBuffer);
+    LONG lRes;
+
+    lRes = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                         L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
+                         0, KEY_READ, &hKey);
+    if (lRes != ERROR_SUCCESS)
+        print_error_and_exit("RegOpenKeyExW failed");
+
+    lRes = RegQueryValueExW(hKey, L"TestKey", 0, NULL,
+                            (LPBYTE)szBuffer, &dwBufferSize);
+    if (lRes != ERROR_FILE_NOT_FOUND)
+        print_error_and_exit("RegQueryValueExW returned unexpected value");
+
+    lRes = RegCloseKey(hKey);
+    if (lRes != ERROR_SUCCESS)
+        print_error_and_exit("RegCloseKey failed");
+
+    printf("tests for advapi32.dll successfully done\n");
+}
+
+void call_gdi32_user32()
+{
+    /* group of functions from gdi32.dll/user32.dll */
+    HWND hwnd;
+    RECT rect;
+    HGDIOBJ hObj;
+    HFONT hFont;
+    PAINTSTRUCT ps;
+    HDC hdc;
+    const wchar_t CLASS_NAME[] = L"Sample Window Class";
+    ATOM result = 0;
+    WNDCLASSW wc = {};
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = GetModuleHandle(NULL);
+    wc.lpszClassName = CLASS_NAME;
+
+    if (RegisterClassW(&wc) == NULL)
+        print_error_and_exit("RegisterClassW");
+
+    hwnd = CreateWindowW(CLASS_NAME, L"Test Window", WS_OVERLAPPEDWINDOW,
+                         CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                         CW_USEDEFAULT, NULL, NULL, wc.hInstance, NULL);
+    if (hwnd == NULL)
+        print_error_and_exit("CreateWindowW failed");
+
+    hdc = BeginPaint(hwnd, &ps);
+    if (hdc == NULL)
+        print_error_and_exit("BeginPaint failed");
+
+    hFont = CreateFontA(48, 0, 0, 0, FW_DONTCARE, FALSE, TRUE, FALSE,
+                        DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
+                        CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH,
+                        TEXT("Test CreateFont"));
+    if (hFont == NULL)
+        print_error_and_exit("CreateFontA failed");
+
+    hObj = SelectObject(hdc, hFont);
+    if (hObj == NULL || hObj == HGDI_ERROR)
+        print_error_and_exit("SelectObject failed");
+
+    /* Sets the coordinates for the rectangle in which the text is to be
+     * formatted.
+     */
+    if (SetRect(&rect, 100, 100, 700, 200) == NULL)
+        print_error_and_exit("SetRect failed");
+
+    if (SetTextColor(hdc, RGB(255, 0, 0)) == CLR_INVALID)
+        print_error_and_exit("SetTextColor failed");
+
+    if (DrawTextW(hdc, L"Test Text", -1, &rect, DT_NOCLIP) == NULL)
+        print_error_and_exit("DrawTextW failed");
+
+    if (DeleteObject(hObj) == false)
+        print_error_and_exit("DeleteObject failed");
+
+    if (DestroyWindow(hwnd) == false)
+        print_error_and_exit("DestroyWindow failed");
+
+    if (UnregisterClassW(CLASS_NAME, wc.hInstance) == false)
+        print_error_and_exit("UnregisterClassW failed");
+
+    printf("tests for user32/gdi32 dlls successfully done\n");
+}
+
+void call_wininet()
+{
+    /* functions from wininet.dll */
+    URL_COMPONENTSW url;
+    LPWSTR url_created = (LPWSTR)malloc(1024);
+    LPWSTR url_canonic = (LPWSTR)malloc(1024);
+    DWORD cchBuffer = 1024, cchBuffer2 = 1024;
+    url.dwStructSize = sizeof(url);
+    url.lpszScheme = NULL;
+    url.dwSchemeLength = 0;
+    url.nScheme = INTERNET_SCHEME_DEFAULT;
+    url.lpszHostName = NULL;
+    url.dwHostNameLength = NULL;
+    url.lpszUrlPath = L"drmemory.org/ docs";
+    url.dwUrlPathLength = wcslen(L"drmemory.org/ docs");
+    url.nPort = INTERNET_DEFAULT_HTTP_PORT;
+    url.lpszUserName = NULL;
+    url.dwUserNameLength = NULL;
+    url.lpszPassword = NULL;
+    url.dwPasswordLength = NULL;
+    url.lpszExtraInfo = NULL;
+    url.dwExtraInfoLength = NULL;
+
+    if (!InternetCreateUrlW(&url, 0, url_created, &cchBuffer))
+        print_error_and_exit("InternetCreateUrlW failed");
+
+    if (!InternetCanonicalizeUrlW(url_created, url_canonic, &cchBuffer2,
+                                  ICU_ESCAPE))
+        print_error_and_exit("InternetCanonicalizeUrlW failed");
+
+    printf("created url = %ws\ncanonicalized url = %ws\n", url_created,
+           url_canonic);
+    free(url_created);
+    free(url_canonic);
+    printf("tests for wininet.dll successfully done\n");
+}
+
+void call_w2_32_wsock32()
+{
+    /* functions from w2_32.dll and wsock32.dll */
+    int error_code;
+    GUID guid;
+
+    /* WSAStartup should be called before gethostbyname, so the function below
+     * will always fail (to test on machines without Internet access).
+     */
+    gethostbyname("http://drmemory.org");
+    error_code = WSAGetLastError();
+    if (error_code != WSANOTINITIALISED) {
+        printf("gethostbyname returned unexpected error code = %d", error_code);
+        exit(-1);
+    }
+
+    error_code = GetTypeByNameA("TEST SERVER", &guid);
+    if (error_code != SOCKET_ERROR) {
+        printf("GetTypeByNameA returned unexpected error code = %d",
+               error_code);
+        exit(-1);
+    }
+    printf("tests for w2_32.dll and wsock32.dll successfully done\n");
+}
+
+void call_oleaut32()
+{
+    /* functions from oleaut32.dll */
+    int error_code;
+    long value = 0;
+
+    LCID locale = GetThreadLocale();
+    error_code = VarI4FromStr(TEST_STR_TO_CONVERT, locale,
+                              LOCALE_NOUSEROVERRIDE, &value);
+    if (error_code != S_OK)
+        print_error_and_exit("VarI4FromStr failed");
+
+    if (value != TEST_VALUE_TO_CONVERT) {
+        printf("VarI4FromStr failed to convert the string, error code = %d",
+               error_code);
+        exit(-1);
+    }
+    printf("tests for oleaut32.dll successfully done\n");
+
+}
+
+void call_ole32()
+{
+    /* functions from ole32.dll */
+    HRESULT res;
+
+    res = OleInitialize(NULL);
+    if (res != S_OK)
+        print_error_and_exit("OleInitialize failed");
+
+    CComPtr<IDataObject> spdto;
+    res = OleSetClipboard(spdto);
+    if (res != S_OK)
+        print_error_and_exit("OleSetClipboard failed");
+
+    spdto.Release();
+    OleUninitialize();
+    printf("tests for ole32.dll successfully done\n");
+}
+
+void call_shlwapi_shell32()
+{
+    /* functions from shlwapi.dll and shell32.dll */
+    HRESULT res;
+
+    PARSEDURLW *parsed_url = (PARSEDURLW *)malloc(sizeof(PARSEDURLW));
+    parsed_url->cbSize = sizeof(PARSEDURLW);
+
+    if (!PathIsExe(L"C:\\Windows\\System32\\calc.exe"))
+        print_error_and_exit("PathIsExe failed");
+
+    res = ParseURLW(L"http://drmemory.org/docs", parsed_url);
+    if (res != S_OK)
+        print_error_and_exit("ParseURLW failed");
+
+    free(parsed_url);
+    printf("tests for shlwapi.dll and shell32.dll successfully done\n");
+}
+
+LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+}
+
+int _tmain(int argc, _TCHAR* argv[])
+{
+    call_advapi32();
+    call_gdi32_user32();
+    call_wininet();
+    call_w2_32_wsock32();
+    call_oleaut32();
+    call_ole32();
+    call_shlwapi_shell32();
+    printf("All tests successfully done\n");
+    return 0;
+}
+


### PR DESCRIPTION
Added function prototypes for the following dlls:
user32.dll, ntdll.dll, wininet.dll, wsock32.dll, ws2_32.dll
oleaut32.dll, ole32.dll, shell32.dll, shlwapi.dll.

Added test application that uses functions from the following dlls:
advapi32.dll, gdi32.dll, wininet.dll, wsock32.dll, ws2_32.dll,
oleaut32.dll, ole32.dll, shell32.dll, shlwapi.dll

Added external python script for comparing expected log with drltrace
output.

Fixed syscall_unix test compilation problem in case of 64-bit Unix.

Fixes #2057