### PR TITLE
DRi#241: use new kernel xfer events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,7 +807,7 @@ else ()
 endif ()
 
 # when updating this, also update the git submodule
-set(DynamoRIO_VERSION_REQUIRED "6.1.17042")
+set(DynamoRIO_VERSION_REQUIRED "6.2.17499")
 
 set(DR_install_dir "dynamorio")
 

--- a/common/alloc.h
+++ b/common/alloc.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -439,24 +439,6 @@ client_handle_heap_destroy(void *drcontext, HANDLE heap, void *client_data);
 
 void
 client_remove_malloc_on_destroy(HANDLE heap, byte *start, byte *end);
-
-/* called BEFORE drmgr has popped the child context */
-void
-client_handle_cbret(void *drcontext);
-
-/* called AFTER drmgr has pushed a new context */
-void
-client_handle_callback(void *drcontext);
-
-/* for is_cb, called AFTER drmgr has pushed a new context */
-void
-client_handle_Ki(void *drcontext, app_pc pc, dr_mcontext_t *mc, bool is_cb);
-
-void
-client_handle_exception(void *drcontext, dr_mcontext_t *mc);
-
-void
-client_handle_continue(void *drcontext, dr_mcontext_t *mc);
 
 bool
 is_in_seh(void *drcontext);

--- a/drheapstat/drheapstat.c
+++ b/drheapstat/drheapstat.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1045,31 +1045,6 @@ client_remove_malloc_on_destroy(HANDLE heap, byte *start, byte *end)
 {
     if (options.check_leaks)
         leak_remove_malloc_on_destroy(heap, start, end);
-}
-
-void
-client_handle_cbret(void *drcontext)
-{
-}
-
-void
-client_handle_callback(void *drcontext)
-{
-}
-
-void
-client_handle_Ki(void *drcontext, app_pc pc, dr_mcontext_t *mc, bool is_cb)
-{
-}
-
-void
-client_handle_exception(void *drcontext, dr_mcontext_t *mc)
-{
-}
-
-void
-client_handle_continue(void *drcontext, dr_mcontext_t *mc)
-{
 }
 #endif /* WINDOWS */
 

--- a/drmemory/alloc_drmem.h
+++ b/drmemory/alloc_drmem.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -29,10 +29,6 @@
 
 #include "callstack.h" /* app_loc_t */
 
-#ifdef UNIX
-extern hashtable_t sighand_table;
-#endif
-
 void
 alloc_drmem_init(void);
 
@@ -43,13 +39,12 @@ bool
 check_unaddressable_exceptions(bool write, app_loc_t *loc, app_pc addr, uint sz,
                                bool addr_on_stack, dr_mcontext_t *mc);
 
+void
+event_kernel_xfer(void *drcontext, const dr_kernel_xfer_info_t *info);
+
 #ifdef UNIX
 dr_signal_action_t
 event_signal_alloc(void *drcontext, dr_siginfo_t *info);
-
-void
-instrument_signal_handler(void *drcontext, instrlist_t *bb, instr_t *inst,
-                          app_pc pc);
 
 bool
 mmap_anon_lookup(byte *addr, byte **start OUT, size_t *size OUT);

--- a/drmemory/drmemory.c
+++ b/drmemory/drmemory.c
@@ -1213,8 +1213,8 @@ set_thread_initial_structures(void *drcontext)
      * can set base part of stack for primary thread.
      * For drinject, stack is clean, except on Vista where a few words
      * are above esp.
-     * Note that this is the start esp: the APC esp is handled in
-     * client_handle_Ki.
+     * Note that this is the start esp, due to DRi#2718: the APC esp is handled in
+     * handle_Ki().
      */
     IF_DEBUG(ok = )
         dr_get_mcontext(drcontext, &mc);
@@ -1935,6 +1935,7 @@ dr_init(client_id_t id)
     dr_register_nudge_event(event_nudge, client_id);
     if (options.soft_kills)
         drx_register_soft_kills(event_soft_kill);
+    drmgr_register_kernel_xfer_event(event_kernel_xfer);
 #ifdef UNIX
     dr_register_fork_init_event(event_fork);
     drmgr_register_signal_event(event_signal);

--- a/drmemory/instru.c
+++ b/drmemory/instru.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1164,13 +1164,6 @@ instru_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
             }
         }
     }
-
-#if defined(UNIX) && defined(TOOL_DR_MEMORY)
-    if (options.shadowing &&
-        hashtable_lookup(&sighand_table, (void*)pc) != NULL) {
-        instrument_signal_handler(drcontext, bb, inst, pc);
-    }
-#endif
 
     if (INSTRUMENT_MEMREFS()) {
         /* We want to spill AFTER any clean call in case it changes mcontext */

--- a/drmemory/spill.c
+++ b/drmemory/spill.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1347,13 +1347,16 @@ fastpath_top_of_bb(void *drcontext, void *tag, instrlist_t *bb, bb_info_t *bi)
 {
     instr_t *inst = instrlist_first(bb);
 #ifdef DEBUG
-    app_pc prev_pc = dr_fragment_app_pc(tag);
-    ASSERT(prev_pc != NULL, "bb tag must not be NULL");
+    /* We look at instr pc, not the tag, to handle displaced code such
+     * as for the vsyscall hook.
+     */
+    app_pc prev_pc = instr_get_app_pc(instrlist_first_app(bb));
+    ASSERT(prev_pc != NULL, "bb first app pc must not be NULL");
     /* i#260 and i#1466: bbs must be contiguous */
     if (inst != NULL && whole_bb_spills_enabled() &&
         /* bi->is_repstr_to_loop is set in app2app and may mess up the instr pc */
         !bi->is_repstr_to_loop) {
-        for (; inst != NULL; inst = instr_get_next(inst)) {
+        for (; inst != NULL; inst = instr_get_next_app(inst)) {
             app_pc cur_pc = instr_get_app_pc(inst);
             if (cur_pc == NULL)
                 continue;


### PR DESCRIPTION
Adds use of DR's new kernel xfer events, eliminating the need to wrap the
Ki routines and watch several system calls.  Removes those events from the
alloc.h interface in favor of local kernel xfer events in the user.
Removes app signal handler tracking which is no longer needed.

Updates DR to fa465385.  Relaxes an assert triggered by DR's ea84da0
regarding handling displaced vsyscall code