### PR TITLE
i#1438 MacOS: Add 64-bit MacOS light mode support

### DIFF
--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -152,7 +152,7 @@ on_supported_version(void)
     if (uname(&uinfo) != 0)
         return false;
 #   define MIN_DARWIN_VERSION_SUPPORTED 11  /* OSX 10.7.x */
-#   define MAX_DARWIN_VERSION_SUPPORTED 15  /* OSX 10.11.x */
+#   define MAX_DARWIN_VERSION_SUPPORTED 18  /* OSX 10.14.x */
     return (dr_sscanf(uinfo.release, "%d", &kernel_major) == 1 &&
             kernel_major <= MAX_DARWIN_VERSION_SUPPORTED &&
             kernel_major >= MIN_DARWIN_VERSION_SUPPORTED);

--- a/drmemory/shadow.c
+++ b/drmemory/shadow.c
@@ -1013,6 +1013,10 @@ shadow_memory_is_shadow(app_pc addr)
  * instrumenting so much code that code size is a bottleneck.
  */
 
+/* To ensure we can access the tables in 64-bit, we copy them into a low-2GB
+ * mmap NOCHECK
+ */
+
 /*
 0000
 0001

--- a/drsyscall/drsyscall_os.h
+++ b/drsyscall/drsyscall_os.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -28,7 +28,7 @@
 #ifdef WINDOWS
 /* We need extra room for dup entries for diff in vs out size to writes. */
 # define MAX_ARGS_IN_ENTRY 18 /* 17 is max known */
-#elif defined(MACOS)
+#elif defined(MACOS) && !defined(X64)
 # define MAX_ARGS_IN_ENTRY 8
 #else
 # define MAX_ARGS_IN_ENTRY 6 /* 6 is max on Linux */

--- a/drsyscall/table_macos_bsd.c
+++ b/drsyscall/table_macos_bsd.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -40,7 +40,14 @@
 #include <sys/semaphore.h>
 #include <sys/event.h>
 #include <poll.h>
-#include <security/mac.h>
+#ifdef X64
+struct mac {
+  size_t m_buflen;
+  char *m_string;
+};
+#else
+# include <security/mac.h>
+#endif
 #include <mach/shared_region.h>
 
 #ifdef MACOS
@@ -1080,8 +1087,11 @@ syscall_info_t syscall_info_bsd[] = {
          {3, sizeof(size_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
          {4, sizeof(u_long), W|HT, DRSYS_TYPE_UNSIGNED_INT},
          {5, sizeof(u_long), W|HT, DRSYS_TYPE_UNSIGNED_INT},
+#if !(defined(MACOS) && defined(X64))
+         /* FIXME i#1438: how are 7th and 8th args passed on Mac64?!? */
          {6, sizeof(u_long), W|HT, DRSYS_TYPE_UNSIGNED_INT},
          {7, sizeof(u_long), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#endif
      }
     },
     {{SYS_exchangedata /*223*/}, "exchangedata", OK, RLONG, 3,
@@ -1645,7 +1655,10 @@ syscall_info_t syscall_info_bsd[] = {
          {3, sizeof(uint32_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
          {4, sizeof(void*), W|HT, DRSYS_TYPE_POINTER},
          {5, sizeof(uint64_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#if !(defined(MACOS) && defined(X64))
+         /* FIXME i#1438: how are 7th and 8th args passed on Mac64?!? */
          {6, sizeof(uint64_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#endif
      }
     },
     {{SYS_psynch_cvsignal /*304*/}, "psynch_cvsignal", OK, DRSYS_TYPE_UNSIGNED_INT, 8,
@@ -1656,8 +1669,11 @@ syscall_info_t syscall_info_bsd[] = {
          {3, sizeof(int), SYSARG_INLINED, DRSYS_TYPE_SIGNED_INT},
          {4, sizeof(void*), W|HT, DRSYS_TYPE_POINTER},
          {5, sizeof(uint64_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#if !(defined(MACOS) && defined(X64))
+         /* FIXME i#1438: how are 7th and 8th args passed on Mac64?!? */
          {6, sizeof(uint64_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
          {7, sizeof(uint32_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#endif
      }
     },
     {{SYS_psynch_cvwait /*305*/}, "psynch_cvwait", OK, DRSYS_TYPE_UNSIGNED_INT, 8,
@@ -1668,8 +1684,11 @@ syscall_info_t syscall_info_bsd[] = {
          {3, sizeof(void*), W|HT, DRSYS_TYPE_POINTER},
          {4, sizeof(uint64_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
          {5, sizeof(uint32_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#if !(defined(MACOS) && defined(X64))
+         /* FIXME i#1438: how are 7th and 8th args passed on Mac64?!? */
          {6, sizeof(int64_t), SYSARG_INLINED, DRSYS_TYPE_SIGNED_INT},
          {7, sizeof(uint32_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#endif
      }
     },
     {{SYS_psynch_rw_rdlock /*306*/}, "psynch_rw_rdlock", OK, DRSYS_TYPE_UNSIGNED_INT, 5,
@@ -1727,7 +1746,10 @@ syscall_info_t syscall_info_bsd[] = {
          {3, sizeof(uint32_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
          {4, sizeof(uint32_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
          {5, sizeof(uint32_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#if !(defined(MACOS) && defined(X64))
+         /* FIXME i#1438: how are 7th and 8th args passed on Mac64?!? */
          {6, sizeof(uint32_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#endif
      }
     },
     {{SYS_aio_fsync /*313*/}, "aio_fsync", OK, RLONG, 2,
@@ -1791,7 +1813,10 @@ syscall_info_t syscall_info_bsd[] = {
          {3, sizeof(int), SYSARG_INLINED, DRSYS_TYPE_SIGNED_INT},
          {4, sizeof(void*), W|HT, DRSYS_TYPE_POINTER},
          {5, sizeof(pid_t), SYSARG_INLINED, DRSYS_TYPE_SIGNED_INT},
+#if !(defined(MACOS) && defined(X64))
+         /* FIXME i#1438: how are 7th and 8th args passed on Mac64?!? */
          {6, sizeof(uint64_t), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#endif
      }
     },
     {{SYS_mlockall /*324*/}, "mlockall", OK, RLONG, 1,
@@ -2069,7 +2094,10 @@ syscall_info_t syscall_info_bsd[] = {
          {3, sizeof(struct kevent64_s), W|HT, DRSYS_TYPE_STRUCT},
          {4, sizeof(int), SYSARG_INLINED, DRSYS_TYPE_SIGNED_INT},
          {5, sizeof(unsigned int), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+#if !(defined(MACOS) && defined(X64))
+         /* FIXME i#1438: how are 7th and 8th args passed on Mac64?!? */
          {6, sizeof(struct timespec), W|HT, DRSYS_TYPE_STRUCT},
+#endif
      }
     },
     {{SYS___old_semwait_signal /*370*/}, "__old_semwait_signal", OK, RLONG, 5,

--- a/tests/addronly-reg.res
+++ b/tests/addronly-reg.res
@@ -24,13 +24,13 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1396
+registers.c_asm.asm:1398
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1408
+registers.c_asm.asm:1410
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1421
+registers.c_asm.asm:1423
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1422
+registers.c_asm.asm:1424
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/bitfield.strict.res
+++ b/tests/bitfield.strict.res
@@ -24,29 +24,29 @@ Error #2: UNINITIALIZED READ
 bitfield.cpp:54
 %if WINDOWS
 Error #3: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:890
+bitfield.cpp_asm.asm:892
 Error #4: UNINITIALIZED READ: reading register bl
-bitfield.cpp_asm.asm:903
+bitfield.cpp_asm.asm:905
 Error #5: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:911
+bitfield.cpp_asm.asm:913
 Error #6: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:916
+bitfield.cpp_asm.asm:918
 Error #7: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:925
+bitfield.cpp_asm.asm:927
 Error #8: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:928
+bitfield.cpp_asm.asm:930
 Error #9: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:933
+bitfield.cpp_asm.asm:935
 Error #10: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:936
+bitfield.cpp_asm.asm:938
 Error #11: UNINITIALIZED READ: reading register dl
-bitfield.cpp_asm.asm:960
+bitfield.cpp_asm.asm:962
 Error #12: UNINITIALIZED READ: reading register esi
-bitfield.cpp_asm.asm:961
+bitfield.cpp_asm.asm:963
 Error #13: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:975
+bitfield.cpp_asm.asm:977
 Error #14: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:986
+bitfield.cpp_asm.asm:988
 %endif
 %if UNIX
 Error #3: UNINITIALIZED READ: reading register ecx

--- a/tests/registers.blacklist.res
+++ b/tests/registers.blacklist.res
@@ -21,13 +21,13 @@
 #
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1396
+registers.c_asm.asm:1398
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1408
+registers.c_asm.asm:1410
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1421
+registers.c_asm.asm:1423
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1422
+registers.c_asm.asm:1424
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)

--- a/tests/registers.pattern.res
+++ b/tests/registers.pattern.res
@@ -24,9 +24,9 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1396
+registers.c_asm.asm:1398
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1408
+registers.c_asm.asm:1410
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -119,15 +119,15 @@ registers.c_asm.asm:1902
 %endif
 %if UNIX
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1066
+registers.c_asm.asm:1064
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1080
-Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1094
-Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1108
-Error #26: UNINITIALIZED READ: reading register eax
 registers.c_asm.asm:1078
+Error #24: UNINITIALIZED READ: reading 2 byte(s)
+registers.c_asm.asm:1092
+Error #25: UNINITIALIZED READ: reading 2 byte(s)
+registers.c_asm.asm:1106
+Error #26: UNINITIALIZED READ: reading register eax
+registers.c_asm.asm:1076
 %endif
 %OUT_OF_ORDER
 : LEAK 15 direct bytes + 0 indirect bytes

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -21,39 +21,39 @@
 #
 %if WINDOWS
 Error #1: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1369
+registers.c_asm.asm:1371
 Error #2: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1376
+registers.c_asm.asm:1378
 Error #3: UNINITIALIZED READ: reading 2 byte(s)
 registers.c:104
 Error #4: UNINITIALIZED READ: reading register ax
-registers.c_asm.asm:1596
+registers.c_asm.asm:1598
 Error #5: UNINITIALIZED READ: reading register dx
-registers.c_asm.asm:1613
+registers.c_asm.asm:1615
 Error #6: UNINITIALIZED READ: reading register ah
-registers.c_asm.asm:1643
+registers.c_asm.asm:1645
 Error #7: UNINITIALIZED READ: reading 1 byte(s)
 registers.c:187
 Error #8: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1345
+registers.c_asm.asm:1347
 Error #9: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1170
+registers.c_asm.asm:1172
 Error #10: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1174
+registers.c_asm.asm:1176
 Error #11: UNINITIALIZED READ: reading register cl
-registers.c_asm.asm:1179
+registers.c_asm.asm:1181
 Error #12: UNINITIALIZED READ: reading register xcx
-registers.c_asm.asm:1199
+registers.c_asm.asm:1201
 Error #13: UNINITIALIZED READ: reading 8 byte(s)
-registers.c_asm.asm:1230
+registers.c_asm.asm:1232
 Error #14: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1396
+registers.c_asm.asm:1398
 Error #15: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1408
+registers.c_asm.asm:1410
 Error #16: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1421
+registers.c_asm.asm:1423
 Error #17: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1422
+registers.c_asm.asm:1424
 %endif
 %if UNIX
 Error #1: UNINITIALIZED READ: reading register eflags
@@ -99,7 +99,7 @@ registers.c_asm.asm:970
 %endif
 %if WINDOWS
 Error #19: UNINITIALIZED READ: reading register ecx
-registers.c_asm.asm:1738
+registers.c_asm.asm:1740
 %endif
 Error #20: UNINITIALIZED READ: reading register
 registers.c:267
@@ -107,27 +107,27 @@ Error #21: UNINITIALIZED READ: reading register
 registers.c:288
 %if WINDOWS
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1823
+registers.c_asm.asm:1825
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1837
+registers.c_asm.asm:1839
 Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1851
+registers.c_asm.asm:1853
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1865
+registers.c_asm.asm:1867
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1900
+registers.c_asm.asm:1902
 %endif
 %if UNIX
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1064
+registers.c_asm.asm:1066
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1078
+registers.c_asm.asm:1080
 Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1092
+registers.c_asm.asm:1094
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1106
+registers.c_asm.asm:1108
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1076
+registers.c_asm.asm:1078
 %endif
 %OUT_OF_ORDER
 : LEAK 15 direct bytes + 0 indirect bytes

--- a/tests/state.c
+++ b/tests/state.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -55,8 +55,11 @@ typedef struct sigcontext sigcontext_t;
 # endif
 #elif defined(MACOS)
 # ifdef X64
-typedef _STRUCT_MCONTEXT_AVX64 sigcontext_t;
-#  define SIGCXT_FROM_UCXT(ucxt) ((sigcontext_t*)((ucxt)->uc_mcontext64))
+/* XCode 10.1 (probably others too) toolchain wants _STRUCT_MCONTEXT
+ * w/o _AVX64 and has a field named uc_mcontext with no 64.
+ */
+typedef _STRUCT_MCONTEXT64 sigcontext_t;
+#  define SIGCXT_FROM_UCXT(ucxt) ((sigcontext_t*)((ucxt)->uc_mcontext))
 #  define XAX __ss.__rax
 # else
 typedef _STRUCT_MCONTEXT_AVX32 sigcontext_t;

--- a/tests/state.pattern.res
+++ b/tests/state.pattern.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
 # **********************************************************
 #
 # Dr. Memory: the memory debugger
@@ -19,4 +19,4 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 Error #1: UNADDRESSABLE ACCESS: writing 1 byte(s)
-state.c:133
+state.c:136

--- a/tests/state.res
+++ b/tests/state.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
 # **********************************************************
 #
 # Dr. Memory: the memory debugger
@@ -19,4 +19,4 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 Error #1: UNADDRESSABLE ACCESS: writing 1 byte(s)
-state.c:133
+state.c:136

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -308,12 +308,12 @@ typedef struct _app_segment_t {
     umbra_map_t *map[MAX_NUM_MAPS];
 } app_segment_t;
 
-#ifdef LINUX
+#ifdef UNIX /* TODO i#1438: Update for Mac64. */
 # define PIE_DEF_SEGMENT       (app_pc)((ptr_uint_t)0x55 << NUM_SEG_BITS)
 # define PIE_DEF_SEG_2X_DISP   ((ptr_uint_t)0x48 << 36)
 # define PIE_ALT_SEGMENT       (app_pc)((ptr_uint_t)0x56 << NUM_SEG_BITS)
 # define PIE_ALT_SEG_2X_DISP   ((ptr_uint_t)0x58 << 36)
-#endif /* LINUX */
+#endif
 
 static ptr_uint_t map_disp[] = {
 #ifdef WINDOWS


### PR DESCRIPTION
Updates DR to 5121dd0f for base 64-bit MacOS support from DR.
Updates the asm-using tests/*.res line numbers from DR asm_defines changes.

Updates the version check, system call numbers, and other miscellaneous
tweaks to get Dr. Memory building and running simple 64-bit apps on MacOS
in light mode (i#2083 blocks full mode).

Issue: #1438, #2083