### PR TITLE
i#2126 win10-1809: Fix 32-bit crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -819,7 +819,7 @@ else ()
 endif ()
 
 # when updating this, also update the git submodule
-set(DynamoRIO_VERSION_REQUIRED "7.0.17855")
+set(DynamoRIO_VERSION_REQUIRED "7.1.17952")
 
 set(DR_install_dir "dynamorio")
 

--- a/drmemory/docs/release.dox
+++ b/drmemory/docs/release.dox
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -65,6 +65,8 @@ The changes between \TOOL_VERSION and version 1.11.0 include:
    checking) support for Linux.
  - Added preliminary support for the Windows Subsystem for Linux
    environment with the regular Dr. Memory Linux package.
+ - Added automated generation of system call information on Windows,
+   enabling running on new releases of Windows 10.
  - Added support for Windows 10 1703.
  - Added support for Windows 10 1709.
  - Added support for Windows 10 1803.

--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -968,18 +968,21 @@ _tmain(int argc, TCHAR *targv[])
             verbose = true;
             /* Enable verbosity in pdf2sysfile.cpp */
             op_verbose_level = 1;
+            drfront_set_verbose(op_verbose_level);
             continue;
         }
         else if (strcmp(argv[i], "-vv") == 0) {
             verbose = true;
             /* Enable verbosity in pdf2sysfile.cpp */
             op_verbose_level = 2;
+            drfront_set_verbose(op_verbose_level);
             continue;
         }
         else if (strcmp(argv[i], "-vvv") == 0) {
             verbose = true;
             /* Enable extra verbosity in pdf2sysfile.cpp */
             op_verbose_level = 3;
+            drfront_set_verbose(op_verbose_level);
             continue;
         }
         else if (strcmp(argv[i], "-h") == 0 ||


### PR DESCRIPTION
Updates DR to dbccde9d for two features:
+ DRi#3391: dynamically identify APC CONTEXT offset, to fix an assert in
  every app and crashes in apps with APC's on win10-1809.
+ The addition of drfront_set_verbose() which we now use here when
  -v* is passed for symbol fetching diagnostics.

Issue: #2126, #1848