### PR TITLE
i#111 win64 tests: Fix more win64 tests

### DIFF
--- a/common/heap.c
+++ b/common/heap.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -647,7 +647,7 @@ heap_iterator(void (*cb_region)(app_pc,app_pc _IF_WINDOWS(HANDLE)),
         LOG(2, "heap zone %d: %p %s\n", i, zone, malloc_get_zone_name(zone));
 # ifdef DEBUG
         malloc_zone_statistics(zone, &stats);
-        LOG(2, "\tblocks=%u, used=%ld, max used=%ld, reserved=%ld\n",
+        LOG(2, "\tblocks=%u, used=%zd, max used=%zd, reserved=%zd\n",
             stats.blocks_in_use, stats.size_in_use, stats.max_size_in_use,
             stats.size_allocated);
 # endif

--- a/drmemory/slowpath_x86.c
+++ b/drmemory/slowpath_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1087,8 +1087,7 @@ map_src_to_dst(shadow_combine_t *comb INOUT, int opnum, int src_bytenum, uint sh
         accum_shadow(&comb->dst[opsz*shift + src_bytenum], shadow);
         break;
     case OP_bswap:
-        ASSERT(opsz == 4, "invalid bswap opsz");
-        accum_shadow(&comb->dst[3 - src_bytenum], shadow);
+        accum_shadow(&comb->dst[(opsz - 1) - src_bytenum], shadow);
         return;
 #ifndef X64
     case OP_pusha:

--- a/drsymcache/drsymcache.c
+++ b/drsymcache/drsymcache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -55,7 +55,7 @@
  * because we include negative entries in the file and make no assumptions
  * that it is a complete record of all lookups we'll need.
  */
-#define SYMCACHE_VERSION 14
+#define SYMCACHE_VERSION 15
 
 /* we need a separate hashtable per module */
 #define SYMCACHE_MASTER_TABLE_HASH_BITS 6
@@ -321,7 +321,7 @@ symcache_write_symfile(const char *modname, mod_cache_t *modcache)
 #ifdef WINDOWS
     BUFFERED_WRITE(f, buf, bsz, sofar, len,
                    UINT64_FORMAT_STRING","UINT64_FORMAT_STRING","
-                   UINT64_FORMAT_STRING",%u,%u,%lu\n",
+                   UINT64_FORMAT_STRING",%u,%u,%zu\n",
                    modcache->module_file_size, modcache->file_version.version,
                    modcache->product_version.version,
                    modcache->checksum, modcache->timestamp,
@@ -449,7 +449,7 @@ symcache_read_symfile(const module_data_t *mod, const char *modname,
         uint checksum;
         size_t module_internal_size;
         if (dr_sscanf(line, "%u,"UINT64_FORMAT_STRING","UINT64_FORMAT_STRING","
-                      UINT64_FORMAT_STRING",%u,%u,%lu",
+                      UINT64_FORMAT_STRING",%u,%u,%zu",
                       &cache_file_size, &module_file_size, &file_version.version,
                       &product_version.version, &checksum, &timestamp,
                       &module_internal_size) != 7) {
@@ -466,7 +466,7 @@ symcache_read_symfile(const module_data_t *mod, const char *modname,
             LOG(2, "\t"UINT64_FORMAT_STRING" vs "UINT64_FORMAT_STRING", "
                 UINT64_FORMAT_STRING" vs "UINT64_FORMAT_STRING", "
                 UINT64_FORMAT_STRING" vs "UINT64_FORMAT_STRING", "
-                "%u vs %u, %u vs %u, %lu vs %lu\n",
+                "%u vs %u, %u vs %u, %zu vs %zu\n",
                 module_file_size, modcache->module_file_size,
                 file_version.version, modcache->file_version.version,
                 product_version.version, modcache->product_version.version,

--- a/drsyscall/drsyscall_windows.c
+++ b/drsyscall/drsyscall_windows.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -564,15 +564,19 @@ syscall_num_from_name(void *drcontext, const module_data_t *info,
         entry = (*drsys_ops.lookup_internal_symbol)(info, name);
         if (entry != NULL)
             num = syscall_num_from_wrapper(drcontext, entry);
-        if (num == -1 && optional_prefix != NULL) {
+        if (num == -1 && optional_prefix != NULL &&
+            strstr(name, optional_prefix) == name) {
             const char *skip_prefix = name + strlen(optional_prefix);
-            ASSERT(strstr(name, optional_prefix) == name,
-                   "missing syscall prefix");
             entry = (*drsys_ops.lookup_internal_symbol)(info, skip_prefix);
             if (entry != NULL)
                 num = syscall_num_from_wrapper(drcontext, entry);
         }
     }
+    /* Work around DRi#3453: drmgr_decode_sysnum_from_wrapper () should check for
+     * "return 1".
+     */
+    if (num == 1 && strstr(name, "NtUser") == name)
+        num = -1;
     if (num == -1)
         return false;
     num_out->number = num;

--- a/tests/rtl_memory_zones.c
+++ b/tests/rtl_memory_zones.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -107,7 +107,7 @@ use_memory_zones(void)
            (sizeof(*zone) == (INT_PTR)block - (INT_PTR)zone));
     printf("Segment.NextSegment == NULL: %d\n",
            zone->Segment.NextSegment == NULL);
-    printf("Segment.Size: %lu\n", zone->Segment.Size);
+    printf("Segment.Size: %zu\n", zone->Segment.Size);
     printf("Segment.Next: 0x%05lx\n",
            (INT_PTR)zone->Segment.Next - (INT_PTR)zone);
     printf("Segment.Limit: 0x%05lx\n",


### PR DESCRIPTION
Fixes the following win64 bugs:

+ Fixes the use of %l{d,u} instead of %z{d,u} in symcache and several
  other places.  This caused the symcache files to never match,
  causing delays and timeouts on some tests, especially those using
  /MDd, due to DRi#2175.

+ Changes short jumps to long jumps in several fastpath locations to
  avoid failures to reach due to longer x64 instructions.

+ Generalizes handling of OP_bswap which assumed a maximum size of 4
  bytes.

+ Adds a workaround for DRi#3453 to avoid an assert with
  -verify_sysnums.

Issue: #111