### PR TITLE
i#2122: fix shadow size underflow

### DIFF
--- a/umbra/umbra.c
+++ b/umbra/umbra.c
@@ -51,11 +51,9 @@ static bool   umbra_initialized;
 ptr_uint_t
 umbra_map_scale_app_to_shadow(umbra_map_t *map, ptr_uint_t value)
 {
-    if (UMBRA_MAP_SCALE_IS_DOWN(map->options.scale)) {
+    if (UMBRA_MAP_SCALE_IS_DOWN(map->options.scale))
         value >>= map->shift;
-        if (value == 0)
-            value = 1;
-    } else if (UMBRA_MAP_SCALE_IS_UP(map->options.scale))
+    else if (UMBRA_MAP_SCALE_IS_UP(map->options.scale))
         value <<= map->shift;
     return value;
 }

--- a/umbra/umbra.c
+++ b/umbra/umbra.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -51,9 +51,11 @@ static bool   umbra_initialized;
 ptr_uint_t
 umbra_map_scale_app_to_shadow(umbra_map_t *map, ptr_uint_t value)
 {
-    if (UMBRA_MAP_SCALE_IS_DOWN(map->options.scale))
+    if (UMBRA_MAP_SCALE_IS_DOWN(map->options.scale)) {
         value >>= map->shift;
-    else if (UMBRA_MAP_SCALE_IS_UP(map->options.scale))
+        if (value == 0)
+            value = 1;
+    } else if (UMBRA_MAP_SCALE_IS_UP(map->options.scale))
         value <<= map->shift;
     return value;
 }

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1031,7 +1031,7 @@ umbra_value_in_shadow_memory_arch(IN    umbra_map_t *map,
     /* i#1260: end pointers are all closed (i.e., inclusive) to handle overflow */
     app_pc app_blk_base, app_blk_end, app_src_end;
     app_pc start, end;
-    byte  *shadow_start, *shadow_addr;
+    byte  *shadow_start, *shadow_addr = NULL;
     size_t shadow_size, iter_size;
 
     if (value > USHRT_MAX || (value_size != 1 && value_size != 2))
@@ -1064,9 +1064,8 @@ umbra_value_in_shadow_memory_arch(IN    umbra_map_t *map,
         shadow_size = umbra_map_scale_app_to_shadow(map, iter_size);
         if (value_size == 1) {
             shadow_addr = memchr(shadow_start, (int)value, shadow_size);
-        } else {
+        } else if (shadow_size > 0) {
             byte *first_byte = shadow_start;
-            shadow_addr = NULL;
             while (first_byte != NULL) {
                 first_byte = memchr(first_byte, (char)value,
                                     shadow_size - 1 - (first_byte - shadow_start));


### PR DESCRIPTION
When scaling down, if we hit 0, we should bump up to 1.  Leaving at 0 leads
to an underflow in umbra_value_in_shadow_memory() which leads to a crash.

Fixes #2122