### PR TITLE
i#2250 VS2017: Fix more link errors with duplicate symbols

### DIFF
--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -79,8 +79,8 @@ if (UNIX)
   # to avoid conflicts with new declaration with "C" linkage in utils.h
   append_property_string(TARGET drltracelib COMPILE_FLAGS "-DNOLINK_STRCASESTR")
 endif()
-if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
-  # i#1805: see comment in drstrace/CMakeLists.txt
+if (WIN32)
+  # i#1805: see comment in drstrace/CMakeLists.txt.  For VS2017 avoid _isdigit.
   append_property_string(TARGET drltracelib LINK_FLAGS "/force:multiple")
 endif ()
 

--- a/drstrace/CMakeLists.txt
+++ b/drstrace/CMakeLists.txt
@@ -185,8 +185,8 @@ if (WIN32)
   # that we try multiple times (i#1925).
   set_tests_properties(drstrace_unit_tests PROPERTIES TIMEOUT 240)
 
-  if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
-    # i#1805: avoid tolower dup symbol errors
+  if (WIN32)
+    # i#1805: avoid tolower dup symbol errors.  For VS2017 avoid _isdigit.
     append_property_string(TARGET drstrace_unit_tests LINK_FLAGS "/force:multiple")
   endif ()
 endif (WIN32)


### PR DESCRIPTION
Extends the i#1805 duplicate symbol handling to all generators.

Issue: #1805, #2250