### PR TITLE
i#111 win64 tests: Fix several win64 tests

### DIFF
--- a/drmemory/suppress-default.win.txt
+++ b/drmemory/suppress-default.win.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -1055,6 +1055,13 @@ fshook32.dll!*
 # i#1825: GdiAddFontResourceW bug
 
 UNINITIALIZED READ
-name=default i#1824 GdiAddFontResourceW
+name=default i#1825 GdiAddFontResourceW
 system call NtGdiAddFontResourceW parameter value #4
 GDI32.dll!GdiAddFontResourceW
+
+##################################################
+# i#2170: RtlRestoreContext context copying bug
+
+UNINITIALIZED READ
+name=default i#2170 RtlRestoreContext
+ntdll.dll!RtlRestoreContext

--- a/tests/cs2bug.res
+++ b/tests/cs2bug.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -110,7 +110,8 @@ cs2bug.cpp:86
 : LEAK 8 direct bytes + 31 indirect bytes
 %endif
 cs2bug.cpp:172
-%endif
+# Nested %if is only supported with "endif UNIX".
+%endif UNIX
 %OPTIONAL # Linux/VS2005
 %if X32
 : LEAK 88 direct bytes + 168 indirect bytes

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -42,7 +42,7 @@ Error #10: UNINITIALIZED READ: reading register eflags
 registers.c_asm.asm:1158
 Error #11: UNINITIALIZED READ: reading register cl
 registers.c_asm.asm:1163
-Error #12: UNINITIALIZED READ: reading register ecx
+Error #12: UNINITIALIZED READ: reading register xcx
 registers.c_asm.asm:1183
 Error #13: UNINITIALIZED READ: reading 8 byte(s)
 registers.c_asm.asm:1214

--- a/tests/runtest.cmake
+++ b/tests/runtest.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -351,6 +351,9 @@ foreach (str ${patterns})
   if (WIN32 AND NOT USE_DRSYMS AND "${${str}}" MATCHES "%if CYGWIN") # cygwin
     # if %CYGWIN is NOT present then counts as Windows
     string(REGEX REPLACE "(^|\n)%if UNIX[^%]+\n%endif\n" "\\1" ${str} "${${str}}")
+    # Support "endif UNIX" to handle nested inside cs2bug.res.
+    # XXX: Should change every endif to have a qualifier.
+    string(REGEX REPLACE "(^|\n)%if UNIX.+\n%endif UNIX\n" "\\1" ${str} "${${str}}")
     string(REGEX REPLACE "(^|\n)%if WINDOWS[^%]+\n%endif\n" "\\1" ${str} "${${str}}")
     string(REGEX REPLACE "(^|\n)%if !CYGWIN[^%]+\n%endif\n" "\\1" ${str} "${${str}}")
     # distinguish pre-vista from post-vista
@@ -363,7 +366,10 @@ foreach (str ${patterns})
     endif ("${CMAKE_SYSTEM_VERSION}" VERSION_LESS "6.0")
   else (WIN32 AND NOT USE_DRSYMS AND "${${str}}" MATCHES "%if CYGWIN")
     if (WIN32)
-      string(REGEX REPLACE "(^|\n)%if UNIX[^%]+\n%endif\n" "\\1" ${str} "${${str}}")
+      string(REGEX REPLACE "(^|\n)%if UNIX[^%]+\n%endif UNIX\n" "\\1" ${str} "${${str}}")
+      # Support "endif UNIX" to handle nested inside cs2bug.res.
+      # XXX: Should change every endif to have a qualifier.
+      string(REGEX REPLACE "(^|\n)%if UNIX.+\n%endif UNIX\n" "\\1" ${str} "${${str}}")
       string(REGEX REPLACE "(^|\n)%if CYGWIN[^%]+\n%endif\n" "\\1" ${str} "${${str}}")
       # distinguish pre-win8 from win8
       if ("${CMAKE_SYSTEM_VERSION}" VERSION_LESS "6.2")

--- a/tests/runtest.cmake
+++ b/tests/runtest.cmake
@@ -366,7 +366,7 @@ foreach (str ${patterns})
     endif ("${CMAKE_SYSTEM_VERSION}" VERSION_LESS "6.0")
   else (WIN32 AND NOT USE_DRSYMS AND "${${str}}" MATCHES "%if CYGWIN")
     if (WIN32)
-      string(REGEX REPLACE "(^|\n)%if UNIX[^%]+\n%endif UNIX\n" "\\1" ${str} "${${str}}")
+      string(REGEX REPLACE "(^|\n)%if UNIX[^%]+\n%endif\n" "\\1" ${str} "${${str}}")
       # Support "endif UNIX" to handle nested inside cs2bug.res.
       # XXX: Should change every endif to have a qualifier.
       string(REGEX REPLACE "(^|\n)%if UNIX.+\n%endif UNIX\n" "\\1" ${str} "${${str}}")


### PR DESCRIPTION
Fixes a few of the failing 64-bit Windows full-mode tests:

+ Adds a default suppression for i#2170: what looks like a
  real bug in RtlRestoreContext context copying.
+ Expands registers.res to match both rcx and ecx.
+ Expands runtest.cmake to handle nested %if in a .res file
  for %if UNIX when %endif UNIX is used, for cs2bug.res.

Issue: #111, #2170