### PR TITLE
i#2260 doc-deploy: Fix error in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
     - if: type = cron OR env(TRAVIS_EVENT_TYPE) = cron
       os: linux
       compiler: gcc
-      env: DEPLOY=yes DEPLOY_DOCS=ye
+      env: DEPLOY=yes DEPLOY_DOCS=yes
     - if: type = cron OR env(TRAVIS_EVENT_TYPE) = cron
       os: osx
       compiler: clang


### PR DESCRIPTION
Fixes an incorrect env var name for triggering our docs deployment.

Issue: #2260