### PR TITLE
i#1983: Add syscall auto-generation to drstrace and drltrace

### DIFF
--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2019 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -105,7 +105,7 @@ add_executable(drltrace ${front_srcs})
 
 configure_DynamoRIO_standalone(drltrace)
 
-target_link_libraries(drltrace drinjectlib drconfiglib drfrontendlib)
+target_link_libraries(drltrace drinjectlib drconfiglib drfrontendlib drsyscall_static)
 
 set_library_version(drltrace ${DRMF_VERSION})
 

--- a/drltrace/drltrace_frontend.cpp
+++ b/drltrace/drltrace_frontend.cpp
@@ -398,6 +398,7 @@ _tmain(int argc, const TCHAR *targv[])
         logdir[0] = '\0';
     }
 
+#ifdef WINDOWS
     if (op_sysnum_file.get_value().empty() || op_symcache_dir.get_value().empty()) {
         bool use_root;
         char local_root_dir[MAXIMUM_PATH];
@@ -459,6 +460,7 @@ _tmain(int argc, const TCHAR *targv[])
             op_sysnum_file.set_value(sysnum_file);
         }
     }
+#endif
 
     dr_standalone_init();
 

--- a/drltrace/drltrace_libcalls.cpp
+++ b/drltrace/drltrace_libcalls.cpp
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -142,7 +142,6 @@ config_parse_type(std::string type_name, uint index)
      * in Windows and Linux.
      */
 
-    /* XXX i#1948: We have to extend a list of supported types here. */
     if (type_name.compare("VOID") == 0) {
         arg->type_name = "void";
         arg->type = DRSYS_TYPE_VOID;
@@ -164,6 +163,14 @@ config_parse_type(std::string type_name, uint index)
         arg->type_name = "HANDLE";
         arg->size = sizeof(HANDLE);
         arg->type = DRSYS_TYPE_HANDLE;
+    } else if (type_name.compare("HKEY") == 0) {
+        arg->type_name = "HKEY";
+        arg->size = sizeof(HKEY);
+        arg->type = DRSYS_TYPE_HANDLE;
+    } else if (type_name.compare("HDC") == 0) {
+        arg->type_name = "HDC";
+        arg->size = sizeof(HDC);
+        arg->type = DRSYS_TYPE_HANDLE;
     } else if (type_name.compare("HFILE") == 0) {
         arg->type_name = "HFILE";
         arg->size = sizeof(HFILE);
@@ -175,6 +182,14 @@ config_parse_type(std::string type_name, uint index)
     } else if (type_name.compare("UINT") == 0) {
         arg->type_name = "uint";
         arg->size = sizeof(UINT);
+        arg->type = DRSYS_TYPE_UNSIGNED_INT;
+    } else if (type_name.compare("ULONG") == 0) {
+        arg->type_name = "ULONG";
+        arg->size = sizeof(ULONG);
+        arg->type = DRSYS_TYPE_UNSIGNED_INT;
+    } else if (type_name.compare("ULONGLONG") == 0) {
+        arg->type_name = "ULONGLONG";
+        arg->size = sizeof(ULONGLONG);
         arg->type = DRSYS_TYPE_UNSIGNED_INT;
     } else if (type_name.compare("DWORD") == 0) {
         arg->type_name = "DWORD";
@@ -209,8 +224,10 @@ config_parse_type(std::string type_name, uint index)
         arg->type_name = "wchar_t";
         arg->type = DRSYS_TYPE_CWSTRING;
     } else {
+        /* XXX i#1948: We have to extend a list of supported types here. */
         arg->type_name = "<unknown>";
-        VNOTIFY(0, "found unknown type %s in the config file" NL, type_name.c_str());
+        DO_ONCE(VNOTIFY(0, "<Found unknown types in the config file>" NL););
+        VNOTIFY(2, "Found unknown type %s in the config file" NL, type_name.c_str());
     }
 
     return arg;

--- a/drltrace/drltrace_options.cpp
+++ b/drltrace/drltrace_options.cpp
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -72,10 +72,20 @@ droption_t<bool> op_config_file_default
  "no_use_config and provide a path to custom config file using -config option.");
 
 droption_t<std::string> op_config_file
-(DROPTION_SCOPE_ALL, "config", "", "The path to custom config file.",
+(DROPTION_SCOPE_ALL, "config", "", "The path to a custom config file.",
  "Specify a custom path where config is located. The config file describes the prototype"
  " of library functions for printing library call arguments.  See drltrace documentation"
  " for more details.");
+
+droption_t<std::string> op_sysnum_file
+(DROPTION_SCOPE_ALL, "sysnum_file", "", "The path to a system call number file.",
+ "Specify where a system call number file is, to support running on recent Windows "
+ "versions.  Normally this is file is auto-generated on launch.");
+
+droption_t<std::string> op_symcache_dir
+(DROPTION_SCOPE_ALL, "symcache_dir", "", "A directory for caching symbol files.",
+ "Specify a writable directory for use in caching symbol files while generating "
+ "-sysnum_file.");
 
 droption_t<bool> op_ignore_underscore
 (DROPTION_SCOPE_CLIENT, "ignore_underscore", false, "Ignores library routine names "

--- a/drltrace/drltrace_options.h
+++ b/drltrace/drltrace_options.h
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -40,6 +40,8 @@ extern droption_t<unsigned int> op_unknown_args;
 extern droption_t<int> op_max_args;
 extern droption_t<bool> op_config_file_default;
 extern droption_t<std::string> op_config_file;
+extern droption_t<std::string> op_sysnum_file;
+extern droption_t<std::string> op_symcache_dir;
 extern droption_t<bool> op_ignore_underscore;
 extern droption_t<std::string> op_only_to_lib;
 extern droption_t<bool> op_help;

--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -1613,8 +1613,8 @@ _tmain(int argc, TCHAR *targv[])
 #ifdef WINDOWS
         if (errcode == STATUS_INVALID_KERNEL_INFO_VERSION &&
             !tried_generating_syscall_file) {
-            warn("Running on an unsupported operating system version.  Attempting to "
-                 "auto-generate system call information...");
+            warn("System call information is missing for this operating system version. "
+                 "Attempting to auto-generate system call information...");
             tried_generating_syscall_file = true;
             /* Give the user some visible feedback. */
             if (op_verbose_level < 1)

--- a/drmemory/syscall.c
+++ b/drmemory/syscall.c
@@ -700,10 +700,10 @@ syscall_init(void *drcontext _IF_WINDOWS(app_pc ntdll_base))
     if (res == DRMF_WARNING_UNSUPPORTED_KERNEL) {
         char os_ver[96];
         get_windows_version_string(os_ver, BUFFER_SIZE_ELEMENTS(os_ver));
-        NOTIFY_ERROR("Running on an unsupported operating system version: %s."
+        NOTIFY_ERROR("System call information is missing for this operating system: %s."
                      "%s" NL, os_ver,
                      options.ignore_kernel ? "" :
-                     " Exiting to trigger auto-generation of system call information."
+                     " Restarting to trigger auto-generation of system call information."
                      " Re-run with -ignore_kernel to attempt to continue instead.");
         if (options.ignore_kernel)
             res = DRMF_SUCCESS;

--- a/drstrace/CMakeLists.txt
+++ b/drstrace/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -139,7 +139,7 @@ if (WIN32)
 endif ()
 add_executable(drstrace ${front_srcs})
 configure_DynamoRIO_standalone(drstrace)
-target_link_libraries(drstrace drinjectlib drconfiglib drfrontendlib)
+target_link_libraries(drstrace drinjectlib drconfiglib drfrontendlib drsyscall_static)
 set_library_version(drstrace ${DRMF_VERSION})
 if (WIN32)
   get_filename_component(symfetch_name ${symfetch_path} NAME)

--- a/drsyscall/drsyscall.h
+++ b/drsyscall/drsyscall.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -1022,9 +1022,7 @@ DR_EXPORT
  * @param[in] num_sysnum_libs   The length of the \p sysnum_lib_paths array.
  * @param[in] outfile  The name of the output text file to be written.
  * @param[in] cache_dir  The path where retrieved symbol data should be cached (and
- *   searched if already retrieved).  If not set, the _NT_SYMBOL_PATH environment
- *   variable will be used, if set; else whatever default dbghelp.dll uses will be
- *   used.
+ *   searched if already retrieved).
  *
  * \note Windows-only.
  */

--- a/drsyscall/pdb2sysfile.cpp
+++ b/drsyscall/pdb2sysfile.cpp
@@ -877,7 +877,7 @@ write_file(const std::unordered_map<std::string, int> &name2num, const std::stri
     }
     file_t f = dr_open_file(outf.c_str(), DR_FILE_WRITE_OVERWRITE);
     if (f == INVALID_FILE) {
-        NOTIFY(0, "Failed to write to %s" NL, outf);
+        NOTIFY(0, "Failed to open %s" NL, outf.c_str());
         return DRMF_ERROR_ACCESS_DENIED;
     }
     NOTIFY(1, "Writing to \"%s\"" NL, outf.c_str());


### PR DESCRIPTION
Adds support for reading system call numbers from a text file to both
drstrace and drltrace.  Adds support for auto-generating that file,
just like is done in Dr. Memory.

Updates DR to 1713c2d2 to fix a decoder assert that breaks the
auto-generation.

Fixes #1983