### PR TITLE
DRi#3886: Fix Catalina library segment alignment issue

### DIFF
--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -101,6 +101,21 @@ if (WIN32)
   set(front_srcs ${front_srcs} ${PROJECT_SOURCE_DIR}/make/resources.rc)
 endif ()
 
+macro(fix_win32_flags srcfile)
+  if (WIN32)
+    if (DEBUG)
+      get_property(cur SOURCE ${srcfile} PROPERTY COMPILE_FLAGS)
+      string(REPLACE "/MT " "" cur "${cur}") # Avoid override warning.
+      set_source_files_properties(${srcfile} PROPERTIES COMPILE_FLAGS "${cur} /EHsc /MTd")
+      append_property_string(SOURCE ${srcfile} LINK_FLAGS "/nodefaultlib:libcmt")
+    else ()
+      append_property_string(SOURCE ${srcfile} COMPILE_FLAGS "/EHsc /MT")
+    endif ()
+  endif ()
+endmacro ()
+
+fix_win32_flags(drltrace_frontend.cpp)
+
 add_executable(drltrace ${front_srcs})
 
 configure_DynamoRIO_standalone(drltrace)

--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -155,7 +155,7 @@ on_supported_version(void)
     if (uname(&uinfo) != 0)
         return false;
 #   define MIN_DARWIN_VERSION_SUPPORTED 11  /* OSX 10.7.x */
-#   define MAX_DARWIN_VERSION_SUPPORTED 18  /* OSX 10.14.x */
+#   define MAX_DARWIN_VERSION_SUPPORTED 19  /* OSX 10.15.x */
     return (dr_sscanf(uinfo.release, "%d", &kernel_major) == 1 &&
             kernel_major <= MAX_DARWIN_VERSION_SUPPORTED &&
             kernel_major >= MIN_DARWIN_VERSION_SUPPORTED);


### PR DESCRIPTION
Pulls in DR 0720551f for a fix to DRi#3886 where library segments have
sub-page alignment and are packed onto the same page on Catalina.

Updates the min supported Mac kernel to 19 (Catalina).