### PR TITLE
i#2118: use long jump for 16-byte address checks

### DIFF
--- a/drmemory/fastpath_x86.c
+++ b/drmemory/fastpath_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1836,7 +1836,11 @@ add_addressing_register_checks(void *drcontext, instrlist_t *bb, instr_t *inst,
             add_jcc_slowpath(drcontext, bb, inst,
                              /* short doesn't quite reach for mem2mem's 1st check
                               * FIXME: use short for 2nd though! */
+                             /* XXX DRi#56: have a pass to auto-convert short jumps
+                              * to long that don't reach; some new drx_ utility maybe. */
                              (mi->mem2mem || mi->load2x ||
+                              /* i#2118: 16-byte add_check_partial_undefined() */
+                              mi->memsz > 8 ||
                               /* new zero-src check => require long */
                               instr_needs_all_srcs_and_vals(inst) ||
                               (mi->memsz < 4 && !opnd_is_null(mi->src[1].app))) ?
@@ -1855,6 +1859,8 @@ add_addressing_register_checks(void *drcontext, instrlist_t *bb, instr_t *inst,
             mark_eflags_used(drcontext, bb, mi->bb);
             add_jcc_slowpath(drcontext, bb, inst,
                              (mi->mem2mem || mi->load2x ||
+                              /* i#2118: 16-byte add_check_partial_undefined() */
+                              mi->memsz > 8 ||
                               /* new zero-src check => require long */
                               instr_needs_all_srcs_and_vals(inst) ||
                               (mi->memsz < 4 && !opnd_is_null(mi->src[1].app))) ?

--- a/tests/asmtest_x86.c
+++ b/tests/asmtest_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -462,7 +462,7 @@ GLOBAL_LABEL(FUNCNAME:)
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
         mov      eax, 0
-        movdqu   [8 + REG_XSP + REG_XAX], xmm0
+        movdqu   XMMWORD [8 + REG_XSP + REG_XAX], xmm0
         ret
         END_FUNC(FUNCNAME)
 #undef FUNCNAME

--- a/tests/asmtest_x86.c
+++ b/tests/asmtest_x86.c
@@ -32,6 +32,7 @@
 void asm_test(char *undef, char *def);
 void asm_test_avx(char *undef, char *def);
 void asm_test_i1680(char *buf);
+void asm_test_reach(void);
 
 static void
 asm_test_C(void)
@@ -41,6 +42,7 @@ asm_test_C(void)
     asm_test(undef, def);
     asm_test_avx(undef, def);
     asm_test_i1680(def);
+    asm_test_reach();
 }
 
 int
@@ -449,6 +451,18 @@ GLOBAL_LABEL(FUNCNAME:)
         add      REG_XSP, 0 /* make a legal SEH64 epilog */
         mov      REG_XSP, REG_XBP
         pop      REG_XBP
+        ret
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+
+#define FUNCNAME asm_test_reach
+/* Tests i#2118 reachability. */
+/* void asm_test_reach(); */
+        DECLARE_FUNC_SEH(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        mov      eax, 0
+        movdqu   [8 + REG_XSP + REG_XAX], xmm0
         ret
         END_FUNC(FUNCNAME)
 #undef FUNCNAME


### PR DESCRIPTION
16-byte memrefs end up with long instrumentation sequences from
add_check_partial_undefined()'s list of shadow pattern possibilities.
We use a longer jump to avoid reachability issues.

Adds a test to asmtest.

Fixes #2118