### PR TITLE
i#2083 x64 reach: put DrM lib in low mem

### DIFF
--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -104,9 +104,12 @@
  *   default 128MB reservation.  DR is more efficient when all its
  *   allocations are inside its reservation.
  * DRi#1081: we disable reset until the DR bug is fixed.
+ * i#2083: disable hard-to-reach tables via -no_vm_base_near_app until a long-term
+ *   fix is in place that loads tables via an extra scratch reg.
  */
 #define DEFAULT_DR_OPS \
-    "-disable_traces -bb_single_restore_prefix -max_bb_instrs 256 -vm_size 256M -no_enable_reset"
+    "-disable_traces -bb_single_restore_prefix -max_bb_instrs 256 -vm_size 256M "\
+    "-no_enable_reset -no_vm_base_near_app"
 
 #define DRMEM_CLIENT_ID 0
 


### PR DESCRIPTION
As a short-term workaround for x64 reachability problems with shadow tables
that are currently directly accessed with displacements, we add to the
default DR options "-no_vm_base_near_app".  Long-term we need to get a
local scratch register and load the table base into it, which will be much
easier with drreg (#1795).

Tested on both Windows with x64 full mode enabled and on Linux in a distro
where this assert is hit.

Issue: #2083