### PR TITLE
i#1795 drreg: cleanup: remove -single_arg_slowpath

### DIFF
--- a/drmemory/client_per_thread.h
+++ b/drmemory/client_per_thread.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -49,7 +49,10 @@ typedef struct _cls_drmem_t {
 # endif
 #endif /* TOOL_DR_MEMORY */
 
-    /* for jmp-to-slowpath optimization where we xl8 to get app pc (PR 494769) */
+    /* Was mostly used for jmp-to-slowpath optimization where we xl8
+     * to get app pc (PR 494769) which was now removed, but also used
+     * for logging.
+     */
     bool self_translating;
 
     /* for i#471 and i#1453: mem2mem via fp or mm reg heuristic */

--- a/drmemory/drmemory.c
+++ b/drmemory/drmemory.c
@@ -242,8 +242,6 @@ dump_statistics(void)
                pop_slowpath+pop_fastpath+pop4_fastpath);
     dr_fprintf(f_global, "slow instead of fast: %8u, b/c unaligned: %8u, 8@border: %8u\n",
                slow_instead_of_fast, slowpath_unaligned, slowpath_8_at_border);
-    dr_fprintf(f_global, "app instrs: fastpath: %7u, no dup: %7u, xl8: %7u\n",
-               app_instrs_fastpath, app_instrs_no_dup, xl8_app_for_slowpath);
     dr_fprintf(f_global, "addr exceptions: header: %7u, tls: %5u, alloca: %5u\n",
                heap_header_exception, tls_exception, alloca_exception);
     dr_fprintf(f_global, "more addr exceptions: ld DR: %5u, cpp DR: %5u\n",

--- a/drmemory/fastpath.c
+++ b/drmemory/fastpath.c
@@ -53,17 +53,7 @@ slow_path_xl8_sharing(app_loc_t *loc, size_t inst_sz, opnd_t memop, dr_mcontext_
     app_pc pc;
     bool translated = true;
     ASSERT(loc != NULL && loc->type == APP_LOC_PC, "invalid param");
-    if (options.single_arg_slowpath) {
-        /* We don't want to pay the xl8 cost every time so we have
-         * an additional entry for the cache pc and we only xl8 when
-         * that crosses the threshold.  This may be superior anyway since
-         * app pc can be duplicated in other bbs where it might behave
-         * differently (though seems unlikely).
-         */
-        translated = loc->u.addr.valid;
-        pc = loc->u.addr.pc;
-    } else
-        pc = loc_to_pc(loc);
+    pc = loc_to_pc(loc);
     xl8_sharing_cnt = (uint)(ptr_uint_t) hashtable_lookup(&xl8_sharing_table, pc);
     if (xl8_sharing_cnt > 0) {
         STATS_INC(xl8_shared_slowpath_count);

--- a/drmemory/fastpath.h
+++ b/drmemory/fastpath.h
@@ -129,8 +129,6 @@ typedef struct _fastpath_info_t {
     reg_id_t reg3_8;
     /* is this instr using shared xl8? */
     bool use_shared;
-    /* for jmp-to-slowpath optimization (PR 494769) */
-    instr_t *appclone;
     instr_t *slow_store_retaddr;
     instr_t *slow_store_retaddr2; /* if takes 2 instrs */
     opnd_t slow_store_dst;

--- a/drmemory/optionsx.h
+++ b/drmemory/optionsx.h
@@ -858,10 +858,6 @@ OPTION_CLIENT_STRING(internal, libc_addrs, "",
 OPTION_CLIENT_BOOL(internal, check_push, true,
                    "Check that pushes are writing to unaddressable memory",
                    "Check that pushes are writing to unaddressable memory")
-OPTION_CLIENT_BOOL(internal, single_arg_slowpath, false,
-                   /* XXX: PR 494769: this feature is not yet finished */
-                   "Use single arg for jmp-to-slowpath and derive second",
-                   "Use single arg for jmp-to-slowpath and derive second")
 OPTION_CLIENT_BOOL(internal, repstr_to_loop, true,
                    "Add fastpath for rep string instrs by converting to normal loop",
                    "Add fastpath for rep string instrs by converting to normal loop")

--- a/drmemory/slowpath.h
+++ b/drmemory/slowpath.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -41,7 +41,6 @@
 
 /* we only need a little over 2 pages for whole_bb_spills_enabled(): could get
  * onto 2 pages by not emitting SPILL_REG_NONE.
- * -no_single_arg_slowpath needs only 10 pages.
  */
 #ifdef X64
 /* linux needs 14 pages, windows needs 16 pages */
@@ -153,9 +152,6 @@ extern uint slowpath_unaligned;
 extern uint slowpath_8_at_border;
 extern uint alloc_stack_count;
 extern uint delayed_free_bytes;
-extern uint app_instrs_fastpath;
-extern uint app_instrs_no_dup;
-extern uint xl8_app_for_slowpath;
 extern uint num_bbs;
 
 # ifdef X86

--- a/drmemory/spill.c
+++ b/drmemory/spill.c
@@ -408,8 +408,7 @@ event_restore_state(void *drcontext, bool restore_memory, dr_restore_state_info_
 
     /* Are we asking DR to translate just pc?  Then return true and ignore regs */
     if (cpt->self_translating) {
-        ASSERT(options.single_arg_slowpath || options.verbose >= 3,
-               "only used for single_arg_slowpath or -verbose 3+");
+        ASSERT(options.verbose >= 3, "only used for -verbose 3+");
         return true;
     }
 #endif


### PR DESCRIPTION
-single_arg_slowpath was never 100% robust, never the default, and its use
of decoding would likely have outweighted the performance gains from the
slimmer code cache footprint.  We remove it to simplify the code.