### PR TITLE
i#2127: Add further Windows version info to diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,7 +819,7 @@ else ()
 endif ()
 
 # when updating this, also update the git submodule
-set(DynamoRIO_VERSION_REQUIRED "7.1.17952")
+set(DynamoRIO_VERSION_REQUIRED "7.1.17958")
 
 set(DR_install_dir "dynamorio")
 

--- a/common/utils.c
+++ b/common/utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -905,6 +905,10 @@ init_os_version(void)
         os_version.version = DR_WINDOWS_VERSION_10_1803;
         os_version.service_pack_major = 1;
         os_version.service_pack_minor = 0;
+        /* Make it clear we don't know these fields: */
+        os_version.build_number = 0;
+        os_version.release_id[0] = '\0';
+        os_version.edition[0] = '\0';
     }
 }
 
@@ -939,6 +943,17 @@ get_windows_version(void)
     if (os_version.version == 0)
         init_os_version();
     return os_version.version;
+}
+
+void
+get_windows_version_string(char *buf OUT, size_t bufsz)
+{
+    if (os_version.version == 0)
+        init_os_version();
+    dr_snprintf(buf, bufsz, "WinVer=%u;Rel=%s;Build=%u;Edition=%s",
+                os_version.version, os_version.release_id, os_version.build_number,
+                os_version.edition);
+    buf[bufsz - 1] = '\0';
 }
 
 GET_NTDLL(NtQuerySystemInformation, (IN  SYSTEM_INFORMATION_CLASS info_class,

--- a/common/utils.h
+++ b/common/utils.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -30,7 +30,11 @@ extern "C" {
 #ifdef WINDOWS
 /* DRi#1424: avoid pulling in features from recent versions to keep compatibility */
 # ifndef _WIN32_WINNT
-#  define _WIN32_WINNT _WIN32_WINNT_WIN2K
+#  ifdef X64
+#   define _WIN32_WINNT _WIN32_WINNT_WIN2003
+#  else
+#   define _WIN32_WINNT _WIN32_WINNT_WINXP
+#  endif
 # endif
 #endif
 
@@ -926,6 +930,9 @@ running_on_Vista_or_later(void);
 
 dr_os_version_t
 get_windows_version(void);
+
+void
+get_windows_version_string(char *buf OUT, size_t bufsz);
 
 app_pc
 get_highest_user_address(void);

--- a/drmemory/drmemory.c
+++ b/drmemory/drmemory.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1819,18 +1819,24 @@ dr_init(client_id_t id)
 #endif
     module_data_t *data;
     const char *opstr;
-    char tool_ver[64];
+    char tool_ver[128];
+    char os_ver[96];
 
-    dr_set_client_name("Dr. Memory", "http://drmemory.org/issues");
+    dr_set_client_name("Dr. Memory", "http://drmemory.org/issues"
+                       /* Try to get more info from users. */
+                       IF_DEBUG_ELSE("", " along with the results of running "
+                                     "'-debug -dr_debug'"));
 
     utils_early_init();
 
+#ifdef WINDOWS
+    get_windows_version_string(os_ver, BUFFER_SIZE_ELEMENTS(os_ver));
+#else
+    os_ver[0] = '\0';
+#endif
     dr_snprintf(tool_ver, BUFFER_SIZE_ELEMENTS(tool_ver),
                 /* we include the date to distinguish RC and custom builds */
-                "%s-%d-(%s)%s%d", VERSION_STRING, BUILD_NUMBER, build_date,
-                /* we include the Windows version here for convenience */
-                IF_WINDOWS_ELSE(" win",""),
-                IF_WINDOWS_ELSE(get_windows_version(),0));
+                "%s-%d-(%s) %s", VERSION_STRING, BUILD_NUMBER, build_date, os_ver);
     NULL_TERMINATE_BUFFER(tool_ver);
     dr_set_client_version_string(tool_ver);
 
@@ -1907,7 +1913,11 @@ dr_init(client_id_t id)
            "redzone size not large enough to store size");
 
     create_global_logfile();
-    LOG(0, "options are \"%s\"\n", opstr);
+#ifdef WINDOWS
+    LOG(0, "Windows version: %s\n", os_ver);
+    ELOGF(0, f_results, "Windows version: %s" NL, os_ver);
+#endif
+    LOG(0, "Options are \"%s\"\n", opstr);
 
     /* delayed from getting app_path, etc. until have logfile and ops */
     ASSERT(app_base != NULL, "internal error finding executable base");

--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -805,6 +805,13 @@ _tmain(int argc, TCHAR *targv[])
 
 #ifdef WINDOWS
     time_t start_time, end_time;
+# ifdef DEBUG
+    /* Avoid stderr printing in debug build from version init on new win10
+     * (otherwise we get 2 prints, one here and in the client).
+     */
+    if (!SetEnvironmentVariable(L"DYNAMORIO_OPTIONS", L"-stderr_mask 0"))
+        info("Failed to quiet frontend DR messages");
+# endif
 #endif
 
     drfront_status_t sc;

--- a/drmemory/syscall.c
+++ b/drmemory/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -698,8 +698,11 @@ syscall_init(void *drcontext _IF_WINDOWS(app_pc ntdll_base))
     res = drsys_init(client_id, &ops);
 #ifdef WINDOWS
     if (res == DRMF_WARNING_UNSUPPORTED_KERNEL) {
-        NOTIFY_ERROR("Running on an unsupported operating system version."
-                     "%s" NL, options.ignore_kernel ? "" :
+        char os_ver[96];
+        get_windows_version_string(os_ver, BUFFER_SIZE_ELEMENTS(os_ver));
+        NOTIFY_ERROR("Running on an unsupported operating system version: %s."
+                     "%s" NL, os_ver,
+                     options.ignore_kernel ? "" :
                      " Exiting to trigger auto-generation of system call information."
                      " Re-run with -ignore_kernel to attempt to continue instead.");
         if (options.ignore_kernel)


### PR DESCRIPTION
Updates DR to fae84d17 to retrieve the Windows build number, edition, and
release identifier.

Prints the new version information in the following places:
+ crash messages;
+ the win10 message about auto-generating syscall info for a new version;
+ results.txt;
+ global logfile.

Suppresses extra printing of DR Windows version warnings in debug build
from the frontend's use of DR standalone mode.

Asks the user to run "-debug -dr_debug" in release build crash messages.

Fixes #2127