### PR TITLE
i#1848 gensysnums: Fix x64 symbol fetch error

### DIFF
--- a/tests/addronly-reg.res
+++ b/tests/addronly-reg.res
@@ -24,13 +24,13 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1318
+registers.c_asm.asm:1380
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1330
+registers.c_asm.asm:1392
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1343
+registers.c_asm.asm:1405
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1344
+registers.c_asm.asm:1406
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/bitfield.strict.res
+++ b/tests/bitfield.strict.res
@@ -24,29 +24,29 @@ Error #2: UNINITIALIZED READ
 bitfield.cpp:54
 %if WINDOWS
 Error #3: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:812
+bitfield.cpp_asm.asm:874
 Error #4: UNINITIALIZED READ: reading register bl
-bitfield.cpp_asm.asm:825
+bitfield.cpp_asm.asm:887
 Error #5: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:833
+bitfield.cpp_asm.asm:895
 Error #6: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:838
+bitfield.cpp_asm.asm:900
 Error #7: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:847
+bitfield.cpp_asm.asm:909
 Error #8: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:850
+bitfield.cpp_asm.asm:912
 Error #9: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:855
+bitfield.cpp_asm.asm:917
 Error #10: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:858
+bitfield.cpp_asm.asm:920
 Error #11: UNINITIALIZED READ: reading register dl
-bitfield.cpp_asm.asm:882
+bitfield.cpp_asm.asm:944
 Error #12: UNINITIALIZED READ: reading register esi
-bitfield.cpp_asm.asm:883
+bitfield.cpp_asm.asm:945
 Error #13: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:897
+bitfield.cpp_asm.asm:959
 Error #14: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:908
+bitfield.cpp_asm.asm:970
 %endif
 %if UNIX
 Error #3: UNINITIALIZED READ: reading register ecx

--- a/tests/registers.blacklist.res
+++ b/tests/registers.blacklist.res
@@ -21,13 +21,13 @@
 #
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1318
+registers.c_asm.asm:1380
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1330
+registers.c_asm.asm:1392
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1343
+registers.c_asm.asm:1405
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1344
+registers.c_asm.asm:1406
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)

--- a/tests/registers.pattern.res
+++ b/tests/registers.pattern.res
@@ -24,9 +24,9 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1318
+registers.c_asm.asm:1380
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1330
+registers.c_asm.asm:1392
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -21,39 +21,39 @@
 #
 %if WINDOWS
 Error #1: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1291
+registers.c_asm.asm:1353
 Error #2: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1298
+registers.c_asm.asm:1360
 Error #3: UNINITIALIZED READ: reading 2 byte(s)
 registers.c:104
 Error #4: UNINITIALIZED READ: reading register ax
-registers.c_asm.asm:1518
+registers.c_asm.asm:1580
 Error #5: UNINITIALIZED READ: reading register dx
-registers.c_asm.asm:1535
+registers.c_asm.asm:1597
 Error #6: UNINITIALIZED READ: reading register ah
-registers.c_asm.asm:1565
+registers.c_asm.asm:1627
 Error #7: UNINITIALIZED READ: reading 1 byte(s)
 registers.c:187
 Error #8: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1267
+registers.c_asm.asm:1329
 Error #9: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1092
+registers.c_asm.asm:1154
 Error #10: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1096
+registers.c_asm.asm:1158
 Error #11: UNINITIALIZED READ: reading register cl
-registers.c_asm.asm:1101
+registers.c_asm.asm:1163
 Error #12: UNINITIALIZED READ: reading register ecx
-registers.c_asm.asm:1121
+registers.c_asm.asm:1183
 Error #13: UNINITIALIZED READ: reading 8 byte(s)
-registers.c_asm.asm:1152
+registers.c_asm.asm:1214
 Error #14: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1318
+registers.c_asm.asm:1380
 Error #15: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1330
+registers.c_asm.asm:1392
 Error #16: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1343
+registers.c_asm.asm:1405
 Error #17: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1344
+registers.c_asm.asm:1406
 %endif
 %if UNIX
 Error #1: UNINITIALIZED READ: reading register eflags
@@ -99,7 +99,7 @@ registers.c_asm.asm:970
 %endif
 %if WINDOWS
 Error #19: UNINITIALIZED READ: reading register ecx
-registers.c_asm.asm:1660
+registers.c_asm.asm:1722
 %endif
 Error #20: UNINITIALIZED READ: reading register
 registers.c:267
@@ -107,15 +107,15 @@ Error #21: UNINITIALIZED READ: reading register
 registers.c:288
 %if WINDOWS
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1745
+registers.c_asm.asm:1807
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1759
+registers.c_asm.asm:1821
 Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1773
+registers.c_asm.asm:1835
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1787
+registers.c_asm.asm:1849
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1822
+registers.c_asm.asm:1884
 %endif
 %if UNIX
 Error #22: UNINITIALIZED READ: reading 1 byte(s)


### PR DESCRIPTION
Updates DR to 191c479 to fix an error in
drfront_fetch_module_symbols() when loading 64-bit symbols.

Issue: #1848