### PR TITLE
i#2233: Add AMD monitorx/mwaitx decode support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016-2019 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -33,9 +33,9 @@ branches:
   only:
   - master
 
-# We use Trusty to get cmake 2.8.12 instead of 2.8.7 from Precise:
+# We use Xenial to match DR.
 sudo: required
-dist: trusty
+dist: xenial
 
 language:
   - c
@@ -65,7 +65,7 @@ install:
   # on 11/15/17.  Xref https://github.com/travis-ci/travis-ci/issues/8552.
   - if [[ "`uname`" == "Darwin" ]]; then brew update; brew install nasm; fi
   # ImageMagick is present but these are not:
-  - if [[ "`uname`" == "Linux" ]]; then sudo apt-get -y install g++-multilib doxygen transfig; fi
+  - if [[ "`uname`" == "Linux" ]]; then sudo apt-get -y install g++-multilib ghostscript doxygen transfig; fi
 
 script:
   - tests/runsuite_wrapper.pl travis

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -380,10 +380,12 @@ if (UNIX)
         "${CMAKE_EXE_LINKER_FLAGS} -fPIE -pie -Wl,--export-dynamic")
     endif ()
   endif ()
+  # We use C++11.
+  set(EXTRA_CXXFLAGS "-std=c++11")
   set(CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_UPPER}
     "${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} ${ARCH_CFLAGS} ${WARN} ${EXTRA_FLAGS}")
   set(CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}
-    "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} ${ARCH_CFLAGS} ${WARN} ${EXTRA_FLAGS}")
+    "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} ${ARCH_CFLAGS} ${WARN} ${EXTRA_FLAGS} ${EXTRA_CXXFLAGS}")
 else (UNIX)
   # FIXME i#1204: fix warnings and up to /W4
   set(WARN "/W2 /WX")

--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2019 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2020 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -119,6 +119,7 @@ fix_win32_flags(drltrace_frontend.cpp)
 add_executable(drltrace ${front_srcs})
 
 configure_DynamoRIO_standalone(drltrace)
+use_DynamoRIO_extension(drltrace droption)
 
 target_link_libraries(drltrace drinjectlib drconfiglib drfrontendlib drsyscall_static)
 


### PR DESCRIPTION
Updates DR to af21cdc0 for decoder support for the AMD-specific
monitorx and mwaitx opcodes.

Fixes #2233