### PR TITLE
i#111 win64: Add recent syscall info for procterm test

### DIFF
--- a/drsyscall/table_windows_ntoskrnl.c
+++ b/drsyscall/table_windows_ntoskrnl.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -40,7 +40,9 @@
 #include "../wininc/ntalpctyp.h"
 #include "../wininc/wdm.h"
 #include "../wininc/ntddk.h"
+#include "../wininc/ntexapi.h"
 #include "../wininc/ntifs.h"
+#include "../wininc/ntmmapi.h"
 #include "../wininc/tls.h"
 #include "../wininc/ktmtypes.h"
 #include "../wininc/winnt_recent.h"
@@ -3420,7 +3422,18 @@ syscall_info_t syscall_ntdll_info[] = {
     {{WIN8,0},"NtAdjustTokenClaimsAndDeviceGroups", UNKNOWN, RNTST, 16, },
     {{WIN8,0},"NtAlertThreadByThreadId", UNKNOWN, RNTST, 1, },
     {{WIN8,0},"NtAlpcConnectPortEx", UNKNOWN, RNTST, 11, },
-    {{WIN8,0},"NtAssociateWaitCompletionPacket", UNKNOWN, RNTST, 8, },
+    {{WIN8,0},"NtAssociateWaitCompletionPacket", OK, RNTST, 8,
+     {
+         {0, sizeof(HANDLE), SYSARG_INLINED, DRSYS_TYPE_HANDLE},
+         {1, sizeof(HANDLE), SYSARG_INLINED, DRSYS_TYPE_HANDLE},
+         {2, sizeof(HANDLE), SYSARG_INLINED, DRSYS_TYPE_HANDLE},
+         {3, sizeof(PVOID), SYSARG_INLINED, DRSYS_TYPE_VOID},
+         {4, sizeof(PVOID), SYSARG_INLINED, DRSYS_TYPE_VOID},
+         {5, sizeof(NTSTATUS), SYSARG_INLINED, DRSYS_TYPE_NTSTATUS},
+         {6, sizeof(ULONG_PTR), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+         {7, sizeof(BOOLEAN), W|HT, DRSYS_TYPE_BOOL},
+     }
+    },
     {{WIN8,0},"NtCancelWaitCompletionPacket", UNKNOWN, RNTST, 2, },
     {{WIN8,0},"NtCreateDirectoryObjectEx", UNKNOWN, RNTST, 5, },
     {{WIN8,0},"NtCreateIRTimer", UNKNOWN, RNTST, 2, },
@@ -3442,10 +3455,28 @@ syscall_info_t syscall_ntdll_info[] = {
      }
     },
     {{WIN8,0},"NtGetCachedSigningLevel", UNKNOWN, RNTST, 6, },
-    {{WIN8,0},"NtQueryWnfStateData", UNKNOWN, RNTST, 6, },
+    {{WIN8,0},"NtQueryWnfStateData", OK, RNTST, 6,
+     {
+         {0, sizeof(WNF_STATE_NAME), R|HT, DRSYS_TYPE_STRUCT},
+         {1, sizeof(WNF_TYPE_ID), R|HT, DRSYS_TYPE_STRUCT},
+         {2, sizeof(PVOID), SYSARG_INLINED, DRSYS_TYPE_VOID},
+         {3, sizeof(WNF_CHANGE_STAMP), W|HT, DRSYS_TYPE_UNSIGNED_INT},
+         {4, -5, WI},
+         {5, sizeof(ULONG), R|W|HT, DRSYS_TYPE_UNSIGNED_INT},
+     }
+    },
     {{WIN8,0},"NtQueryWnfStateNameInformation", UNKNOWN, RNTST, 5, },
     {{WIN8,0},"NtSetCachedSigningLevel", UNKNOWN, RNTST, 5, },
-    {{WIN8,0},"NtSetInformationVirtualMemory", UNKNOWN, RNTST, 6, },
+    {{WIN8,0},"NtSetInformationVirtualMemory", OK, RNTST, 6,
+     {
+         {0, sizeof(HANDLE), SYSARG_INLINED, DRSYS_TYPE_HANDLE},
+         {1, sizeof(ULONG), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+         {2, sizeof(ULONG_PTR), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+         {3, -2, R|SYSARG_SIZE_IN_ELEMENTS, sizeof(MEMORY_RANGE_ENTRY)},
+         {4, -5, R},
+         {5, sizeof(ULONG), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+     }
+    },
     {{WIN8,0},"NtSetIRTimer", UNKNOWN, RNTST, 2, },
     {{WIN8,0},"NtSubscribeWnfStateChange", UNKNOWN, RNTST, 4, },
     {{WIN8,0},"NtUnmapViewOfSectionEx", UNKNOWN, RNTST, 3,
@@ -3456,7 +3487,17 @@ syscall_info_t syscall_ntdll_info[] = {
      }
     },
     {{WIN8,0},"NtUnsubscribeWnfStateChange", UNKNOWN, RNTST, 1, },
-    {{WIN8,0},"NtUpdateWnfStateData", UNKNOWN, RNTST, 7, },
+    {{WIN8,0},"NtUpdateWnfStateData", OK, RNTST, 7,
+     {
+         {0, sizeof(WNF_STATE_NAME), R|HT, DRSYS_TYPE_STRUCT},
+         {1, -2, R},
+         {2, sizeof(ULONG), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+         {3, sizeof(WNF_TYPE_ID), R|HT, DRSYS_TYPE_STRUCT},
+         {4, sizeof(PVOID), SYSARG_INLINED, DRSYS_TYPE_VOID},
+         {5, sizeof(WNF_CHANGE_STAMP), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+         {6, sizeof(LOGICAL), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+     }
+    },
     {{WIN8,0},"NtWaitForAlertByThreadId", UNKNOWN, RNTST, 2, },
     {{WIN8,WIN8},"NtWaitForWnfNotifications", UNKNOWN, RNTST, 2, },
     {{WIN8,0},"NtWow64AllocateVirtualMemory64", UNKNOWN, RNTST, 7,

--- a/wininc/ntexapi.h
+++ b/wininc/ntexapi.h
@@ -12,6 +12,8 @@
 #ifndef _NTEXAPI_H_
 #define _NTEXAPI_H_ 1
 
+#include "ndk_iotypes.h"
+
 NTSTATUS NTAPI
 NtEnumerateBootEntries(
     __out_bcount_opt(*BufferLength) PVOID Buffer,
@@ -199,7 +201,7 @@ NTSTATUS
 NTAPI
 NtWaitForWorkViaWorkerFactory(
     __in HANDLE WorkerFactoryHandle,
-    __out _FILE_IO_COMPLETION_INFORMATION *MiniPacket
+    __out FILE_IO_COMPLETION_INFORMATION *MiniPacket
     );
 
 NTSTATUS
@@ -232,6 +234,66 @@ NtSetTimer2(
     __in PLARGE_INTEGER DueTime,
     __in_opt PLARGE_INTEGER Period,
     __in PT2_SET_PARAMETERS Parameters
+    );
+
+typedef struct _WNF_STATE_NAME {
+    ULONG Data[2];
+} WNF_STATE_NAME, *PWNF_STATE_NAME;
+
+typedef const WNF_STATE_NAME *PCWNF_STATE_NAME;
+
+typedef enum _WNF_STATE_NAME_LIFETIME {
+    WnfWellKnownStateName,
+    WnfPermanentStateName,
+    WnfPersistentStateName,
+    WnfTemporaryStateName
+} WNF_STATE_NAME_LIFETIME;
+
+typedef enum _WNF_STATE_NAME_INFORMATION {
+    WnfInfoStateNameExist,
+    WnfInfoSubscribersPresent,
+    WnfInfoIsQuiescent
+} WNF_STATE_NAME_INFORMATION;
+
+typedef enum _WNF_DATA_SCOPE {
+    WnfDataScopeSystem,
+    WnfDataScopeSession,
+    WnfDataScopeUser,
+    WnfDataScopeProcess
+} WNF_DATA_SCOPE;
+
+typedef struct _WNF_TYPE_ID {
+    GUID TypeId;
+} WNF_TYPE_ID, *PWNF_TYPE_ID;
+
+typedef const WNF_TYPE_ID *PCWNF_TYPE_ID;
+
+typedef ULONG WNF_CHANGE_STAMP, *PWNF_CHANGE_STAMP;
+
+typedef ULONG LOGICAL;
+typedef ULONG *PLOGICAL;
+
+NTSTATUS
+NTAPI
+NtQueryWnfStateData(
+    _In_ PCWNF_STATE_NAME StateName,
+    _In_opt_ PCWNF_TYPE_ID TypeId,
+    _In_opt_ const VOID* ExplicitScope,
+    _Out_ PWNF_CHANGE_STAMP ChangeStamp,
+    _Out_writes_bytes_to_opt_(*BufferSize, *BufferSize) PVOID Buffer,
+    _Inout_ PULONG BufferSize
+    );
+
+NTSTATUS
+NTAPI
+NtUpdateWnfStateData(
+    _In_ PCWNF_STATE_NAME StateName,
+    _In_reads_bytes_opt_(Length) const VOID* Buffer,
+    _In_opt_ ULONG Length,
+    _In_opt_ PCWNF_TYPE_ID TypeId,
+    _In_opt_ const PVOID ExplicitScope,
+    _In_ WNF_CHANGE_STAMP MatchingChangeStamp,
+    _In_ LOGICAL CheckStamp
     );
 
 #endif /* _NTEXAPI_H_ 1 */

--- a/wininc/ntioapi.h
+++ b/wininc/ntioapi.h
@@ -74,6 +74,53 @@ NtFlushBuffersFileEx(
     _Out_ PIO_STATUS_BLOCK IoStatusBlock
     );
 
+
+typedef enum _IO_SESSION_STATE {
+    IoSessionStateCreated,
+    IoSessionStateInitialized,
+    IoSessionStateConnected,
+    IoSessionStateDisconnected,
+    IoSessionStateDisconnectedLoggedOn,
+    IoSessionStateLoggedOn,
+    IoSessionStateLoggedOff,
+    IoSessionStateTerminated,
+    IoSessionStateMax
+} IO_SESSION_STATE;
+
+NTAPI
+NtOpenSession(
+    __out PHANDLE SessionHandle,
+    __in ACCESS_MASK DesiredAccess,
+    __in POBJECT_ATTRIBUTES ObjectAttributes
+    );
+
+NTSTATUS
+NTAPI
+NtNotifyChangeSession(
+    __in HANDLE SessionHandle,
+    __in ULONG IoStateSequence,
+    __in PVOID Reserved,
+    __in ULONG Action,
+    __in IO_SESSION_STATE IoState,
+    __in IO_SESSION_STATE IoState2,
+    __in PVOID Buffer,
+    __in ULONG BufferSize
+    );
+
+
+NTSTATUS
+NTAPI
+NtAssociateWaitCompletionPacket(
+    _In_ HANDLE WaitCompletionPacketHandle,
+    _In_ HANDLE IoCompletionHandle,
+    _In_ HANDLE TargetObjectHandle,
+    _In_opt_ PVOID KeyContext,
+    _In_opt_ PVOID ApcContext,
+    _In_ NTSTATUS IoStatus,
+    _In_ ULONG_PTR IoStatusInformation,
+    _Out_opt_ PBOOLEAN AlreadySignaled
+    );
+
 #endif /* __PHLIB_NTIOAPI_H */
 
 /* EOF */

--- a/wininc/ntmmapi.h
+++ b/wininc/ntmmapi.h
@@ -14,26 +14,26 @@
 #ifndef __PHLIB_NTMMAPI_H
 #define __PHLIB_NTMMAPI_H
 
-NTSTATUS
-NTAPI
-NtOpenSession(
-    __out PHANDLE SessionHandle,
-    __in ACCESS_MASK DesiredAccess,
-    __in POBJECT_ATTRIBUTES ObjectAttributes
-    );
+typedef enum _VIRTUAL_MEMORY_INFORMATION_CLASS {
+    VmPrefetchInformation,
+    VmPagePriorityInformation,
+    VmCfgCallTargetInformation
+} VIRTUAL_MEMORY_INFORMATION_CLASS;
+
+typedef struct _MEMORY_RANGE_ENTRY {
+    PVOID VirtualAddress;
+    SIZE_T NumberOfBytes;
+} MEMORY_RANGE_ENTRY, *PMEMORY_RANGE_ENTRY;
 
 NTSTATUS
 NTAPI
-NtNotifyChangeSession(
-    __in HANDLE SessionHandle,
-    __in ULONG IoStateSequence,
-    __in PVOID Reserved,
-    __in ULONG Action,
-    __in IO_SESSION_STATE IoState,
-    __in IO_SESSION_STATE IoState2,
-    __in PVOID Buffer,
-    __in ULONG BufferSize
-    );
+NtSetInformationVirtualMemory(
+    _In_ HANDLE ProcessHandle,
+    _In_ VIRTUAL_MEMORY_INFORMATION_CLASS VmInformationClass,
+    _In_ ULONG_PTR NumberOfEntries,
+    _In_reads_(NumberOfEntries) PMEMORY_RANGE_ENTRY VirtualAddresses,
+    _In_reads_bytes_(VmInformationLength) PVOID VmInformation,
+    _In_ ULONG VmInformationLength);
 
 #endif /* __PHLIB_NTMMAPI_H */
 


### PR DESCRIPTION
Adds several recent syscalls to eliminate false positives in the x64
procterm test on Windows.

Issue: #111