### PR TITLE
DRi#1967 cron builds: Travis and Appveyor deployment

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2017-2018 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -92,3 +92,29 @@ build_script:
   - echo %PATH%
   # The perl in c:\perl can't open a pipe so we use cygwin perl.
   - c:\cygwin\bin\perl ../tests/runsuite_wrapper.pl travis use_ninja %EXTRA_ARGS%
+
+# Automated deployment of builds to GitHub Releases.
+# We rely on a Travis cron job to push a tag to the repo which then
+# triggers this deployment.
+# We disable test running for these package builds in runsuite.cmake by
+# looking for $APPVEYOR_REPO_TAG=="true".
+# XXX i#1967: build an .msi package as well.
+artifacts:
+  - path: 'build\build_*\DrMemory*.zip'
+    name: DrMem.zip
+    type: zip
+deploy:
+  provider: GitHub
+  auth_token:
+    secure: mfNFJ47dV/0CNpg156CiHuK3t6VUNCVhAIYNVkJfwjwY0dbhD1kIdMPfTMdarCnz
+  artifact: DrMem.zip
+  draft: false
+  prerelease: false
+  # We want to use the same release as Travis.
+  force_update: true
+  # Using the default "release:" name (the tag) to match Travis.
+  # This description replaces the one provided by Travis.
+  description: 'Auto-generated periodic build (Appveyor build $(appveyor_build_version)).'
+  on:
+    branch: master
+    appveyor_repo_tag: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,13 @@ jobs:
   include:
     - os: linux
       compiler: gcc
+      env: DEPLOY=yes
     - os: linux
       compiler: clang
     - os: osx
       # gcc on Travis claims to not be CMAKE_COMPILER_IS_GNUCC so we only run clang.
       compiler: clang
+      env: DEPLOY=yes
       # XXX: DRi#2764: Travis OSX resources are over-subscribed and it can take
       # hours to get an OSX machine, so we skip running PR's for now.
       if: type = push
@@ -67,3 +69,32 @@ install:
 
 script:
   - tests/runsuite_wrapper.pl travis
+
+# We disable test running for these package builds in runsuite.cmake by
+# looking for $TRAVIS_EVENT_TYPE=="cron".
+# Longer-term we may want to use package.cmake instead and even make official
+# builds on Travis (DRi#2861).
+before_deploy:
+  - git config --local user.name "Travis Auto-Tag"
+  - git config --local user.email "drmemory-devs@googlegroups.com"
+  # XXX: for now we duplicate this version number here with CMakeLists.txt.
+  # We should find a way to share (xref DRi#1565).
+  # We support setting TAG_SUFFIX on triggered builds so we can have
+  # multiple unique tags in one day (the patchlevel here is the day number).
+  - export GIT_TAG="cronbuild-1.11.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
+  - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
+deploy:
+  provider: releases
+  api_key:
+    secure: V3kgcRiwijjpmcSuVio1+/oZ8cqJGaVlL42hN0w/jjO6LoELy2kknT5h80H7wMVKpZnMg+2v/yWj5hawlrwh8nCS51lYllPHN7K+ivzkyJ3R4cp1WAzL56vnYFYz1/twYpeS10Zl6JL6wt788WcibpShMOIlAnXnm1kU9BBVtYE=
+  file_glob: true
+  file: "build*/DrMemory*.tar.gz"
+  skip_cleanup: true
+  # The name must just be the tag in order to match Appveyor.
+  name: $GIT_TAG
+  # This body is clobbered by Appveyor.
+  body: "Auto-generated periodic build (Travis build $TRAVIS_BUILD_NUMBER)."
+  on:
+    repo: DynamoRIO/drmemory
+    branch: master
+    condition: $TRAVIS_EVENT_TYPE = cron && $DEPLOY = yes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -231,6 +231,8 @@ if (APPLE)
   math(EXPR VERSION_NUMBER_PATCHLEVEL "(${VERSION_NUMBER_PATCHLEVEL} % 200) + 56")
 endif (APPLE)
 
+# N.B.: when updating this, update the git tag in .travis.yml.
+# We should find a way to share (xref DRi#1565).
 set(VERSION_NUMBER_DEFAULT "1.11.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default TOOL_VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir.


### PR DESCRIPTION
Adds deployment of Travis and Appveyor-built zip packages to a fresh GitHub
Release following the scheme developed for DR.