### PR TITLE
i#111 win64: enable full mode by default for Windows 64

### DIFF
--- a/drmemory/docs/release.dox
+++ b/drmemory/docs/release.dox
@@ -62,7 +62,7 @@ The Dr. Memory distribution contains the following:
 The current version is \TOOL_VERSION.
 The changes between \TOOL_VERSION and version 1.11.0 include:
  - Added preliminary 64-bit full mode (i.e., with uninitialized read
-   checking) support for Linux.
+   checking) support.
  - Added preliminary support for the Windows Subsystem for Linux
    environment with the regular Dr. Memory Linux package.
  - Added automated generation of system call information on Windows,
@@ -410,8 +410,7 @@ The changes between version 1.1.0 and 1.0.1 include:
 Dr. Memory is still under development.  It has some missing features and undoubtedly
 some bugs.  The missing features include:
 
- - Uninitialized read checking is not yet supported for 64-bit applications
-   nor for ARM platforms.
+ - Uninitialized read checking is not yet supported for ARM platforms.
  - Windows system call parameters are not all known, which can
    result in false positives and false negatives, especially on graphical
    applications on more recent versions of Windows.
@@ -419,6 +418,9 @@ some bugs.  The missing features include:
    Dr. Memory attempts to separate such errors into potential_errors.txt.
  - Definedness is tracked at the byte level, not at the bit level,
    which when bitfields are in use can lead to false positives.
+ - Mac OSX supports only 32-bit applications and does not yet have
+   a full isolation barrier between Dr. Memory and the application,
+   which can cause failures on large applications.
  - Race corner cases:
    - Pathological races between mallocs and frees can result in Dr. Memory's
      shadow memory structures becoming mis-aligned with subsequent false

--- a/drmemory/drmemory.c
+++ b/drmemory/drmemory.c
@@ -1890,11 +1890,6 @@ dr_init(client_id_t id)
         NOTIFY("WARNING: Dr. Memory for Mac is Beta software.  Please report any"NL);
         NOTIFY("problems encountered to http://drmemory.org/issues."NL);
 #endif
-#if defined(X64) && defined(WINDOWS)
-        /* i#111: full mode not ported yet to 64-bit Windows */
-        if (options.pattern == 0)
-            NOTIFY("WARNING: 64-bit non-pattern modes are experimental on Windows"NL);
-#endif
 #ifdef ARM
         /* i#1726: full mode not ported yet to ARM */
         if (!option_specified.pattern && !option_specified.light)

--- a/drmemory/optionsx.h
+++ b/drmemory/optionsx.h
@@ -493,10 +493,8 @@ OPTION_CLIENT_BOOL(drmemscope, handle_leaks_only, false,
                    "Check only for handle leak errors and no other errors",
                    "Puts "TOOLNAME" into a handle-leak-check-only mode that has lower overhead but does not detect other types of errors other than handle leaks in Windows.")
 #endif /* WINDOWS */
-/* XXX i#111: x86_64 full mode is not quite ready on Windows */
 /* XXX i#1726: only pattern is currently supported on ARM */
-OPTION_CLIENT_BOOL(drmemscope, check_uninitialized,
-                   IF_ARM_ELSE(false, IF_WINDOWS_ELSE(IF_X64_ELSE(false, true), true)),
+OPTION_CLIENT_BOOL(drmemscope, check_uninitialized, IF_ARM_ELSE(false, true),
                    "Check for uninitialized read errors",
                    "Check for uninitialized read errors.  When disabled, puts "TOOLNAME" into a mode that has lower overhead but does not detect definedness errors.  Furthermore, the lack of definedness information reduces accuracy of leak identification, resulting in potentially failing to identify some leaks.")
 OPTION_CLIENT_BOOL(drmemscope, check_stack_bounds, false,
@@ -590,11 +588,8 @@ OPTION_CLIENT_SCOPE(drmemscope, perturb_seed, uint, 0, 0, UINT_MAX,
 OPTION_CLIENT_BOOL(drmemscope, unaddr_only, false,
                    "Enables a lightweight mode that detects only unaddressable errors",
                    "This option enables a lightweight mode that only detects critical errors of unaddressable accesses on heap data.  This option cannot be used with 'light' or 'check_uninitialized'.")
-/* XXX i#111: x86_64 full mode is not quite ready on Windows */
 /* XXX i#1726: only pattern is currently supported on ARM */
-OPTION_CLIENT_SCOPE(drmemscope, pattern, uint,
-                    IF_ARM_ELSE(DEFAULT_PATTERN,
-                                IF_WINDOWS_ELSE(IF_X64_ELSE(DEFAULT_PATTERN, 0), 0)),
+OPTION_CLIENT_SCOPE(drmemscope, pattern, uint, IF_ARM_ELSE(DEFAULT_PATTERN, 0),
                     0, USHRT_MAX,
                     "Enables pattern mode. A non-zero 2-byte value must be provided",
                     "Use sentinels to detect accesses on unaddressable regions around allocated heap objects.  When this option is enabled, checks for uninitialized read errors will be disabled.  The value passed as the pattern must be a non-zero 2-byte value.")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -424,9 +424,8 @@ function(newtest_gcc test source depender gcc_ops test_ops drmem_ops dr_ops
   add_dependencies(${depender} target_${test})
 endfunction(newtest_gcc)
 
-# FIXME i#111: 64-bit full mode doesn't quite support Windows yet.
 # i#1726: ARM is only supported in pattern mode.
-if (NOT ARM AND UNIX OR NOT X64)
+if (NOT ARM)
 # Leaving indentation as-is to avoid code churn
 newtest(hello hello.c)
 newtest(malloc malloc.c)
@@ -447,9 +446,7 @@ else ()
 endif ()
 if (TOOL_DR_MEMORY)
   # Doesn't make sense for DrHeapstat
-  if (NOT X64) # FIXME i#111: failing on Travis
-    newtest(multierror multierror.cpp)
-  endif ()
+  newtest(multierror multierror.cpp)
 endif (TOOL_DR_MEMORY)
 if (NOT ARM) # XXX i#1726: port to ARM
   newtest_custbuild(bitfield bitfield.cpp "-DBITFIELD_ASM" bitfield)

--- a/tests/runtest.cmake
+++ b/tests/runtest.cmake
@@ -482,10 +482,10 @@ foreach (line ${lines})
     if (TOOL_DR_HEAPSTAT AND "${line}" MATCHES "~~")
       set(enable_check OFF)
     endif ()
-    # XXX i#111, i#1726: on ARM and x64 Windows, we don't yet support
+    # XXX i#1726: on ARM, we don't yet support
     # full mode, but we will soon.  To avoid changing a ton of .res
     # files we instead just ignore uninit lines here.
-    if (ARM OR WIN32 AND X64)
+    if (ARM)
       if ("${line}" MATCHES "total uninitialized")
         set(enable_check OFF)
         set(remove_line OFF)


### PR DESCRIPTION
Updates the options, tests, and documentation for making full mode the
default for 64-bit Windows.

Issue: #111