### PR TITLE
i#111 x64: support -leaks_only -no_esp_fastpath

### DIFF
--- a/drmemory/options.c
+++ b/drmemory/options.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -450,12 +450,6 @@ options_init(const char *opstr)
             options.check_gdi = false;
     }
 #endif
-    /* i#677: drmemory -leaks_only does not work with -no_esp_fastpath
-     * XXX: there is nothing fundamentally impossible, it is just we didn't
-     * bother to make it work as such combination is not very useful.
-     */
-    if (options.leaks_only && !options.esp_fastpath)
-        usage_error("-leaks_only cannot be used with -no_esp_fastpath", "");
     if (options.perturb_only) {
         options.perturb = true;
         options.track_allocs = false;

--- a/drmemory/stack.c
+++ b/drmemory/stack.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -504,7 +504,8 @@ bool
 instrument_esp_adjust(void *drcontext, instrlist_t *bb, instr_t *inst, bb_info_t *bi,
                       sp_adjust_action_t sp_action)
 {
-    if (options.esp_fastpath)
+    /* i#677: We don't need -esp_fastpath gencode for insert_zeroing_loop(). */
+    if (options.esp_fastpath || sp_action == SP_ADJUST_ACTION_ZERO)
         return instrument_esp_adjust_fastpath(drcontext, bb, inst, bi, sp_action);
     else
         return instrument_esp_adjust_slowpath(drcontext, bb, inst, bi, sp_action);

--- a/tests/asmtest_x86.c
+++ b/tests/asmtest_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -461,6 +461,7 @@ GLOBAL_LABEL(FUNCNAME:)
 /* void asm_test_reach(); */
         DECLARE_FUNC_SEH(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
+        END_PROLOG
         mov      eax, 0
         movdqu   XMMWORD [8 + REG_XSP + REG_XAX], xmm0
         ret


### PR DESCRIPTION
For x64 we do not yet have -esp_fastpath, but we want to support
-leaks_only.  It uses part of the -esp_fastpath path to run a stack
zeroing loop, but it does not actually need the -esp_fastpath gencode,
so we simply remove the option check and route to the fastpath
handler.

Issue: #111, #677