### PR TITLE
i#1438 MacOS: 64-bit full mode support

### DIFF
--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -108,6 +108,11 @@
 #define DEFAULT_DR_OPS \
     "-disable_traces -bb_single_restore_prefix -max_bb_instrs 256 -vm_size 256M "\
     "-no_enable_reset"
+#if defined(MACOS) && defined(X64)
+# define DEFAULT_DR_OPS_EXT " -signal_stack_size 64K"
+#else
+# define DEFAULT_DR_OPS_EXT ""
+#endif
 
 #define DRMEM_CLIENT_ID 0
 
@@ -889,7 +894,7 @@ _tmain(int argc, TCHAR *targv[])
     drfront_string_replace_character(drmem_root, ALT_DIRSEP, DIRSEP); /* canonicalize */
 
     BUFPRINT(dr_ops, BUFFER_SIZE_ELEMENTS(dr_ops),
-             drops_sofar, len, "%s ", DEFAULT_DR_OPS);
+             drops_sofar, len, "%s%s ", DEFAULT_DR_OPS, DEFAULT_DR_OPS_EXT);
 #ifdef WINDOWS
     /* FIXME i#699: early injection crashes the child on 32-bit or on wow64 vista+.
      * We work around it here.  Should remove this once the real bug is fixed.

--- a/drmemory/shadow.c
+++ b/drmemory/shadow.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1011,10 +1011,6 @@ shadow_memory_is_shadow(app_pc addr)
  *
  * Table lookup is most performant way to do many operations, when we're
  * instrumenting so much code that code size is a bottleneck.
- */
-
-/* To ensure we can access the tables in 64-bit, we copy them into a low-2GB
- * mmap NOCHECK
  */
 
 /*

--- a/drsyscall/drsyscall_macos.c
+++ b/drsyscall/drsyscall_macos.c
@@ -199,8 +199,12 @@ drsyscall_os_init(void *drcontext)
     dr_recurlock_lock(systable_lock);
     for (i = 0; i < count_syscall_info_bsd; i++) {
 #if defined(MACOS) && defined(X64)
-        /* We want to use SYS_ enums in the table so we add the BSD marker here. */
-        syscall_info_bsd[i].num.number |= SYSCALL_NUM_MARKER_BSD;
+        /* We want to use SYS_ enums in the table so we could add the BSD marker
+         * here via:
+         *   syscall_info_bsd[i].num.number |= SYSCALL_NUM_MARKER_BSD;
+         * however, DR is removing the marker from the numbers we see, so we leave it
+         * off.  XXX: Will a user look at raw syscalls and include it?
+         */
 #endif
         IF_DEBUG(bool ok =)
             hashtable_add(&systable, (void *) &syscall_info_bsd[i].num,

--- a/package.cmake
+++ b/package.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2015 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -117,8 +117,8 @@ else ()
 endif ()
 
 if (APPLE)
-  # DRi#58: core DR does not yet support 64-bit Mac
-  set(arg_32_only ON)
+  # Macs no longer support 32-bit at all.
+  set(arg_64_only ON)
 endif ()
 
 # i#1099: be sure to set BUILDING_PACKAGE
@@ -151,14 +151,16 @@ else ()
 endif ()
 
 if (NOT arg_drmem_only)
-  testbuild_ex("drheapstat-${name_sfx}release-32" OFF "
-    TOOL_DR_HEAPSTAT:BOOL=ON
-    CMAKE_BUILD_TYPE:STRING=Release
-    " OFF ON "")
-  testbuild_ex("drheapstat-${name_sfx}debug-32" OFF "
-    TOOL_DR_HEAPSTAT:BOOL=ON
-    CMAKE_BUILD_TYPE:STRING=Debug
-    " OFF ON "")
+  if (NOT arg_64_only)
+    testbuild_ex("drheapstat-${name_sfx}release-32" OFF "
+      TOOL_DR_HEAPSTAT:BOOL=ON
+      CMAKE_BUILD_TYPE:STRING=Release
+      " OFF ON "")
+    testbuild_ex("drheapstat-${name_sfx}debug-32" OFF "
+      TOOL_DR_HEAPSTAT:BOOL=ON
+      CMAKE_BUILD_TYPE:STRING=Debug
+      " OFF ON "")
+  endif ()
   testbuild_ex("drheapstat-${name_sfx}release-64" ON "
     TOOL_DR_HEAPSTAT:BOOL=ON
     CMAKE_BUILD_TYPE:STRING=Release
@@ -171,18 +173,20 @@ endif (NOT arg_drmem_only)
 if (NOT arg_32_only)
   testbuild_ex("drmemory-${name_sfx}release-64" ON "
     CMAKE_BUILD_TYPE:STRING=Release
-  " OFF ON "")
+    " OFF ON "")
   testbuild_ex("drmemory-${name_sfx}debug-64" ON "
     CMAKE_BUILD_TYPE:STRING=Debug
-  " OFF ON "")
+    " OFF ON "")
 endif (NOT arg_32_only)
-# 32-bit last, to match DR for embedded packaging
-testbuild_ex("drmemory-${name_sfx}release-32" OFF "
-  CMAKE_BUILD_TYPE:STRING=Release
-  " OFF ON "")
-testbuild_ex("drmemory-${name_sfx}debug-32" OFF "
-  CMAKE_BUILD_TYPE:STRING=Debug
-  " OFF ON "")
+if (NOT arg_64_only)
+  # 32-bit last, to match DR for embedded packaging
+  testbuild_ex("drmemory-${name_sfx}release-32" OFF "
+    CMAKE_BUILD_TYPE:STRING=Release
+    " OFF ON "")
+  testbuild_ex("drmemory-${name_sfx}debug-32" OFF "
+    CMAKE_BUILD_TYPE:STRING=Debug
+    " OFF ON "")
+endif ()
 
 if (arg_cpackappend)
   # ${last_package_build_dir} is a global var set in parent scope by


### PR DESCRIPTION
Fixes for 64-bit Mac full mode on small apps:
+ Updates DR to 704b750f to fix memquery performance and
  release build warnings.
+ Pass "-signal_stack_size 64K" since the default seems too small.
+ Remove the BSD syscall number marker from the drsyscall table since
  DR removes it from the numbers we see.
+ Updates package.cmake to build Mac 64_only.

Issue: #1438