### PR TITLE
Get Travis and Appveyor green via suppression and line num fixes

### DIFF
--- a/tests/addronly-reg.res
+++ b/tests/addronly-reg.res
@@ -24,13 +24,13 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1380
+registers.c_asm.asm:1396
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1392
+registers.c_asm.asm:1408
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1405
+registers.c_asm.asm:1421
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1406
+registers.c_asm.asm:1422
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/bitfield.strict.res
+++ b/tests/bitfield.strict.res
@@ -24,29 +24,29 @@ Error #2: UNINITIALIZED READ
 bitfield.cpp:54
 %if WINDOWS
 Error #3: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:874
+bitfield.cpp_asm.asm:890
 Error #4: UNINITIALIZED READ: reading register bl
-bitfield.cpp_asm.asm:887
+bitfield.cpp_asm.asm:903
 Error #5: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:895
+bitfield.cpp_asm.asm:911
 Error #6: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:900
+bitfield.cpp_asm.asm:916
 Error #7: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:909
+bitfield.cpp_asm.asm:925
 Error #8: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:912
+bitfield.cpp_asm.asm:928
 Error #9: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:917
+bitfield.cpp_asm.asm:933
 Error #10: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:920
+bitfield.cpp_asm.asm:936
 Error #11: UNINITIALIZED READ: reading register dl
-bitfield.cpp_asm.asm:944
+bitfield.cpp_asm.asm:960
 Error #12: UNINITIALIZED READ: reading register esi
-bitfield.cpp_asm.asm:945
+bitfield.cpp_asm.asm:961
 Error #13: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:959
+bitfield.cpp_asm.asm:975
 Error #14: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:970
+bitfield.cpp_asm.asm:986
 %endif
 %if UNIX
 Error #3: UNINITIALIZED READ: reading register ecx

--- a/tests/registers.blacklist.res
+++ b/tests/registers.blacklist.res
@@ -21,13 +21,13 @@
 #
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1380
+registers.c_asm.asm:1396
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1392
+registers.c_asm.asm:1408
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1405
+registers.c_asm.asm:1421
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1406
+registers.c_asm.asm:1422
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)

--- a/tests/registers.pattern.res
+++ b/tests/registers.pattern.res
@@ -24,9 +24,9 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1380
+registers.c_asm.asm:1396
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1392
+registers.c_asm.asm:1408
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -119,15 +119,15 @@ registers.c_asm.asm:1900
 %endif
 %if UNIX
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1080
+registers.c_asm.asm:1064
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1094
+registers.c_asm.asm:1078
 Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1108
-Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1122
-Error #26: UNINITIALIZED READ: reading register eax
 registers.c_asm.asm:1092
+Error #25: UNINITIALIZED READ: reading 2 byte(s)
+registers.c_asm.asm:1106
+Error #26: UNINITIALIZED READ: reading register eax
+registers.c_asm.asm:1076
 %endif
 %OUT_OF_ORDER
 : LEAK 15 direct bytes + 0 indirect bytes

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -21,39 +21,39 @@
 #
 %if WINDOWS
 Error #1: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1353
+registers.c_asm.asm:1369
 Error #2: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1360
+registers.c_asm.asm:1376
 Error #3: UNINITIALIZED READ: reading 2 byte(s)
 registers.c:104
 Error #4: UNINITIALIZED READ: reading register ax
-registers.c_asm.asm:1580
+registers.c_asm.asm:1596
 Error #5: UNINITIALIZED READ: reading register dx
-registers.c_asm.asm:1597
+registers.c_asm.asm:1613
 Error #6: UNINITIALIZED READ: reading register ah
-registers.c_asm.asm:1627
+registers.c_asm.asm:1643
 Error #7: UNINITIALIZED READ: reading 1 byte(s)
 registers.c:187
 Error #8: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1329
+registers.c_asm.asm:1345
 Error #9: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1154
+registers.c_asm.asm:1170
 Error #10: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1158
+registers.c_asm.asm:1174
 Error #11: UNINITIALIZED READ: reading register cl
-registers.c_asm.asm:1163
+registers.c_asm.asm:1179
 Error #12: UNINITIALIZED READ: reading register xcx
-registers.c_asm.asm:1183
+registers.c_asm.asm:1199
 Error #13: UNINITIALIZED READ: reading 8 byte(s)
-registers.c_asm.asm:1214
+registers.c_asm.asm:1230
 Error #14: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1380
+registers.c_asm.asm:1396
 Error #15: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1392
+registers.c_asm.asm:1408
 Error #16: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1405
+registers.c_asm.asm:1421
 Error #17: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1406
+registers.c_asm.asm:1422
 %endif
 %if UNIX
 Error #1: UNINITIALIZED READ: reading register eflags
@@ -99,7 +99,7 @@ registers.c_asm.asm:970
 %endif
 %if WINDOWS
 Error #19: UNINITIALIZED READ: reading register ecx
-registers.c_asm.asm:1722
+registers.c_asm.asm:1738
 %endif
 Error #20: UNINITIALIZED READ: reading register
 registers.c:267
@@ -107,27 +107,27 @@ Error #21: UNINITIALIZED READ: reading register
 registers.c:288
 %if WINDOWS
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1807
+registers.c_asm.asm:1823
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1821
+registers.c_asm.asm:1837
 Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1835
+registers.c_asm.asm:1851
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1849
+registers.c_asm.asm:1865
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1884
+registers.c_asm.asm:1900
 %endif
 %if UNIX
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1064
+registers.c_asm.asm:1080
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1078
+registers.c_asm.asm:1094
 Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1092
+registers.c_asm.asm:1108
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1106
+registers.c_asm.asm:1122
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1076
+registers.c_asm.asm:1092
 %endif
 %OUT_OF_ORDER
 : LEAK 15 direct bytes + 0 indirect bytes

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -147,12 +147,15 @@ for (my $i = 0; $i < $#lines; ++$i) {
                 'syscall_file_gen' => 1,
                 'handle' => 1,
                 'app_suite' => 1,
-                'app_suite.pattern' => 1);
+                'app_suite.pattern' => 1,
+                # These two are i#2178:
+                'slowesp' => 1,
+                'noreplace_realloc' => 1);
         } elsif ($^O eq 'darwin' || $^O eq 'MacOS') {
             %ignore_failures_32 = ('malloc' => 1); # i#2038
             %ignore_failures_64 = ('malloc' => 1);
         } else {
-            print "No auto-ignored tests for platform $^O\n";
+            %ignore_failures_32 = ('pcache-use' => 1); # i#2202
         }
         # Read ahead to examine the test failures:
         $fail = 0;


### PR DESCRIPTION
Updates the line numbers of various asm-using tests after the DR
update in f1c8f7b.

Adds pcache-use (i#2202) and slowesp + noreplace-realloc (i#2178) to
the CI ignore list.

Issue: #2202, #2178