### PR TITLE
Update non-Windows base version to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_deploy:
   # We should find a way to share (xref DRi#1565).
   # We support setting TAG_SUFFIX on triggered builds so we can have
   # multiple unique tags in one day (the patchlevel here is the day number).
-  - export GIT_TAG="cronbuild-1.11.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
+  - export GIT_TAG="cronbuild-2.0.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
   - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
 deploy:
   provider: releases

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,10 +233,16 @@ endif (APPLE)
 
 # N.B.: when updating this, update the git tag in .travis.yml.
 # We should find a way to share (xref DRi#1565).
-set(VERSION_NUMBER_DEFAULT "1.11.${VERSION_NUMBER_PATCHLEVEL}")
-# do not store the default TOOL_VERSION_NUMBER in the cache to prevent a stale one
+if (WIN32)
+  # Windows is still missing 64-bit uninitialized read support so we're still calling
+  # it 1.11.xxx.
+  set(VERSION_NUMBER_DEFAULT "1.11.${VERSION_NUMBER_PATCHLEVEL}")
+else ()
+  set(VERSION_NUMBER_DEFAULT "2.0.${VERSION_NUMBER_PATCHLEVEL}")
+endif ()
+# Do not store the default TOOL_VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir.
-# avoid "VERSION_NUMBER" name since conflics w/ DR's var
+# Avoid "VERSION_NUMBER" name since conflics w/ DR's var.
 set(TOOL_VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")
 if ("${TOOL_VERSION_NUMBER}" STREQUAL "")
   set(TOOL_VERSION_NUMBER ${VERSION_NUMBER_DEFAULT})


### PR DESCRIPTION
The version split when we added 64-bit full mode to UNIX and released
it as 2.0.x before it was ready for Windows.  The cronbuilds were
using the 1.11.x Windows number so we could share the same Github
version, but that just caused (justifiable) confusion.  Here we bump
the version to 2.0 for UNIX but leave it at 1.11 for Windows, which
will result in different git tags and cronbuilds until we get Windows
up to 2.0.