### PR TITLE
Update base version to 2.1.0 for all platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -81,7 +81,7 @@ before_deploy:
   # We should find a way to share (xref DRi#1565).
   # We support setting TAG_SUFFIX on triggered builds so we can have
   # multiple unique tags in one day (the patchlevel here is the day number).
-  - export GIT_TAG="cronbuild-2.0.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
+  - export GIT_TAG="cronbuild-2.1.$((`git log -n 1 --format=%ct` / (60*60*24)))${TAG_SUFFIX}"
   - git tag $GIT_TAG -a -m "Travis auto-generated tag for build $TRAVIS_BUILD_NUMBER."
 deploy:
   provider: releases

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,13 +233,7 @@ endif (APPLE)
 
 # N.B.: when updating this, update the git tag in .travis.yml.
 # We should find a way to share (xref DRi#1565).
-if (WIN32)
-  # Windows is still missing 64-bit uninitialized read support so we're still calling
-  # it 1.11.xxx.
-  set(VERSION_NUMBER_DEFAULT "1.11.${VERSION_NUMBER_PATCHLEVEL}")
-else ()
-  set(VERSION_NUMBER_DEFAULT "2.0.${VERSION_NUMBER_PATCHLEVEL}")
-endif ()
+set(VERSION_NUMBER_DEFAULT "2.1.${VERSION_NUMBER_PATCHLEVEL}")
 # Do not store the default TOOL_VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir.
 # Avoid "VERSION_NUMBER" name since conflics w/ DR's var.

--- a/drmemory/docs/release.dox
+++ b/drmemory/docs/release.dox
@@ -60,7 +60,10 @@ The Dr. Memory distribution contains the following:
 \section sec_changes Changes Since Prior Releases
 
 The current version is \TOOL_VERSION.
-The changes between \TOOL_VERSION and version 1.11.0 include:
+The changes between \TOOL_VERSION and version 2.1.0 include:
+ - Nothing yet.
+
+The changes between version 2.1.0 and version 1.11.0 include:
  - Added preliminary 64-bit full mode (i.e., with uninitialized read
    checking) support.
  - Added preliminary support for the Windows Subsystem for Linux


### PR DESCRIPTION
Eliminates the split versioning for Windows vs Linux and updates the
base version to 2.1.0.  Updates the Travis git tag and changelist as
well.