### PR TITLE
i#1848: auto-generate a syscall file on a new OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1376,7 +1376,8 @@ if (USE_DRSYMS)
   set(DynamoRIO_RPATH ON)
   configure_DynamoRIO_standalone(${toolname})
   set(DynamoRIO_RPATH ${old_rpath})
-  target_link_libraries(${toolname} drinjectlib drconfiglib drfrontendlib)
+  target_link_libraries(${toolname} drinjectlib drconfiglib drfrontendlib
+    drsyscall_static)
   if (WIN32)
     set_target_properties(${toolname} PROPERTIES
       VERSION ${TOOL_VERSION_NUMBER}

--- a/common/utils.c
+++ b/common/utils.c
@@ -45,7 +45,7 @@
 /* globals that affect NOTIFY* and *LOG* macros */
 int tls_idx_util = -1;
 bool op_print_stderr = true;
-uint op_verbose_level;
+int op_verbose_level;
 bool op_pause_at_assert;
 bool op_pause_via_loop;
 bool op_ignore_asserts;

--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -694,6 +694,43 @@ process_results_file(const char *logdir, const char *symdir,
         info("skipping symbol fetching");
     }
 }
+
+static bool
+generate_sysnum_file(const char *symdir)
+{
+    int i;
+    size_t lib_count = 0;
+    char **sysnum_lib_paths;
+    void *drcontext = dr_standalone_init();
+    if (drcontext == NULL)
+        return false;
+    char outfile[MAXIMUM_PATH];
+    _snprintf(outfile, BUFFER_SIZE_ELEMENTS(outfile), "%s%c%s",
+              symdir, DIRSEP, dr_is_wow64() ? SYSNUM_FILE_WOW64 : SYSNUM_FILE);
+    NULL_TERMINATE_BUFFER(outfile);
+    drmf_status_t res = drsys_find_sysnum_libs(NULL, &lib_count);
+    if (res != DRMF_ERROR_INVALID_SIZE)
+        return false;
+    sysnum_lib_paths = malloc(lib_count * sizeof(sysnum_lib_paths[0]));
+    if (sysnum_lib_paths == NULL)
+        return false;
+    for (i = 0; i < lib_count; ++i) {
+        sysnum_lib_paths[i] = malloc(MAXIMUM_PATH);
+        if (sysnum_lib_paths[i] == NULL)
+            return false;
+    }
+    res = drsys_find_sysnum_libs(sysnum_lib_paths, &lib_count);
+    if (res != DRMF_SUCCESS)
+        return false;
+    if (drcontext == NULL)
+        return false;
+    res = drsys_generate_sysnum_file
+        (drcontext, sysnum_lib_paths, lib_count, outfile, symdir);
+    for (i = 0; i < lib_count; ++i)
+        free(sysnum_lib_paths[i]);
+    free(sysnum_lib_paths);
+    return (res == DRMF_SUCCESS);
+}
 #endif /* WINDOWS */
 
 /* check client options and abort on an option error */
@@ -743,6 +780,7 @@ _tmain(int argc, TCHAR *targv[])
     bool use_root_for_logdir;
 #ifdef WINDOWS
     char *pidfile = NULL;
+    bool tried_generating_syscall_file = false;
 #endif
 #ifndef MACOS /* XXX i#1286: implement nudge on MacOS */
     process_id_t nudge_pid = 0;
@@ -928,6 +966,20 @@ _tmain(int argc, TCHAR *targv[])
 	}
         else if (strcmp(argv[i], "-v") == 0) {
             verbose = true;
+            /* Enable verbosity in pdf2sysfile.cpp */
+            op_verbose_level = 1;
+            continue;
+        }
+        else if (strcmp(argv[i], "-vv") == 0) {
+            verbose = true;
+            /* Enable verbosity in pdf2sysfile.cpp */
+            op_verbose_level = 2;
+            continue;
+        }
+        else if (strcmp(argv[i], "-vvv") == 0) {
+            verbose = true;
+            /* Enable extra verbosity in pdf2sysfile.cpp */
+            op_verbose_level = 3;
             continue;
         }
         else if (strcmp(argv[i], "-h") == 0 ||
@@ -1397,133 +1449,159 @@ _tmain(int argc, TCHAR *targv[])
     dr_get_config_dir(false/*local*/, true/*use temp*/, buf, BUFFER_SIZE_ELEMENTS(buf));
     info("DynamoRIO configuration directory is %s", buf);
 
+    do {
 #ifdef UNIX
-    errcode = dr_inject_prepare_to_exec(app_name, (const char **)app_argv, &inject_data);
+        errcode = dr_inject_prepare_to_exec(app_name, (const char **)app_argv,
+                                            &inject_data);
 #else
-    errcode = dr_inject_process_create(app_name, (const char **)app_argv, &inject_data);
+        errcode = dr_inject_process_create(app_name, (const char **)app_argv,
+                                           &inject_data);
 #endif
-    if (errcode != 0) {
+        if (errcode != 0) {
 #ifdef WINDOWS
-        int sofar =
+            int sofar =
 #endif
-            _snprintf(buf, BUFFER_SIZE_ELEMENTS(buf),
-                      "failed to create process (err=%d) for \"%s\": ",
-                      errcode, app_name);
+                _snprintf(buf, BUFFER_SIZE_ELEMENTS(buf),
+                          "failed to create process (err=%d) for \"%s\": ",
+                          errcode, app_name);
 #ifdef WINDOWS
-        if (sofar > 0) {
-            FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                          NULL, errcode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                          (LPTSTR) buf + sofar,
-                          BUFFER_SIZE_ELEMENTS(buf) - sofar*sizeof(char), NULL);
+            if (sofar > 0) {
+                FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                              NULL, errcode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                              (LPTSTR) buf + sofar,
+                              BUFFER_SIZE_ELEMENTS(buf) - sofar*sizeof(char), NULL);
+            }
+#endif
+            NULL_TERMINATE_BUFFER(buf);
+            fatal("%s", buf);
+            goto error; /* actually won't get here */
         }
-#endif
-        NULL_TERMINATE_BUFFER(buf);
-        fatal("%s", buf);
-        goto error; /* actually won't get here */
-    }
 
-    pid = dr_inject_get_process_id(inject_data);
+        pid = dr_inject_get_process_id(inject_data);
 #ifdef WINDOWS
-    if (pidfile != NULL)
-        write_pid_to_file(pidfile, pid);
+        if (pidfile != NULL)
+            write_pid_to_file(pidfile, pid);
 #endif
 
-    /* we need to locate the results file, but only for top-level process (i#328) */
-    BUFPRINT(client_ops, BUFFER_SIZE_ELEMENTS(client_ops),
-             cliops_sofar, len, "-resfile %d ", pid);
+        /* we need to locate the results file, but only for top-level process (i#328) */
+        BUFPRINT(client_ops, BUFFER_SIZE_ELEMENTS(client_ops),
+                 cliops_sofar, len, "-resfile %d ", pid);
 
-    process = dr_inject_get_image_name(inject_data);
-    /* we don't care if this app is already registered for DR b/c our
-     * this-pid config will override
-     */
-    info("configuring %s pid=%d dr_ops=\"%s\"", process, pid, dr_ops);
-    status = dr_register_process(process, pid,
-                                 false/*local*/, dr_root,  DR_MODE_CODE_MANIPULATION,
-                                 use_dr_debug, DR_PLATFORM_DEFAULT, dr_ops);
-    if (status != DR_SUCCESS) {
-        const char *err_msg = dr_config_status_code_to_string(status);
-        fatal("failed to register DynamoRIO configuration for \"%s\"(%d) "
-              "dr_ops=\"%s\".\n"
-              "Error code %d (%s)",
-              process, pid, dr_ops, status, err_msg);
-        goto error; /* actually won't get here */
-    }
-    info("configuring client \"%s\" ops=\"%s\"", client_path, client_ops);
-    /* check client options and abort on an option error */
-    check_client_options(client_ops);
-    status = dr_register_client(process, pid,
-                                false/*local*/, DR_PLATFORM_DEFAULT, DRMEM_CLIENT_ID,
-                                0, client_path, client_ops);
-    if (status != DR_SUCCESS) {
-        const char *err_msg = dr_config_status_code_to_string(status);
-        fatal("failed to register DynamoRIO client configuration for \"%s\","
-              " ops=\"%s\"\n"
-              "Error code %d (%s)",
-              client_path, client_ops, status, err_msg);
-        goto error; /* actually won't get here */
-    }
-
-    if (native_parent) {
-        /* Create a regular config file without -native_parent so the children will
-         * run normally.
+        process = dr_inject_get_image_name(inject_data);
+        /* we don't care if this app is already registered for DR b/c our
+         * this-pid config will override
          */
-        info("configuring child processes");
-        if (dr_process_is_registered(process, 0, false/*local*/, DR_PLATFORM_DEFAULT,
-                                     NULL, NULL, NULL, NULL)) {
-            if (dr_unregister_process(process, 0, false/*local*/, DR_PLATFORM_DEFAULT)
-                == DR_SUCCESS)
-                warn("overriding existing registration");
-            else {
-                fatal("failed to override existing registration");
+        info("configuring %s pid=%d dr_ops=\"%s\"", process, pid, dr_ops);
+        status = dr_register_process(process, pid,
+                                     false/*local*/, dr_root,  DR_MODE_CODE_MANIPULATION,
+                                     use_dr_debug, DR_PLATFORM_DEFAULT, dr_ops);
+        if (status != DR_SUCCESS) {
+            const char *err_msg = dr_config_status_code_to_string(status);
+            fatal("failed to register DynamoRIO configuration for \"%s\"(%d) "
+                  "dr_ops=\"%s\".\n"
+                  "Error code %d (%s)",
+                  process, pid, dr_ops, status, err_msg);
+            goto error; /* actually won't get here */
+        }
+        info("configuring client \"%s\" ops=\"%s\"", client_path, client_ops);
+        /* check client options and abort on an option error */
+        check_client_options(client_ops);
+        status = dr_register_client(process, pid,
+                                    false/*local*/, DR_PLATFORM_DEFAULT, DRMEM_CLIENT_ID,
+                                    0, client_path, client_ops);
+        if (status != DR_SUCCESS) {
+            const char *err_msg = dr_config_status_code_to_string(status);
+            fatal("failed to register DynamoRIO client configuration for \"%s\","
+                  " ops=\"%s\"\n"
+                  "Error code %d (%s)",
+                  client_path, client_ops, status, err_msg);
+            goto error; /* actually won't get here */
+        }
+
+        if (native_parent) {
+            /* Create a regular config file without -native_parent so the children will
+             * run normally.
+             */
+            info("configuring child processes");
+            if (dr_process_is_registered(process, 0, false/*local*/, DR_PLATFORM_DEFAULT,
+                                         NULL, NULL, NULL, NULL)) {
+                if (dr_unregister_process(process, 0, false/*local*/, DR_PLATFORM_DEFAULT)
+                    == DR_SUCCESS)
+                    warn("overriding existing registration");
+                else {
+                    fatal("failed to override existing registration");
+                    goto error; /* actually won't get here */
+                }
+            }
+            if (dr_register_process(process, 0, false/*local*/, dr_root,
+                                    DR_MODE_CODE_MANIPULATION, use_dr_debug,
+                                    DR_PLATFORM_DEFAULT, dr_ops) != DR_SUCCESS) {
+                fatal("failed to register child DynamoRIO configuration");
+                goto error; /* actually won't get here */
+            }
+            /* clear out "-native_parent" */
+            memset(client_ops + native_parent_pos, ' ', strlen("-native_parent"));
+            if (dr_register_client(process, 0, false/*local*/, DR_PLATFORM_DEFAULT,
+                                   DRMEM_CLIENT_ID, 0, client_path, client_ops)
+                != DR_SUCCESS) {
+                fatal("failed to register child DynamoRIO client configuration");
                 goto error; /* actually won't get here */
             }
         }
-        if (dr_register_process(process, 0, false/*local*/, dr_root,
-                                DR_MODE_CODE_MANIPULATION, use_dr_debug,
-                                DR_PLATFORM_DEFAULT, dr_ops) != DR_SUCCESS) {
-            fatal("failed to register child DynamoRIO configuration");
-            goto error; /* actually won't get here */
-        }
-        /* clear out "-native_parent" */
-        memset(client_ops + native_parent_pos, ' ', strlen("-native_parent"));
-        if (dr_register_client(process, 0, false/*local*/, DR_PLATFORM_DEFAULT,
-                               DRMEM_CLIENT_ID, 0, client_path, client_ops)
-            != DR_SUCCESS) {
-            fatal("failed to register child DynamoRIO client configuration");
-            goto error; /* actually won't get here */
-        }
-    }
 
-    if (!dr_inject_process_inject(inject_data, false/*!force*/, NULL)) {
-        fatal("unable to inject");
-        goto error; /* actually won't get here */
-    }
+        if (!dr_inject_process_inject(inject_data, false/*!force*/, NULL)) {
+            fatal("unable to inject");
+            goto error; /* actually won't get here */
+        }
 
 #ifdef WINDOWS
-    if (top_stats)
-        start_time = time(NULL);
+        if (top_stats)
+            start_time = time(NULL);
 #endif
-    dr_inject_process_run(inject_data);
+        dr_inject_process_run(inject_data);
 #ifdef UNIX
-    fatal("Failed to exec application");
+        fatal("Failed to exec application");
 #else
-    info("waiting for app to exit...");
-    errcode = WaitForSingleObject(dr_inject_get_process_handle(inject_data), INFINITE);
-    if (errcode != WAIT_OBJECT_0)
-        info("failed to wait for app: %d\n", errcode);
-    if (top_stats) {
-        double wallclock;
-        end_time = time(NULL);
-        wallclock = difftime(end_time, start_time);
-        dr_inject_print_stats(inject_data, (int) wallclock, true/*time*/, true/*mem*/);
-    }
+        info("waiting for app to exit...");
+        errcode = WaitForSingleObject(dr_inject_get_process_handle(inject_data),
+                                      INFINITE);
+        if (errcode != WAIT_OBJECT_0)
+            info("failed to wait for app: %d\n", errcode);
+        if (top_stats) {
+            double wallclock;
+            end_time = time(NULL);
+            wallclock = difftime(end_time, start_time);
+            dr_inject_print_stats(inject_data, (int) wallclock, true/*time*/,
+                                  true/*mem*/);
+        }
 #endif
-    if (native_parent) {
-        if (dr_unregister_process(process, 0, false/*local*/, DR_PLATFORM_DEFAULT)
-            != DR_SUCCESS)
-            warn("failed to unregister child processes");
-    }
-    errcode = dr_inject_process_exit(inject_data, false/*don't kill process*/);
+        if (native_parent) {
+            if (dr_unregister_process(process, 0, false/*local*/, DR_PLATFORM_DEFAULT)
+                != DR_SUCCESS)
+                warn("failed to unregister child processes");
+        }
+        errcode = dr_inject_process_exit(inject_data, false/*don't kill process*/);
+#ifdef WINDOWS
+        if (errcode == STATUS_INVALID_KERNEL_INFO_VERSION &&
+            !tried_generating_syscall_file) {
+            warn("Running on an unsupported operating system version.  Attempting to "
+                 "auto-generate system call information...");
+            tried_generating_syscall_file = true;
+            /* Give the user some visible feedback. */
+            if (op_verbose_level < 1)
+                op_verbose_level = 1;
+            if (generate_sysnum_file(symdir)) {
+                sym_info("Auto-generation succeeded.  Re-launching the application.");
+                /* Some options change values and then complain (e.g.,
+                 * check_stack_bounds).
+                 */
+                options_reset_to_defaults();
+                continue; /* restart app */
+            }
+        }
+#endif
+        break;
+    } while (true);
 #ifdef WINDOWS
     process_results_file(logdir, symdir, pid, app_name, errcode);
 #endif

--- a/drmemory/options.c
+++ b/drmemory/options.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -128,6 +128,17 @@ static const char * const bool_string[2] = {
 };
 
 drmemory_options_t options = {
+#define OPTION_CLIENT(scope, name, type, defval, min, max, short, long) \
+    defval,
+#define OPTION_FRONT(scope, name, type, defval, min, max, short, long) \
+    /*nothing*/
+    /* we use <> so other tools can override the optionsx.h in "." */
+#include <optionsx.h>
+};
+#undef OPTION_CLIENT
+#undef OPTION_FRONT
+
+drmemory_options_t option_defaults = {
 #define OPTION_CLIENT(scope, name, type, defval, min, max, short, long) \
     defval,
 #define OPTION_FRONT(scope, name, type, defval, min, max, short, long) \
@@ -314,6 +325,13 @@ option_disable_memory_checks()
     options.shadowing = false;
     options.check_uninitialized = false;
     options.pattern = 0;
+}
+
+void
+options_reset_to_defaults(void)
+{
+    memcpy(&options, &option_defaults, sizeof(options));
+    memset(&option_specified, 0, sizeof(option_specified));
 }
 
 void

--- a/drmemory/options.h
+++ b/drmemory/options.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -61,6 +61,9 @@ extern bool stack_swap_threshold_fixed;
 
 void
 options_init(const char *opstr);
+
+void
+options_reset_to_defaults(void);
 
 void
 usage_error(const char *msg, const char *submsg);

--- a/drmemory/optionsx.h
+++ b/drmemory/optionsx.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -613,6 +613,9 @@ OPTION_CLIENT_BOOL(drmemscope, ignore_kernel, false,
 OPTION_CLIENT_BOOL(drmemscope, use_syscall_tables, true,
                    "Use Dr. Memory's own syscall tables where possible",
                    "On by default, this allows disabling the use of Dr. Memory's own syscall tables, in case the check for whether they match the underlying kernel is inaccurate.")
+OPTION_CLIENT_STRING(drmemscope, syscall_number_path, "",
+                   "Points at a directory containing a system call number file",
+                   "When running on an operating system version that this version of Dr. Memory does not have direct support for, a system call number file can be used to provide needed operating system information.  These files are named syscalls_{x86,wow64,x64}.txt.  This parameter should point at the directory containing the file.  By default these are located in -symcache_dir.")
 OPTION_CLIENT_BOOL(drmemscope, coverage, false,
                    "Measure and provide code coverage information",
                    "Measure code coverage during application execution.  The resulting data is written to a separate file named with a 'drcov' prefix in the same directory as Dr. Memory's other results files.  The raw data can be turned into a human-readable format using the drcov2lcov utility.")

--- a/drmemory/slowpath.h
+++ b/drmemory/slowpath.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -249,9 +249,6 @@ slowpath_module_unload(void *drcontext, const module_data_t *mod);
  * have jmp_smart (i#56/PR 209710)!
  */
 #define PREXL8M instrlist_meta_fault_preinsert
-
-bool
-reg_is_gpr(reg_id_t reg);
 
 bool
 reg_is_8bit(reg_id_t reg);

--- a/drmemory/slowpath_arm.c
+++ b/drmemory/slowpath_arm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -51,12 +51,6 @@
 /***************************************************************************
  * ISA
  */
-
-bool
-reg_is_gpr(reg_id_t reg)
-{
-    return (reg >= DR_REG_START_GPR && reg <= DR_REG_STOP_GPR);
-}
 
 bool
 reg_is_8bit(reg_id_t reg)

--- a/drmemory/slowpath_x86.c
+++ b/drmemory/slowpath_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -69,12 +69,6 @@ reg_is_caller_saved(reg_id_t reg)
     return (reg == DR_REG_XAX || reg == DR_REG_XDX || reg == DR_REG_XCX);
 }
 #endif
-
-bool
-reg_is_gpr(reg_id_t reg)
-{
-    return (reg >= REG_RAX && reg <= REG_DIL);
-}
 
 bool
 reg_is_8bit(reg_id_t reg)

--- a/drmemory/syscall.c
+++ b/drmemory/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -310,14 +310,6 @@ auxlib_shadow_post_syscall(void *drcontext, int sysnum, dr_mcontext_t *mc)
 /***************************************************************************
  * SYSCALL HANDLING
  */
-
-#ifdef WINDOWS
-/* i#1908: we support loading numbers from a file */
-# define SYSNUM_FILE IF_X64_ELSE("syscalls_x64.txt", "syscalls_x86.txt")
-# define SYSNUM_FILE_WOW64 "syscalls_wow64.txt"
-static char sysnum_path[MAXIMUM_PATH];
-# define SYSNUM_URL "http://drmemory.org"
-#endif
 
 const char *
 get_syscall_name(drsys_sysnum_t num)
@@ -677,26 +669,43 @@ syscall_init(void *drcontext _IF_WINDOWS(app_pc ntdll_base))
 
 #ifdef WINDOWS
     /* i#1908: we support loading numbers from a file */
-    if (!obtain_configfile_path(sysnum_path, BUFFER_SIZE_ELEMENTS(sysnum_path),
-                                sysnum_fname)) {
-        ASSERT(false, "failed to compute sysnum file path");
-    } else
-        ops.sysnum_file = sysnum_path;
+    char sysnum_path[MAXIMUM_PATH];
+    if (options.syscall_number_path[0] != '\0') {
+        _snprintf(sysnum_path, BUFFER_SIZE_ELEMENTS(sysnum_path), "%s%c%s",
+                  options.syscall_number_path, DIRSEP, sysnum_fname);
+    } else {
+        _snprintf(sysnum_path, BUFFER_SIZE_ELEMENTS(sysnum_path), "%s%c%s",
+                  options.symcache_dir, DIRSEP, sysnum_fname);
+    }
+    NULL_TERMINATE_BUFFER(sysnum_path);
+    ops.sysnum_file = sysnum_path;
+    if (!dr_file_exists(sysnum_path)) {
+        /* We don't do a full fallback: we won't fall back on a privilege error
+         * or something, but if there's no logs/symbols/ file at all we'll
+         * try bin/ which is where prior releases put them and asked users to
+         * put manually downloaded files.
+         */
+        if (!obtain_configfile_path(sysnum_path, BUFFER_SIZE_ELEMENTS(sysnum_path),
+                                    sysnum_fname) ||
+            !dr_file_exists(sysnum_path)) {
+            ops.sysnum_file = NULL;
+        }
+    }
+    if (ops.sysnum_file != NULL)
+        NOTIFY("Using system call file %s" NL, ops.sysnum_file);
     ops.skip_internal_tables = !options.use_syscall_tables;
 #endif
     res = drsys_init(client_id, &ops);
 #ifdef WINDOWS
     if (res == DRMF_WARNING_UNSUPPORTED_KERNEL) {
-        NOTIFY_ERROR("Running on an unsupported operating system. Please download "
-                     "%s/%s and save as %s to avoid false positives "
-                     "and other problems. If that fails, please file a bug report."
-                     "%s" NL, SYSNUM_URL, sysnum_fname, sysnum_path,
-                     options.ignore_kernel ? "" :
-                     " Re-run with -ignore_kernel to attempt continued execution.");
+        NOTIFY_ERROR("Running on an unsupported operating system version."
+                     "%s" NL, options.ignore_kernel ? "" :
+                     " Exiting to trigger auto-generation of system call information."
+                     " Re-run with -ignore_kernel to attempt to continue instead.");
         if (options.ignore_kernel)
             res = DRMF_SUCCESS;
         else
-            drmemory_abort();
+            dr_abort_with_code(STATUS_INVALID_KERNEL_INFO_VERSION);
     }
 #endif
     if (res != DRMF_SUCCESS) {

--- a/drsyscall/CMakeLists.txt
+++ b/drsyscall/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -71,7 +71,8 @@ else (UNIX)
     table_windows_ntgdi.c
     table_windows_kernel32.c
     drsyscall_wingdi.c
-    drsyscall_fileparse.c)
+    drsyscall_fileparse.c
+    pdb2sysfile.cpp)
   if (SYSCALL_DRIVER)
     set(srcs ${srcs}
       drmemory/syscall_driver.c)
@@ -97,7 +98,7 @@ macro(configure_drsyscall_target target)
   # a pain to export w/ the proper link rules.  But we at least use the
   # same flags and avoid compiling the same file differently.
   set_property(TARGET ${target} PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
-  target_link_libraries(${target} ${ntimp_lib})
+  target_link_libraries(${target} drfrontendlib ${ntimp_lib})
   if (NOT USER_SPECIFIED_DynamoRIO_DIR AND "${CMAKE_GENERATOR}" MATCHES "Visual Studio")
     add_dependencies(${target} ntdll_imports)
   endif ()
@@ -125,6 +126,7 @@ set(PREFERRED_BASE 0x77000000)
 configure_DynamoRIO_client(drsyscall)
 use_DynamoRIO_extension(drsyscall drmgr)
 use_DynamoRIO_extension(drsyscall drcontainers)
+use_DynamoRIO_extension(drsyscall drsyms)
 set_library_version(drsyscall ${DRMF_VERSION_MAJOR_MINOR})
 configure_drsyscall_target(drsyscall)
 export_drsyscall_target(drsyscall "drmgr")
@@ -139,6 +141,7 @@ add_library(drsyscall_static STATIC ${srcs_static} ${external_srcs})
 configure_DynamoRIO_client(drsyscall_static)
 use_DynamoRIO_extension(drsyscall_static drmgr_static)
 use_DynamoRIO_extension(drsyscall_static drcontainers)
+use_DynamoRIO_extension(drsyscall_static drsyms_static)
 configure_drsyscall_target(drsyscall_static)
 add_static_lib_debug_info(drsyscall_static ${DRMF_INSTALL_BIN})
 export_drsyscall_target(drsyscall_static "drmgr_static")
@@ -149,13 +152,11 @@ add_library(drsyscall_int STATIC ${srcs_static})
 configure_DynamoRIO_client(drsyscall_int)
 use_DynamoRIO_extension(drsyscall_int drmgr_static)
 use_DynamoRIO_extension(drsyscall_int drcontainers)
-if (DEBUG_BUILD)
-  if (STATIC_DRSYMS)
-    use_DynamoRIO_extension(drsyscall_int drsyms_static)
-  else ()
-    use_DynamoRIO_extension(drsyscall_int drsyms)
-  endif ()
-endif (DEBUG_BUILD)
+if (STATIC_DRSYMS)
+  use_DynamoRIO_extension(drsyscall_int drsyms_static)
+else ()
+  use_DynamoRIO_extension(drsyscall_int drsyms)
+endif ()
 configure_drsyscall_target(drsyscall_int)
 
 # Documentation is handled as part of the main tool docs processing.

--- a/drsyscall/drsyscall.h
+++ b/drsyscall/drsyscall.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -408,6 +408,9 @@ typedef struct _drsys_options_t {
      * Windows in particular, with a simple data file update.  The file is only
      * examined if the built-in system call tables do not match the current operating
      * system.
+     *
+     * This file can be generated using drsys_find_sysnum_dlls() and
+     * drsys_generate_sysnum_file().
      *
      * The file format is text line-based.  The first line must contain the string
      * "DrSyscall Number File" (#DRSYS_SYSNUM_FILE_HEADER).  The second line must
@@ -973,6 +976,62 @@ DR_EXPORT
 drmf_status_t
 drsys_iterate_memargs(void *drcontext, drsys_iter_cb_t cb, void *user_data);
 
+/***************************************************************************
+ * WINDOWS SYSCALL NUMBER DETERMINATION
+ */
+
+DR_EXPORT
+/**
+ * Locates the system libraries that contain system calls for the current operating
+ * system for the purpose of passing them to drsys_generate_sysnum_file().  Returns
+ * an array of paths.  The caller must set the capacity of the array in \p
+ * num_sysnum_libs and allocate at least MAXIMUM_PATH bytes for each entry in
+ * the array.  If the array length is too small, this function returns
+ * DRMF_ERROR_INVALID_SIZE and sets \p num_sysnum_libs to the size needed.  On
+ * success, returns DRMF_SUCCESS and the library count in \p num_sysnum_libs.
+ *
+ * @param[out] sysnum_lib_paths  Pointer to an array of length \p num_sysnum_libs
+ *   which will hold the paths of the libraries on success.
+ * @param[in,out] num_sysnum_libs   The caller must set this to the capacity of
+ *   \p sysnum_lib_paths on entry.  On success this will hold the number of paths
+ *   written to the array.  When returning DRMF_ERROR_INVALID_SIZE this will hold
+ *   the required size of the array.
+ *
+ * \note Windows-only.
+ */
+drmf_status_t
+drsys_find_sysnum_libs(OUT char **sysnum_lib_paths, INOUT size_t *num_sysnum_libs);
+
+DR_EXPORT
+/**
+ * Writes out a text file that contains system call numbers for the operating system
+ * whose system libraries are in \p sysnum_lib_paths with a count of \p
+ * num_sysnum_libs.  Typically this list will be obtained for the current operating
+ * system from drsys_find_sysnum_libs().  The text file is written to \p outfile in
+ * the format expected by the sysnum_file field of #drsys_options_t.
+ *
+ * To accomplish this, this function requires debug symbols for each of the
+ * libraries.  It attempts to retrieve the symbols over the network if they are not
+ * found in the \p cache_dir or _NT_SYMBOL_PATH used by dbghelp.dll through the
+ * drsyms extension.
+ *
+ * @param[in] drcontext  The current DynamoRIO thread context or standalone context.
+ * @param[in] sysnum_lib_paths  Pointer to an array of length \p num_sysnum_libs
+ *   which holds the paths of the system libraries from which system call numbers
+ *   should be extracted.
+ * @param[in] num_sysnum_libs   The length of the \p sysnum_lib_paths array.
+ * @param[in] outfile  The name of the output text file to be written.
+ * @param[in] cache_dir  The path where retrieved symbol data should be cached (and
+ *   searched if already retrieved).  If not set, the _NT_SYMBOL_PATH environment
+ *   variable will be used, if set; else whatever default dbghelp.dll uses will be
+ *   used.
+ *
+ * \note Windows-only.
+ */
+drmf_status_t
+drsys_generate_sysnum_file(void *drcontext, const char **sysnum_lib_paths,
+                           size_t num_sysnum_libs, const char *outfile,
+                           const char *cache_dir);
 
 /***************************************************************************
  * SYNCHRONOUS ITERATORS

--- a/drsyscall/drsyscall_fileparse.c
+++ b/drsyscall/drsyscall_fileparse.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -111,7 +111,8 @@ read_sysnum_file(void *drcontext, const char *sysnum_file, module_data_t *ntdll_
      */
     do {
         search = strstr(line, "\nSTART=0x");
-        LOG(SYSCALL_VERBOSE, "syscall file: examining %.16s\n", search+1);
+        LOG(SYSCALL_VERBOSE, "syscall file: examining %.16s\n",
+            search == NULL ? "<null>" : search+1);
         if (search == NULL || search - map > actual_size)
             goto read_sysnum_file_done;
         if (dr_sscanf(search+1, "START=0x%x", &val) != 1)

--- a/drsyscall/drsyscall_windows.c
+++ b/drsyscall/drsyscall_windows.c
@@ -437,10 +437,13 @@ name2num_entry_add(const char *name, drsys_sysnum_t num, bool dup_Zw, bool dup_n
         e->name, num.number, num.secondary);
     ok = hashtable_add(&name2num_table, (void *)e->name, (void *)e);
     if (!ok) {
-        /* If we have any more of these, add a flag to drsyscall_numx.h */
-        ASSERT(strcmp(e->name, "GetThreadDesktop") == 0/*i#487*/ ||
-               strstr(e->name, "PREPAREFORLOGOFF") != NULL, /* NoParam vs OneParam */
-               "no dup entries in name2num_table");
+        /* With auto-generated files on a new OS, we may have had a shift from
+         * NtUserCallOneParam.FOO to NtUserFoo (this has happened before:
+         * WindowFromDC, GetKeyboardLayout).  So we downgrade this to just a warning.
+         */
+        if (strcmp(e->name, "GetThreadDesktop") != 0/*i#487*/ &&
+            strstr(e->name, "PREPAREFORLOGOFF") == NULL /* NoParam vs OneParam */)
+            WARN("WARNING: duplicate entry added to name2num_table: %s\n", e->name);
         name2num_entry_free((void *)e);
     }
 }

--- a/drsyscall/pdb2sysfile.cpp
+++ b/drsyscall/pdb2sysfile.cpp
@@ -233,29 +233,29 @@ look_for_usercall_targets(const char *dll_path, byte *map_base, size_t map_size,
         else if (i == NUM_USERCALL - 1)
             imp_name = sym_prefix + alt_twoparam;
 #endif
-        NOTIFY(3, "Looking for %s\n", imp_name.c_str());
+        NOTIFY(3, "Looking for %s" NL, imp_name.c_str());
         drsym_error_t symres = drsym_lookup_symbol(dll_path, imp_name.c_str(), &offs, 0);
         if (symres != DRSYM_SUCCESS) {
-            NOTIFY(3, "Looking for %s\n", imp_name.c_str());
+            NOTIFY(3, "Looking for %s" NL, imp_name.c_str());
             imp_name = sym_prefix + imp_prefixB + usercall_names[i];
             symres = drsym_lookup_symbol(dll_path, imp_name.c_str(), &offs, 0);
         }
         if (symres == DRSYM_SUCCESS) {
             usercall_addr[i] = map_base + offs;
             ++num_found;
-            NOTIFY(2, "%s = %d +0x%x == " PFX "\n", imp_name.c_str(), symres, offs,
+            NOTIFY(2, "%s = %d +0x%x == " PFX "" NL, imp_name.c_str(), symres, offs,
                    usercall_addr[i]);
         } else {
-            NOTIFY(3, "Looking for %s\n", imp_name.c_str());
+            NOTIFY(3, "Looking for %s" NL, imp_name.c_str());
             imp_name = sym_prefix + usercall_names[i];
             symres = drsym_lookup_symbol(dll_path, imp_name.c_str(), &offs, 0);
             if (symres == DRSYM_SUCCESS) {
                 usercall_addr[i] = map_base + offs;
                 ++num_found;
-                NOTIFY(2, "%s = %d +0x%x == " PFX "\n", usercall_names[i], symres,
+                NOTIFY(2, "%s = %d +0x%x == " PFX "" NL, usercall_names[i], symres,
                        offs, usercall_addr[i]);
             } else {
-                NOTIFY(2, "Error locating usercall %s\n", usercall_names[i]);
+                NOTIFY(2, "Error locating usercall %s" NL, usercall_names[i]);
             }
         }
     }
@@ -334,7 +334,7 @@ look_for_usercall(void *dcontext, byte *entry, const char *sym, byte *mod_end,
                     sysname = sysname_from_wrapper(sym);
                     if (!sysname.empty())
                         sysnum = imm;
-                    NOTIFY(2, "Call #0x%02x to %s at %s+0x%x == %s,%d\n", imm,
+                    NOTIFY(2, "Call #0x%02x to %s at %s+0x%x == %s,%d" NL, imm,
                            usercall_names[i], sym, pre_pc - entry, sysname.c_str(),
                            sysnum);
                     found = true;
@@ -357,7 +357,7 @@ look_for_usercall(void *dcontext, byte *entry, const char *sym, byte *mod_end,
                     sysname = sysname_from_wrapper(sym);
                     if (!sysname.empty())
                         sysnum = imm;
-                    NOTIFY(2, "Call #0x%02x to %s at %s+0x%x == %s,%d\n", imm,
+                    NOTIFY(2, "Call #0x%02x to %s at %s+0x%x == %s,%d" NL, imm,
                            usercall_names[i], sym, pre_pc - entry, sysname.c_str(),
                            sysnum);
                     found = true;
@@ -745,7 +745,7 @@ typedef struct _search_data_t {
 static bool
 search_syms_cb(const char *name, size_t modoffs, void *data)
 {
-    NOTIFY(3, "Found symbol \"%s\" at offs "PIFX"\n" NL, name, modoffs);
+    NOTIFY(3, "Found symbol \"%s\" at offs "PIFX NL, name, modoffs);
     search_data_t *sd = (search_data_t *) data;
     /* XXX DRi#2715: drsyms sometimes passes bogus offsets so we're robust here */
     if (modoffs >= sd->dll_size)
@@ -765,7 +765,7 @@ search_syms_cb(const char *name, size_t modoffs, void *data)
             look_for_usercall(sd->dcontext, sd->dll_base + modoffs, name,
                               sd->dll_base + sd->dll_size, sd->usercall_addr);
         if (name_num.second != -1) {
-            NOTIFY(2, "Adding usercall %s = 0x%x\n", name_num.first.c_str(),
+            NOTIFY(2, "Adding usercall %s = 0x%x" NL, name_num.first.c_str(),
                    name_num.second);
             ++sd->usercalls_found;
             (*sd->name2num)[name_num.first] = name_num.second;

--- a/drsyscall/pdb2sysfile.cpp
+++ b/drsyscall/pdb2sysfile.cpp
@@ -1,0 +1,935 @@
+/* **********************************************************
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2003-2008 VMware, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Copyright (c) 2003-2007 Determina Corp. */
+
+/* Some of this is based on the winsysnums.c client in DR */
+
+#ifdef WINDOWS
+# define UNICODE
+# define _UNICODE
+#else
+# error Only Windows is supported
+#endif
+
+#include "dr_api.h" /* for the types */
+#include "dr_frontend.h"
+#include "droption.h"
+#include "drsyms.h"
+#include "../common/utils.h" /* only for BUFFER*, DIRSEP */
+#include "../drsyscall/drsyscall.h"
+
+#include <assert.h>
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+
+/* We'll get an error in standalone usage by DrM's frontend if we call
+ * dr_get_current_drcontext() in the utils.h NOTIFY so we make our own.
+ * The frontend's -v, -vv, and -vvv set op_verbose_level.
+ */
+#undef NOTIFY
+#define NOTIFY(level, ...) do {          \
+    if (op_verbose_level >= (level)) {   \
+        dr_fprintf(STDERR, __VA_ARGS__); \
+    }                                    \
+} while (0)
+
+/***************************************************************************
+ * Usercalls
+ */
+
+static std::string
+sysname_from_wrapper(std::string wrapper)
+{
+  static std::unordered_map<std::string, std::string> wrapper2sysname({
+    {"AllowForegroundActivation"     , "NtUserCallNoParam.ALLOWFOREGNDACTIVATION"      },
+    {"CreateMenu"                    , "NtUserCallNoParam.CREATEMENU"                  },
+    {"CreatePopupMenu"               , "NtUserCallNoParam.CREATEMENUPOPUP"             },
+    {"CreateSystemThreads"           , "NtUserCallNoParam.CREATESYSTEMTHREADS"         },
+    {"DeferredDesktopRotation"       , "NtUserCallNoParam.DEFERREDDESKTOPROTATION"     },
+    {"DestroyCaret"                  , "NtUserCallNoParam.DESTROY_CARET"               },
+    {"DisableProcessWindowsGhosting" , "NtUserCallNoParam.DISABLEPROCWNDGHSTING"       },
+    {"EnableMiPShellThread"          , "NtUserCallNoParam.ENABLEMIPSHELLTHREAD"        },
+    {"EnablePerMonitorMenuScaling"   , "NtUserCallNoParam.ENABLEPERMONITORMENUSCALING" },
+    {"GetIMEShowStatus"              , "NtUserCallNoParam.GETIMESHOWSTATUS"            },
+    {"GetInputDesktop"               , "NtUserCallNoParam.GETINPUTDESKTOP"             },
+    {"GetMessagePos"                 , "NtUserCallNoParam.GETMESSAGEPOS"               },
+    {"GetUnpredictedMessagePos"      , "NtUserCallNoParam.GETUNPREDICTEDMESSAGEPOS"    },
+    {"RegisterMessagePumpHook"       , "NtUserCallNoParam.INIT_MESSAGE_PUMP"           },
+    {"IsMiPShellThreadEnabled"       , "NtUserCallNoParam.ISMIPSHELLTHREADENABLED"     },
+    {"IsQueueAttached"               , "NtUserCallNoParam.ISQUEUEATTACHED"             },
+    {"LoadCursorsAndIcons"           , "NtUserCallNoParam.LOADCURSANDICOS"             },
+    {"ReleaseCapture"                , "NtUserCallNoParam.RELEASECAPTURE"              },
+    {"UnregisterMessagePumpHook"     , "NtUserCallNoParam.UNINIT_MESSAGE_PUMP"         },
+    {"UpdatePerUserImmEnabling"      , "NtUserCallNoParam.UPDATEPERUSERIMMENABLING"    },
+
+    {"AllowSetForegroundWindow"      , "NtUserCallOneParam.ALLOWSETFOREGND"            },
+    {"BeginDeferWindowPos"           , "NtUserCallOneParam.BEGINDEFERWNDPOS"           },
+    {"CreateAniIcon"                 , "NtUserCallOneParam.CREATEEMPTYCUROBJECT"       },
+    {"DdeUninitialize"               , "NtUserCallOneParam.CSDDEUNINITIALIZE"          },
+    {"DirectedYield"                 , "NtUserCallOneParam.DIRECTEDYIELD"              },
+    {"DwmLockScreenUpdates"          , "NtUserCallOneParam.DWMLOCKSCREENUPDATES"       },
+    {"EnableSessionForMMCSS"         , "NtUserCallOneParam.ENABLESESSIONFORMMCSS"      },
+    {"EnumClipboardFormats"          , "NtUserCallOneParam.ENUMCLIPBOARDFORMATS"       },
+    {"ForceEnableNumpadTranslation"  , "NtUserCallOneParam.FORCEENABLENUMPADTRANSLATION"},
+    {"ForceFocusBasedMouseWheelRouting", "NtUserCallOneParam.FORCEFOCUSBASEDMOUSEWHEELROUTING"},
+    {"MsgWaitForMultipleObjectsEx"   , "NtUserCallOneParam.GETINPUTEVENT"              },
+    {"GetKeyboardLayout"             , "NtUserCallOneParam.GETKEYBOARDLAYOUT"          },
+    {"GetKeyboardType"               , "NtUserCallOneParam.GETKEYBOARDTYPE"            },
+    {"GetProcessDefaultLayout"       , "NtUserCallOneParam.GETPROCDEFLAYOUT"           },
+    {"GetQueueStatus"                , "NtUserCallOneParam.GETQUEUESTATUS"             },
+    {"GetSendMessageReceiver"        , "NtUserCallOneParam.GETSENDMSGRECVR"            },
+    {"GetWinStationInfo"             , "NtUserCallOneParam.GETWINSTAINFO"              },
+    {"IsThreadMessageQueueAttached"  , "NtUserCallOneParam.ISTHREADMESSAGEQUEUEATTACHED"},
+    {"LoadLocalFonts"                , "NtUserCallOneParam.LOADFONTS"                  },
+    {"LockSetForegroundWindow"       , "NtUserCallOneParam.LOCKFOREGNDWINDOW"          },
+    {"MessageBeep"                   , "NtUserCallOneParam.MESSAGEBEEP"                },
+    {"PostQuitMessage"               , "NtUserCallOneParam.POSTQUITMESSAGE"            },
+    {"PostUIActions"                 , "NtUserCallOneParam.POSTUIACTIONS"              },
+    {"UserRealizePalette"            , "NtUserCallOneParam.REALIZEPALETTE"             },
+    {"RegisterSystemThread"          , "NtUserCallOneParam.REGISTERSYSTEMTHREAD"       },
+    {"ReleaseDC"                     , "NtUserCallOneParam.RELEASEDC"                  },
+    {"ReplyMessage"                  , "NtUserCallOneParam.REPLYMESSAGE"               },
+    {"SetCaretBlinkTime"             , "NtUserCallOneParam.SETCARETBLINKTIME"          },
+    {"SetDoubleClickTime"            , "NtUserCallOneParam.SETDBLCLICKTIME"            },
+    {"SetInputServiceState"          , "NtUserCallOneParam.SETINPUTSERVICESTATE"       },
+    {"SetMessageExtraInfo"           , "NtUserCallOneParam.SETMESSAGEEXTRAINFO"        },
+    {"SetProcessDefaultLayout"       , "NtUserCallOneParam.SETPROCDEFLAYOUT"           },
+    {"SetShellChangeNotifyWindow"    , "NtUserCallOneParam.SETSHELLCHANGENOTIFYWINDOW" },
+    {"SetTSFEventState"              , "NtUserCallOneParam.SETTSFEVENTSTATE"           },
+    {"LoadAndSendWatermarkStrings"   , "NtUserCallOneParam.SETWATERMARKSTRINGS"        },
+    {"ShowCursor"                    , "NtUserCallOneParam.SHOWCURSOR"                 },
+    {"ShowStartGlass"                , "NtUserCallOneParam.SHOWSTARTGLASS"             },
+    {"SwapMouseButton"               , "NtUserCallOneParam.SWAPMOUSEBUTTON"            },
+    {"WindowFromDC"                  , "NtUserCallOneParam.WINDOWFROMDc"               },
+    {"WOWModuleUnload"               , "NtUserCallOneParam.WOWMODULEUNLOAD"            },
+
+    {"DeregisterShellHookWindow"     , "NtUserCallHwnd.DEREGISTERSHELLHOOKWINDOW"      },
+    {"GetModernAppWindow"            , "NtUserCallHwnd.GETMODERNAPPWINDOW"             },
+    {"GetWindowContextHelpId"        , "NtUserCallHwnd.GETWNDCONTEXTHLPID"             },
+    {"RegisterShellHookWindow"       , "NtUserCallHwnd.REGISTERSHELLHOOKWINDOW"        },
+
+    {"SetProgmanWindow"              , "NtUserCallHwndOpt.SETPROGMANWINDOW"            },
+    {"SetTaskmanWindow"              , "NtUserCallHwndOpt.SETTASKMANWINDOW"            },
+
+    {"ClearWindowState"              , "NtUserCallHwndParam.CLEARWINDOWSTATE"          },
+    {"EnableModernAppWindowKeyboardIntercept", "NtUserCallHwndParam.ENABLEMODERNAPPWINDOWKBDINTERCEPT"},
+    {"RegisterKeyboardCorrectionCallout", "NtUserCallHwndParam.REGISTERKBDCORRECTION"  },
+    {"RegisterWindowArrangementCallout", "NtUserCallHwndParam.REGISTERWINDOWARRANGEMENTCALLOUT"},
+    {"SetWindowState"                , "NtUserCallHwndParam.SETWINDOWSTATE"            },
+    {"SetWindowContextHelpId"        , "NtUserCallHwndParam.SETWNDCONTEXTHLPID"        },
+
+    {"ArrangeIconicWindows"          , "NtUserCallHwndLock.ARRANGEICONICWINDOWS"       },
+    {"DrawMenuBar"                   , "NtUserCallHwndLock.DRAWMENUBAR"                },
+    {"xxxGetSysMenuHandle"           , "NtUserCallHwndLock.GETSYSMENUHANDLE"           },
+    {"xxxGetSysMenuPtr"              , "NtUserCallHwndLock.GETSYSMENUHANDLEX"          },
+    {"GetWindowTrackInfoAsync"       , "NtUserCallHwndLock.GETWINDOWTRACKINFOASYNC"    },
+    {"RealMDIRedrawFrame"            , "NtUserCallHwndLock.REDRAWFRAME"                },
+    {"SetActiveImmersiveWindow"      , "NtUserCallHwndLock.SETACTIVEIMMERSIVEWINDOW"   },
+    {"SetForegroundWindow"           , "NtUserCallHwndLock.SETFOREGROUNDWINDOW"        },
+    {"MDIAddSysMenu"                 , "NtUserCallHwndLock.SETSYSMENU"                 },
+    {"UpdateWindow"                  , "NtUserCallHwndLock.UPDATEWINDOW"               },
+
+    {"EnableWindow"                  , "NtUserCallHwndParamLock.ENABLEWINDOW"          },
+    {"SetModernAppWindow"            , "NtUserCallHwndParamLock.SETMODERNAPPWINDOW"    },
+    {"ShowOwnedPopups"               , "NtUserCallHwndParamLock.SHOWOWNEDPOPUPS"       },
+    {"SwitchToThisWindow"            , "NtUserCallHwndParamLock.SWITCHTOTHISWINDOW"    },
+    {"ValidateRgn"                   , "NtUserCallHwndParamLock.VALIDATERGN"           },
+    {"NotifyOverlayWindow"           , "NtUserCallHwndParam.NOTIFYOVERLAYWINDOW"       },
+
+    {"ChangeWindowMessageFilter"     , "NtUserCallTwoParam.CHANGEWNDMSGFILTER"         },
+    {"EnableShellWindowManagementBehavior", "NtUserCallTwoParam.ENABLESHELLWINDOWMGT"  },
+    {"GetCursorPos"                  , "NtUserCallTwoParam.GETCURSORPOS"               },
+    {"InitOemXlateTables"            , "NtUserCallTwoParam.INITANSIOEM"                },
+    {"RegisterGhostWindow"           , "NtUserCallTwoParam.REGISTERGHSTWND"            },
+    {"RegisterLogonProcess"          , "NtUserCallTwoParam.REGISTERLOGONPROCESS"       },
+    {"RegisterFrostWindow"           , "NtUserCallTwoParam.REGISTERSBLFROSTWND"        },
+    {"RegisterUserHungAppHandlers"   , "NtUserCallTwoParam.REGISTERUSERHUNGAPPHANDLERS"},
+    {"SetCaretPos"                   , "NtUserCallTwoParam.SETCARETPOS"                },
+    {"SetCITInfo"                    , "NtUserCallTwoParam.SETCITINFO"                 },
+    {"SetCursorPos"                  , "NtUserCallTwoParam.SETCURSORPOS"               },
+    {"SetThreadQueueMergeSetting"    , "NtUserCallTwoParam.SETTHREADQUEUEMERGESETTING" },
+    {"UnhookWindowsHook"             , "NtUserCallTwoParam.UNHOOKWINDOWSHOOK"          },
+    {"WOWCleanup"                    , "NtUserCallTwoParam.WOWCLEANUP"                 },
+      });
+  return wrapper2sysname[wrapper];
+}
+
+static const char *const usercall_names[] = {
+    "NtUserCallNoParam",       "NtUserCallOneParam",  "NtUserCallHwnd",
+    "NtUserCallHwndOpt",       "NtUserCallHwndParam", "NtUserCallHwndLock",
+    "NtUserCallHwndParamLock", "NtUserCallTwoParam",
+};
+#define NUM_USERCALL (sizeof(usercall_names) / sizeof(usercall_names[0]))
+
+/* For searching for usercalls we'll go quite a ways */
+#define MAX_BYTES_BEFORE_USERCALL 0x300
+
+static void
+look_for_usercall_targets(const char *dll_path, byte *map_base, size_t map_size,
+                          byte *usercall_addr[NUM_USERCALL],
+                          size_t *usercall_targets_found)
+{
+    int i;
+    size_t num_found = 0;
+    std::string sym_prefix(dll_path);
+    /* Get the basename. */
+    sym_prefix = sym_prefix.substr(sym_prefix.find_last_of("\\/") + 1);
+    /* Remove the extension. */
+    sym_prefix = sym_prefix.substr(0, sym_prefix.find_last_of('.'));
+    /* Now add ! so we can have a module!sym fully-qualified name, to avoid
+     * querying a previously-queried module.
+     */
+    sym_prefix += "!";
+    for (i = 0; i < NUM_USERCALL; i++) {
+        size_t offs;
+        /* To handle win10-1607 we have to look for imports from win32u.dll.
+         * But, for 32-bit, NoParam instead calls to a local routine that invokes yet
+         * another routine that finally does the import.
+         */
+        static const std::string alt_noparam("Local_NtUserCallNoParam");
+        static const std::string alt_twoparam("Local_NtUserCallTwoParam");
+        static const std::string imp_prefixA = "_imp__";
+        /* x64 uses a single 2nd underscore for some routines. */
+        static const std::string imp_prefixB = "_imp_";
+        /* We have to look for the __imp first, b/c win10-1607 does have
+         * a NoParam wrapper.
+         */
+        std::string imp_name(sym_prefix + imp_prefixA + usercall_names[i]);
+#ifndef X64
+        if (i == 0)
+            imp_name = sym_prefix + alt_noparam;
+        else if (i == NUM_USERCALL - 1)
+            imp_name = sym_prefix + alt_twoparam;
+#endif
+        NOTIFY(3, "Looking for %s\n", imp_name.c_str());
+        drsym_error_t symres = drsym_lookup_symbol(dll_path, imp_name.c_str(), &offs, 0);
+        if (symres != DRSYM_SUCCESS) {
+            NOTIFY(3, "Looking for %s\n", imp_name.c_str());
+            imp_name = sym_prefix + imp_prefixB + usercall_names[i];
+            symres = drsym_lookup_symbol(dll_path, imp_name.c_str(), &offs, 0);
+        }
+        if (symres == DRSYM_SUCCESS) {
+            usercall_addr[i] = map_base + offs;
+            ++num_found;
+            NOTIFY(2, "%s = %d +0x%x == " PFX "\n", imp_name.c_str(), symres, offs,
+                   usercall_addr[i]);
+        } else {
+            NOTIFY(3, "Looking for %s\n", imp_name.c_str());
+            imp_name = sym_prefix + usercall_names[i];
+            symres = drsym_lookup_symbol(dll_path, imp_name.c_str(), &offs, 0);
+            if (symres == DRSYM_SUCCESS) {
+                usercall_addr[i] = map_base + offs;
+                ++num_found;
+                NOTIFY(2, "%s = %d +0x%x == " PFX "\n", usercall_names[i], symres,
+                       offs, usercall_addr[i]);
+            } else {
+                NOTIFY(2, "Error locating usercall %s\n", usercall_names[i]);
+            }
+        }
+    }
+    *usercall_targets_found = num_found;
+}
+
+static std::pair<std::string, int>
+look_for_usercall(void *dcontext, byte *entry, const char *sym, byte *mod_end,
+                  byte *usercall_addr[NUM_USERCALL])
+{
+    /* For 32-bit we expect:
+     *  USER32!AllowSetForegroundWindow:
+     *  76120500 8bff            mov     edi,edi
+     *  76120502 55              push    ebp
+     *  76120503 8bec            mov     ebp,esp
+     *  76120505 6a2e            push    2Eh
+     *  76120507 ff7508          push    dword ptr [ebp+8]
+     *  7612050a ff15706a1376    call    dword ptr [USER32!_imp__NtUserCallOneParam (76136a70)]
+     *  76120510 5d              pop     ebp
+     *  76120511 c20400          ret     4
+     *
+     * For 64-bit:
+     *  USER32!AllowSetForegroundWindow:
+     *  00007ffb`15e3bdd0 8bc9            mov     ecx,ecx
+     *  00007ffb`15e3bdd2 ba2e000000      mov     edx,2Eh
+     *  00007ffb`15e3bdd7 48ff2572e20500  jmp     qword ptr [USER32!_imp_NtUserCallOneParam (00007ffb`15e9a050)]
+     */
+    bool found_set_imm = false;
+    int imm = 0;
+    app_pc pc, pre_pc;
+    instr_t *instr;
+    std::string sysname;
+    int sysnum = -1;
+    if (entry == NULL)
+        return std::make_pair("", -1);
+    instr = instr_create(dcontext);
+    pc = entry;
+    while (true) {
+        instr_reset(dcontext, instr);
+        pre_pc = pc;
+        pc = decode(dcontext, pc, instr);
+        if (op_verbose_level >= 3) {
+            instr_set_translation(instr, pre_pc);
+            dr_print_instr(dcontext, STDOUT, instr, "");
+        }
+        if (pc == NULL || !instr_valid(instr) || pc >= mod_end)
+            break;
+#ifdef X64
+        if (!found_set_imm && instr_get_opcode(instr) == OP_mov_imm &&
+            opnd_is_reg(instr_get_dst(instr, 0))) {
+            /* The code is in the last param. */
+            reg_id_t reg = opnd_get_reg(instr_get_dst(instr, 0));
+            if (reg == DR_REG_ECX || /* NoParam */
+                reg == DR_REG_EDX || /* OneParam */
+                reg == DR_REG_R8D) { /* TwoParam */
+                found_set_imm = true;
+                imm = (int)opnd_get_immed_int(instr_get_src(instr, 0));
+            }
+        }
+#else
+        /* If there are multiple push-immeds we want the outer one
+         * as the code is the last param.
+         */
+        if (!found_set_imm && instr_get_opcode(instr) == OP_push_imm) {
+            found_set_imm = true;
+            imm = (int)opnd_get_immed_int(instr_get_src(instr, 0));
+        }
+#endif
+        else if (instr_is_call_direct(instr) && found_set_imm) {
+            /* We don't rule out usercall imports due to Local_NtUserCallNoParam */
+            app_pc tgt = opnd_get_pc(instr_get_target(instr));
+            bool found = false;
+            int i;
+            for (i = 0; i < NUM_USERCALL; i++) {
+                if (tgt == usercall_addr[i]) {
+                    sysname = sysname_from_wrapper(sym);
+                    if (!sysname.empty())
+                        sysnum = imm;
+                    NOTIFY(2, "Call #0x%02x to %s at %s+0x%x == %s,%d\n", imm,
+                           usercall_names[i], sym, pre_pc - entry, sysname.c_str(),
+                           sysnum);
+                    found = true;
+                    break;
+                }
+            }
+            if (found)
+                break;
+            found_set_imm = false;
+        } else if ((instr_is_call_indirect(instr) ||
+                    instr_get_opcode(instr) == OP_jmp_ind) &&
+                   found_set_imm &&
+                   (opnd_is_abs_addr(instr_get_target(instr))
+                    IF_X64(|| opnd_is_rel_addr(instr_get_target(instr))))) {
+            app_pc tgt = (app_pc) opnd_get_addr(instr_get_target(instr));
+            bool found = false;
+            int i;
+            for (i = 0; i < NUM_USERCALL; i++) {
+                if (tgt == usercall_addr[i]) {
+                    sysname = sysname_from_wrapper(sym);
+                    if (!sysname.empty())
+                        sysnum = imm;
+                    NOTIFY(2, "Call #0x%02x to %s at %s+0x%x == %s,%d\n", imm,
+                           usercall_names[i], sym, pre_pc - entry, sysname.c_str(),
+                           sysnum);
+                    found = true;
+                    break;
+                }
+            }
+            if (found)
+                break;
+            found_set_imm = false;
+        } else if (instr_is_return(instr))
+            break;
+        else if (instr_is_call(instr))
+            found_set_imm = false;
+        if (pc - entry > MAX_BYTES_BEFORE_USERCALL)
+            break;
+    }
+    instr_destroy(dcontext, instr);
+    return std::make_pair(sysname, sysnum);
+}
+
+/***************************************************************************
+ * Fetch symbols
+ */
+
+static const char * const syscall_dlls[] = {
+    "ntdll.dll",
+    "kernelbase.dll",
+    "kernel32.dll",
+    "gdi32.dll",
+    "imm32.dll",
+    "user32.dll",
+    "win32u.dll",
+};
+#define NUM_SYSCALL_DLLS (sizeof(syscall_dlls)/sizeof(syscall_dlls[0]))
+
+DR_EXPORT
+drmf_status_t
+drsys_find_sysnum_libs(OUT char **sysnum_lib_paths, INOUT size_t *num_sysnum_libs)
+{
+    if (num_sysnum_libs == nullptr)
+        return DRMF_ERROR_INVALID_PARAMETER;
+    if (*num_sysnum_libs < NUM_SYSCALL_DLLS) {
+        *num_sysnum_libs = NUM_SYSCALL_DLLS;
+        return DRMF_ERROR_INVALID_SIZE;
+    }
+    if (sysnum_lib_paths == nullptr)
+        return DRMF_ERROR_INVALID_PARAMETER;
+    *num_sysnum_libs = NUM_SYSCALL_DLLS;
+    TCHAR system_rootw[MAXIMUM_PATH];
+    char system_root[MAXIMUM_PATH];
+    /* Get %SystemRoot%. */
+    DWORD len = GetWindowsDirectory(system_rootw, BUFFER_SIZE_ELEMENTS(system_rootw));
+    if (len == 0) {
+        _tcsncpy(system_rootw, _T("C:\\Windows"), BUFFER_SIZE_ELEMENTS(system_rootw));
+        NULL_TERMINATE_BUFFER(system_rootw);
+    }
+    if (drfront_tchar_to_char(system_rootw, system_root,
+                              BUFFER_SIZE_ELEMENTS(system_root)) != DRFRONT_SUCCESS) {
+        NOTIFY(0, "Failed to determine system root" NL);
+        return DRMF_ERROR_NOT_FOUND;
+    }
+    for (int i = 0; i < NUM_SYSCALL_DLLS; ++i) {
+        _snprintf(sysnum_lib_paths[i], MAXIMUM_PATH, "%s%csystem32%c%s",
+                  system_root, DIRSEP, DIRSEP, syscall_dlls[i]);
+        sysnum_lib_paths[i][MAXIMUM_PATH-1] = '\0';
+    }
+    return DRMF_SUCCESS;
+}
+
+static drmf_status_t
+fetch_symbols(const char **sysnum_lib_paths, size_t num_sysnum_libs,
+              const char *cache_dir)
+{
+    if (drfront_sym_init(NULL, "dbghelp.dll") != DRFRONT_SUCCESS) {
+        NOTIFY(0, "Failed to initialize the symbol module" NL);
+        return DRMF_ERROR;
+    }
+    /* Set _NT_SYMBOL_PATH for the app. */
+    char symsrv_dir[MAXIMUM_PATH];
+    if (drfront_set_client_symbol_search_path(cache_dir, false, symsrv_dir,
+                                              BUFFER_SIZE_ELEMENTS(symsrv_dir)) !=
+        DRFRONT_SUCCESS ||
+        drfront_set_symbol_search_path(symsrv_dir) != DRFRONT_SUCCESS)
+        NOTIFY(0, "WARNING: Can't set symbol search path. Symbol lookup may fail." NL);
+
+    for (int i = 0; i < num_sysnum_libs; ++i) {
+        char pdb_path[MAXIMUM_PATH];
+        drfront_status_t sc = DRFRONT_SUCCESS;
+        /* Sometimes there are transient errors on the symbol server side so we
+         * re-try.
+         */
+#define NUM_TRIES 2
+        for (int j = 0; j < NUM_TRIES; ++j) {
+            NOTIFY(1, "Fetching symbols for \"%s\", attempt #%d" NL,
+                   sysnum_lib_paths[i], j);
+            sc = drfront_fetch_module_symbols(sysnum_lib_paths[i], pdb_path,
+                                              BUFFER_SIZE_ELEMENTS(pdb_path));
+            if (sc == DRFRONT_SUCCESS) {
+                NOTIFY(1, "\tSuccessfully fetched or found symbols at \"%s\"" NL,
+                       pdb_path);
+                break;
+            }
+            /* Else try again */
+            /* An invalid local path does not produce very useful error messages,
+             * so we blindly try without it.  Things like forward slashes cause
+             * problems.
+             */
+            if (drfront_get_env_var("_NT_SYMBOL_PATH", symsrv_dir,
+                                    BUFFER_SIZE_ELEMENTS(symsrv_dir))
+                == DRFRONT_SUCCESS) {
+                NOTIFY(0, "Ignoring local _NT_SYMBOL_PATH in next attempt." NL);
+                if (drfront_set_client_symbol_search_path
+                    (cache_dir, true, symsrv_dir, BUFFER_SIZE_ELEMENTS(symsrv_dir)) !=
+                    DRFRONT_SUCCESS ||
+                    drfront_set_symbol_search_path(symsrv_dir) != DRFRONT_SUCCESS) {
+                    NOTIFY(0, "WARNING: Can't set symbol search path. "
+                           "Symbol lookup may fail." NL);
+                }
+            }
+        }
+        if (sc != DRFRONT_SUCCESS) {
+            NOTIFY(0, "Failed to fetch symbols for %s: error %d" NL,
+                   sysnum_lib_paths[i], sc);
+            return DRMF_ERROR_NOT_FOUND;
+        }
+    }
+    if (drfront_sym_exit() != DRFRONT_SUCCESS)
+        NOTIFY(0, "drfront_sym_exit failed %d" NL, GetLastError());
+    return DRMF_SUCCESS;
+}
+
+/***************************************************************************
+ * Parse dlls
+ */
+
+/* We expect the win8 x86 sysenter adjacent "inlined" callee to be as simple as
+ *     75caeabc 8bd4        mov     edx,esp
+ *     75caeabe 0f34        sysenter
+ *     75caeac0 c3          ret
+ */
+#define MAX_INSTRS_SYSENTER_CALLEE  4
+/* the max distance from call to the sysenter callee target */
+#define MAX_SYSENTER_CALLEE_OFFSET  0x50
+#define MAX_INSTRS_BEFORE_SYSCALL 16
+#define MAX_INSTRS_IN_FUNCTION 256
+
+/* Returns whether found a syscall.
+ * - found_eax: whether the caller has seen "mov imm => %eax"
+ * - found_edx: whether the caller has seen "mov $0x7ffe0300 => %edx",
+ *              xref the comment below about "mov $0x7ffe0300 => %edx".
+ */
+static bool
+process_syscall_instr(void *dcontext, instr_t *instr, bool found_eax, bool found_edx)
+{
+    /* ASSUMPTION: a mov imm of 0x7ffe0300 into edx followed by an
+     * indirect call via edx is a system call on XP and later
+     * On XP SP1 it's call *edx, while on XP SP2 it's call *(edx)
+     * For wow it's a call through fs.
+     * XXX: DR's core exports various is_*_syscall routines (such as
+     * instr_is_wow64_syscall()) which we could use here instead of
+     * duplicating if they were more flexible about when they could
+     * be called (instr_is_wow64_syscall() for ex. asserts if not
+     * in a wow process).
+     */
+    bool is_wow64 = dr_is_wow64();
+    if (/* int 2e or x64 or win8 sysenter */
+        (instr_is_syscall(instr) &&
+         found_eax && !is_wow64) ||
+        /* sysenter case */
+        (found_edx && found_eax &&
+         instr_is_call_indirect(instr) &&
+         /* XP SP{0,1}, 2003 SP0: call *edx */
+         ((opnd_is_reg(instr_get_target(instr)) &&
+           opnd_get_reg(instr_get_target(instr)) == DR_REG_EDX) ||
+          /* XP SP2, 2003 SP1: call *(edx) */
+          (opnd_is_base_disp(instr_get_target(instr)) &&
+           opnd_get_base(instr_get_target(instr)) == DR_REG_EDX &&
+           opnd_get_index(instr_get_target(instr)) == DR_REG_NULL &&
+           opnd_get_disp(instr_get_target(instr)) == 0))) ||
+        /* wow case
+         * we don't require found_ecx b/c win8 does not use ecx
+         */
+        (is_wow64 && found_eax &&
+         instr_is_call_indirect(instr) &&
+         ((opnd_is_far_base_disp(instr_get_target(instr)) &&
+           opnd_get_base(instr_get_target(instr)) == DR_REG_NULL &&
+           opnd_get_index(instr_get_target(instr)) == DR_REG_NULL &&
+           opnd_get_segment(instr_get_target(instr)) == DR_SEG_FS) ||
+          /* win10 has imm in edx and a near call */
+          found_edx)))
+        return true;
+    return false;
+}
+
+/* Returns whether found a syscall.
+ * - found_eax: whether the caller has seen "mov imm => %eax"
+ * - found_edx: whether the caller has seen "mov $0x7ffe0300 => %edx",
+ *              xref the comment in process_syscall_instr.
+ */
+static bool
+process_syscall_call(void *dcontext, byte *next_pc, instr_t *call,
+                     bool found_eax, bool found_edx)
+{
+    int num_instr;
+    byte *pc;
+    instr_t instr;
+    bool found_syscall = false;
+
+    assert(instr_get_opcode(call) == OP_call && opnd_is_pc(instr_get_target(call)));
+    pc = opnd_get_pc(instr_get_target(call));
+    if (pc > next_pc + MAX_SYSENTER_CALLEE_OFFSET ||
+        pc <= next_pc /* assuming the call won't go backward */)
+        return false;
+    /* Handle win8 x86 which has sysenter callee adjacent-"inlined":
+     *     ntdll!NtYieldExecution:
+     *     77d7422c b801000000  mov     eax,1
+     *     77d74231 e801000000  call    ntdll!NtYieldExecution+0xb (77d74237)
+     *     77d74236 c3          ret
+     *     77d74237 8bd4        mov     edx,esp
+     *     77d74239 0f34        sysenter
+     *     77d7423b c3          ret
+     *
+     * Or DrMem-i#1366-c#2:
+     *     USER32!NtUserCreateWindowStation:
+     *     75caea7a b841110000  mov     eax,0x1141
+     *     75caea7f e838000000  call    user32!...+0xd (75caeabc)
+     *     75caea84 c22000      ret     0x20
+     *     ...
+     *     USER32!GetWindowStationName:
+     *     75caea8c 8bff        mov     edi,edi
+     *     75caea8e 55          push    ebp
+     *     ...
+     *     75caeabc 8bd4        mov     edx,esp
+     *     75caeabe 0f34        sysenter
+     *     75caeac0 c3          ret
+     */
+    /* We expect the win8 x86 sysenter adjacent "inlined" callee to be as simple as
+     *     75caeabc 8bd4        mov     edx,esp
+     *     75caeabe 0f34        sysenter
+     *     75caeac0 c3          ret
+     */
+    instr_init(dcontext, &instr);
+    num_instr = 0;
+    do {
+        instr_reset(dcontext, &instr);
+        pc = decode(dcontext, pc, &instr);
+        if (op_verbose_level >= 3)
+            dr_print_instr(dcontext, STDOUT, &instr, "");
+        if (pc == NULL || !instr_valid(&instr))
+            break;
+        if (instr_is_syscall(&instr) || instr_is_call_indirect(&instr)) {
+            found_syscall = process_syscall_instr(dcontext, &instr, found_eax, found_edx);
+            break;
+        } else if (instr_is_cti(&instr)) {
+            break;
+        }
+        num_instr++;
+    } while (num_instr <= MAX_INSTRS_SYSENTER_CALLEE);
+    instr_free(dcontext, &instr);
+    return found_syscall;
+}
+
+static int
+get_syscall_num(void *dcontext, byte *pc, byte *mod_start, byte *mod_end)
+{
+    bool found_syscall = false, found_eax = false, found_edx = false, found_ecx = false;
+    byte *pre_pc;
+    int sysnum = -1;
+    int num_instr = 0;
+    bool is_wow64 = dr_is_wow64();
+    bool is_x64 = IF_X64_ELSE(true, false);
+    instr_t instr;
+    instr_init(dcontext, &instr);
+
+    while (true) {
+        instr_reset(dcontext, &instr);
+        pre_pc = pc;
+        pc = decode(dcontext, pc, &instr);
+        if (op_verbose_level >= 3) {
+            instr_set_translation(&instr, pre_pc);
+            dr_print_instr(dcontext, STDOUT, &instr, "");
+        }
+        if (pc == NULL || !instr_valid(&instr))
+            break;
+        if (instr_is_syscall(&instr) || instr_is_call_indirect(&instr)) {
+            /* If we see a syscall instr or an indirect call which is not syscall,
+             * we assume this is not a syscall wrapper.
+             */
+            found_syscall = process_syscall_instr(dcontext, &instr, found_eax, found_edx);
+            if (!found_syscall)
+                break; /* assume not a syscall wrapper, give up gracefully */
+        } else if (instr_is_return(&instr)) {
+            /* we must break on return to avoid case like win8 x86
+             * which has sysenter callee adjacent-"inlined"
+             *     ntdll!NtYieldExecution:
+             *     77d7422c b801000000  mov     eax,1
+             *     77d74231 e801000000  call    ntdll!NtYieldExecution+0xb (77d74237)
+             *     77d74236 c3          ret
+             *     77d74237 8bd4        mov     edx,esp
+             *     77d74239 0f34        sysenter
+             *     77d7423b c3          ret
+             */
+            /* If we wanted the # args we'd get it here, for stdcall. */
+            break;
+        } else if (instr_get_opcode(&instr) == OP_call) {
+            found_syscall = process_syscall_call(dcontext, pc, &instr,
+                                                 found_eax, found_edx);
+            /* If we see a call and it is not a sysenter callee,
+             * we assume this is not a syscall wrapper.
+             */
+            if (!found_syscall)
+                break; /* assume not a syscall wrapper, give up gracefully */
+        } else if (instr_is_cti(&instr)) {
+            /* We expect only ctis like ret or ret imm, syscall, and call, which are
+             * handled above. Give up gracefully if we hit any other cti.
+             * XXX: what about jmp to shared ret (seen in the past on some syscalls)?
+             */
+            /* Update: win10 TH2 1511 x64 has a cti:
+             *   ntdll!NtContinue:
+             *   00007ff9`13185630 4c8bd1          mov     r10,rcx
+             *   00007ff9`13185633 b843000000      mov     eax,43h
+             *   00007ff9`13185638 f604250803fe7f01 test byte ptr [SharedUserData+0x308
+             *                                                     (00000000`7ffe0308)],1
+             *   00007ff9`13185640 7503            jne     ntdll!NtContinue+0x15
+             *                                             (00007ff9`13185645)
+             *   00007ff9`13185642 0f05            syscall
+             *   00007ff9`13185644 c3              ret
+             *   00007ff9`13185645 cd2e            int     2Eh
+             *   00007ff9`13185647 c3              ret
+             */
+            if (is_x64 && instr_is_cbr(&instr) &&
+                opnd_get_pc(instr_get_target(&instr)) == pc + 3/*syscall;ret*/) {
+                /* keep going */
+            } else
+                break;
+        } else if ((!found_eax || !found_edx || !found_ecx) &&
+                   instr_get_opcode(&instr) == OP_mov_imm &&
+                   opnd_is_reg(instr_get_dst(&instr, 0))) {
+            if (!found_eax && opnd_get_reg(instr_get_dst(&instr, 0)) == DR_REG_EAX) {
+                sysnum = (int) opnd_get_immed_int(instr_get_src(&instr, 0));
+                found_eax = true;
+            } else if (!found_edx &&
+                       opnd_get_reg(instr_get_dst(&instr, 0)) == DR_REG_EDX) {
+                uint imm = (uint) opnd_get_immed_int(instr_get_src(&instr, 0));
+                if (imm == 0x7ffe0300 ||
+                    /* On Win10 the immed is ntdll!Wow64SystemServiceCall */
+                    (is_wow64 && imm > (ptr_uint_t)mod_start &&
+                     imm < (ptr_uint_t)mod_end))
+                    found_edx = true;
+            } else if (!found_ecx &&
+                       opnd_get_reg(instr_get_dst(&instr, 0)) == DR_REG_ECX) {
+                found_ecx = true;
+                /* If we wanted the wow64 fixup index we'd get it here */
+            }
+        } else if (instr_get_opcode(&instr) == OP_xor &&
+                   opnd_is_reg(instr_get_src(&instr, 0)) &&
+                   opnd_get_reg(instr_get_src(&instr, 0)) == DR_REG_ECX &&
+                   opnd_is_reg(instr_get_dst(&instr, 0)) &&
+                   opnd_get_reg(instr_get_dst(&instr, 0)) == DR_REG_ECX) {
+            /* xor to 0 */
+            found_ecx = true;
+        }
+        num_instr++;
+        if (num_instr > MAX_INSTRS_BEFORE_SYSCALL) /* wrappers should be short! */
+            break; /* avoid weird cases like NPXEMULATORTABLE */
+    }
+    instr_free(dcontext, &instr);
+
+    if (found_syscall)
+        return sysnum;
+    return -1;
+}
+
+typedef struct _search_data_t {
+    void *dcontext;
+    byte *dll_base;
+    size_t dll_size;
+    std::string prefix_to_add;
+    std::unordered_map<std::string, int> *name2num;
+    byte *usercall_addr[NUM_USERCALL];
+    size_t usercall_targets_found;
+    size_t usercalls_found;
+} search_data_t;
+
+static bool
+search_syms_cb(const char *name, size_t modoffs, void *data)
+{
+    NOTIFY(3, "Found symbol \"%s\" at offs "PIFX"\n" NL, name, modoffs);
+    search_data_t *sd = (search_data_t *) data;
+    /* XXX DRi#2715: drsyms sometimes passes bogus offsets so we're robust here */
+    if (modoffs >= sd->dll_size)
+        return true;
+    /* We ignore the Zw variant */
+    if (name[0] != 'Z' || name[1] != 'w') {
+        int num = get_syscall_num(sd->dcontext, sd->dll_base + modoffs, sd->dll_base,
+                                  sd->dll_base + sd->dll_size);
+        std::string add_as = std::string(name);
+        if (name[0] != 'N' || name[1] != 't')
+            add_as = sd->prefix_to_add + add_as;
+        if (num != -1)
+            (*sd->name2num)[add_as] = num;
+    }
+    if (sd->usercall_targets_found > 0) {
+        std::pair<std::string, int> name_num =
+            look_for_usercall(sd->dcontext, sd->dll_base + modoffs, name,
+                              sd->dll_base + sd->dll_size, sd->usercall_addr);
+        if (name_num.second != -1) {
+            NOTIFY(2, "Adding usercall %s = 0x%x\n", name_num.first.c_str(),
+                   name_num.second);
+            ++sd->usercalls_found;
+            (*sd->name2num)[name_num.first] = name_num.second;
+        }
+    }
+    return true; /* keep iterating */
+}
+
+static drmf_status_t
+identify_syscalls(void *dcontext, const char **dlls, size_t num_dlls,
+                  std::unordered_map<std::string, int> &name2num)
+{
+    if (drsym_init(NULL) != DRSYM_SUCCESS) {
+        NOTIFY(0, "Failed to initialize drsyms" NL);
+        return DRMF_ERROR;
+    }
+    for (size_t i = 0; i < num_dlls; ++i) {
+        size_t map_size;
+        byte *map_base = dr_map_executable_file(dlls[i], DR_MAPEXE_SKIP_WRITABLE,
+                                                &map_size);
+        if (map_base == NULL) {
+            NOTIFY(0, "Failed to map \"%s\"" NL, dlls[i]);
+            return DRMF_ERROR;
+        }
+
+        /* We go through all symbols. */
+        size_t prev_size = name2num.size();
+        std::string pattern(std::string(dlls[i]) + "!*");
+        std::string prefix = "";
+        if (strcasestr(dlls[i], "user32") != NULL ||
+            strcasestr(dlls[i], "win32u") != NULL ||
+            strcasestr(dlls[i], "imm32") != NULL)
+            prefix = "NtUser";
+        else if (strcasestr(dlls[i], "gdi32") != NULL)
+            prefix = "NtGdi";
+        NOTIFY(1, "Searching for system calls in \"%s\"" NL, dlls[i]);
+        search_data_t sd = {dcontext, map_base, map_size, prefix, &name2num, };
+        look_for_usercall_targets(dlls[i], map_base, map_size, sd.usercall_addr,
+                                  &sd.usercall_targets_found);
+        drsym_error_t symres = drsym_search_symbols(dlls[i], pattern.c_str(),
+                                                    true, search_syms_cb, &sd);
+        if (symres != DRSYM_SUCCESS) {
+            NOTIFY(0, "Error %d searching \"%s\"" NL, symres, dlls[i]);
+            return DRMF_ERROR;
+        }
+        NOTIFY(1, "\tFound %d system calls (%d usercalls) in \"%s\"" NL,
+               name2num.size() - prev_size, sd.usercalls_found, dlls[i]);
+        if (!dr_unmap_executable_file(map_base, map_size))
+            NOTIFY(0, "Failed to unmap \"%s\"" NL, dlls[i]);
+        /* We may as well clean up.  This also prevents drsyms from searching
+         * in other libraries, in case our qualified names fall back to global.
+         */
+        symres = drsym_free_resources(dlls[i]);
+        if (symres != DRSYM_SUCCESS) {
+            NOTIFY(0, "Error %d unloading \"%s\"" NL, symres, dlls[i]);
+            /* This is a non-fatal error. */
+        }
+    }
+    drsym_exit();
+    return DRMF_SUCCESS;
+}
+
+/***************************************************************************
+ * Write out file
+ */
+
+static bool
+cmp_names(const std::pair<std::string, int> &left,
+          const std::pair<std::string, int> &right)
+{
+    return left.first < right.first;
+}
+
+static drmf_status_t
+write_file(const std::unordered_map<std::string, int> &name2num, const std::string &outf)
+{
+    std::string key("NtGetContextThread");
+    if (name2num.find(key) == name2num.end()) {
+        NOTIFY(0, "Failed to determine number for %s" NL, key.c_str());
+        return DRMF_ERROR;
+    }
+    file_t f = dr_open_file(outf.c_str(), DR_FILE_WRITE_OVERWRITE);
+    if (f == INVALID_FILE) {
+        NOTIFY(0, "Failed to write to %s" NL, outf);
+        return DRMF_ERROR_ACCESS_DENIED;
+    }
+    NOTIFY(1, "Writing to \"%s\"" NL, outf.c_str());
+    dr_fprintf(f, "%s\n%d\n%s\n", DRSYS_SYSNUM_FILE_HEADER, DRSYS_SYSNUM_FILE_VERSION,
+               key.c_str());
+    dr_fprintf(f, "START=0x%x\n", name2num.at(key));
+
+    /* It doesn't have to be sorted but it's nicer for humans this way. */
+    std::vector<std::pair<std::string, int> > sorted(name2num.size());
+    std::partial_sort_copy(name2num.begin(), name2num.end(),
+                           sorted.begin(), sorted.end(), cmp_names);
+    for (const auto &keyval : sorted) {
+        NOTIFY(2, "%s == 0x%x" NL, keyval.first.c_str(), keyval.second);
+        dr_fprintf(f, "%s=0x%x\n", keyval.first.c_str(), keyval.second);
+    }
+
+    // The usercalls are different because we can't find wrappers for many of them.
+    // They run in consecutive numbers so we fill in gaps as best we can.
+    std::unordered_map<int, std::string> num2name;
+    for (const auto &keyval : name2num) {
+        num2name[keyval.second] = keyval.first;
+    }
+    int num = -1;
+#define NONE -1
+#define USERCALL(type, name, w2k, xp, w2003, vistaSP01, vistaSP2, w7, w8, w81, w10, \
+                 w11, w12, w13, w14, w15) \
+    do {                                    \
+        std::string sysname(#type"."#name); \
+        auto keyval = name2num.find(sysname); \
+        if (keyval != name2num.end())               \
+            num = (*keyval).second;             \
+        else if (w15 != -1) { /* Assume once gone it's not coming back */ \
+            ++num; \
+            /* If an entry was removed we'll collide.  Just skip in that case. */\
+            if (num2name.find(num) == num2name.end()) { \
+                NOTIFY(2, "%s == 0x%x" NL, sysname.c_str(), num);           \
+                dr_fprintf(f, "%s=0x%x\n", sysname.c_str(), num);   \
+            }\
+        } \
+    } while (false);
+#include "drsyscall_usercallx.h"
+#undef USERCALL
+#undef NONE
+
+    dr_fprintf(f, "%s\n", DRSYS_SYSNUM_FILE_FOOTER);
+    dr_close_file(f);
+    NOTIFY(0, "Successfully wrote \"%s\"" NL, outf.c_str());
+    return DRMF_SUCCESS;
+}
+
+/***************************************************************************
+ * Top-level
+ */
+
+DR_EXPORT
+drmf_status_t
+drsys_generate_sysnum_file(void *drcontext, const char **sysnum_lib_paths,
+                           size_t num_sysnum_libs, const char *outfile,
+                           const char *cache_dir)
+{
+    bool ok;
+    if (drfront_access(cache_dir, DRFRONT_WRITE, &ok) != DRFRONT_SUCCESS || !ok) {
+        NOTIFY(0, "Invalid -cache_dir: cannot find/write %s" NL, cache_dir);
+        return DRMF_ERROR_INVALID_PARAMETER;
+    }
+    NOTIFY(1, "Symbol cache directory is \"%s\"" NL, cache_dir);
+
+    std::unordered_map<std::string, int> name2num;
+
+    drmf_status_t res = fetch_symbols(sysnum_lib_paths, num_sysnum_libs, cache_dir);
+    if (res != DRMF_SUCCESS)
+        return res;
+
+    res = identify_syscalls(drcontext, sysnum_lib_paths, num_sysnum_libs, name2num);
+    if (res != DRMF_SUCCESS)
+        return res;
+
+    res = write_file(name2num, outfile);
+    if (res != DRMF_SUCCESS)
+        return res;
+
+    return DRMF_SUCCESS;
+}

--- a/framework/drmf_utils.c
+++ b/framework/drmf_utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -26,7 +26,7 @@
 #include "dr_api.h"
 
 bool op_print_stderr = false;
-uint op_verbose_level = 0;
+int op_verbose_level = -1;
 bool op_ignore_asserts = true;
 file_t f_global = INVALID_FILE;
 int tls_idx_util = -1;
@@ -83,6 +83,9 @@ nonheap_free(void *p, size_t size, heapstat_t type)
     dr_nonheap_free(p, size);
 }
 
+#ifdef UNIX
+LINK_ONCE
+#endif
 bool
 safe_read(void *base, size_t size, void *out_buf)
 {

--- a/make/resources.rc
+++ b/make/resources.rc
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -55,6 +55,10 @@
 #elif defined(RC_IS_FRONTEND)
 # define FILE_NAME TOOLNAME ".exe"
 # define FILE_DESCRIPTION TOOLNAME_CAP_SPC " front end"
+# define FILE_TYPE VFT_APP
+#elif defined(RC_IS_GENSYSNUMS)
+# define FILE_NAME "gensysnums.exe"
+# define FILE_DESCRIPTION "System call number utility"
 # define FILE_TYPE VFT_APP
 #elif defined(RC_IS_SYMQUERY)
 # define FILE_NAME "symquery.exe"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1053,10 +1053,10 @@ if (NOT APPLE AND NOT ARM)
     # our internal tables.
     find_package(Perl)
     if (NOT PERL_FOUND)
-      message(STATUS "Warning: perl not found: disabling syscall file tests")
+      message(STATUS "Warning: perl not found: disabling syscall_file_all test")
     else ()
-      # DrM looks in the bin dir:
-      set(syscall_file_path "${PROJECT_BINARY_DIR}/${BUILD_BIN}")
+      # Place somewhere that DrM won't look by default:
+      set(syscall_file_path "${CMAKE_CURRENT_BINARY_DIR}")
       add_custom_target(syscall_files ALL
         DEPENDS "${syscall_file_path}/syscalls_x86.txt")
       add_custom_command(
@@ -1067,13 +1067,20 @@ if (NOT APPLE AND NOT ARM)
         COMMAND ${PERL_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/mksyscalltxt.pl
           ${syscall_file_path}
         VERBATIM)
-      newtest_nobuild(syscall_file app_suite_tests
+      newtest_nobuild(syscall_file_all app_suite_tests
         # Run enough tests to generate some errors w/o accurate syscall info.
         # Disable Msgbox (slow) and ScrollDC (GDI error flakiness).
         "--gtest_filter=ATLTests.*:NtUserTests.*:-NtUserTests.Msgbox:NtUserTests.ScrollDC"
-        "-no_use_syscall_tables;-ignore_kernel;-suppress;{DRMEMORY_CTEST_SRC_DIR}/app_suite/default-suppressions.txt"
-        "-checklevel;1" OFF "")
+        "-no_use_syscall_tables;-ignore_kernel;-syscall_number_path;${syscall_file_path};-suppress;{DRMEMORY_CTEST_SRC_DIR}/app_suite/default-suppressions.txt"
+        "-checklevel;1" OFF "syscall_file")
     endif (NOT PERL_FOUND)
+    # Test auto-generating syscall number files (i#1848):
+    newtest_nobuild(syscall_file_gen app_suite_tests
+      # Run enough tests to generate some errors w/o accurate syscall info.
+      # Disable Msgbox (slow) and ScrollDC (GDI error flakiness).
+      "--gtest_filter=ATLTests.*:NtUserTests.*:-NtUserTests.Msgbox:NtUserTests.ScrollDC"
+      "-no_use_syscall_tables;-suppress;{DRMEMORY_CTEST_SRC_DIR}/app_suite/default-suppressions.txt"
+      "-checklevel;1" OFF "syscall_file")
   endif ()
 endif ()
 

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # **********************************************************
-# Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -114,11 +114,13 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'wrap_wincrt' => 1, # i#1741: flaky.
                                    'app_suite.pattern' => 1,
                                    'app_suite' => 1,
-                                   'drstrace_unit_tests' => 1);
+                                   'drstrace_unit_tests' => 1, # i#2156: sym fetch
+                                   'syscall_file_gen' => 1); # i#2156: sym fetch
             %ignore_failures_64 = ('handle' => 1,
                                    'app_suite' => 1,
                                    'app_suite.pattern' => 1,
-                                   'drstrace_unit_tests' => 1);
+                                   'drstrace_unit_tests' => 1, # i#2156: sym fetch
+                                   'syscall_file_gen' => 1); # i#2156: sym fetch
         } elsif ($^O eq 'darwin' || $^O eq 'MacOS') {
             %ignore_failures_32 = ('malloc' => 1); # i#2038
             %ignore_failures_64 = ('malloc' => 1);


### PR DESCRIPTION
Moves the default syscall file location into logs/symbols instead of the
bin/ directory, as we need a writable location.  Adds a new option
-syscall_number_path to allow specifying a custom location.

Adds functionality to drsyscall to fetch debug info for system libraries
and parse every symbol in each library looking for syscall wrappers.  Two
interfaces are added: drsys_find_sysnum_dlls() and
drsys_generate_sysnum_file().  Includes usercall identification support via
a list of target wrappers for key usercalls plus interpolation between
known numbers to include speculative results for all usercalls.  The
syscall wrapper parsing code is based on DR's winsysnums.c, expanded to
support 64-bit.

The resulting syscall file only supports the current machine, unlike the
general files we have posted for downloading.

Adds auto-triggering of the new functionality when an unknown OS version is
detected.  A special exit code is used, and when the frontend sees it, it
invokes the drsyscall functions for generating a syscall file.  If that is
successful, it re-launches the app.

Adds new options -vv and -vvv to support raising verbosity for the
drsyscall code invoked directly from the frontend.

Changes the existing mksystable.pl-based test to test the new auto-gen
functionality.

Fixes #1848