### PR TITLE
i#2250 VS2017: Switch Appveyor to VS2017

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ configuration:
 
 #TEMPORARY
 environment:
-  APPVEYOR_RDP_PASSWORD: DiagnoseDrMExits
+  APPVEYOR_RDP_PASSWORD: Diagnose:4DrMExits
 
 init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,6 +53,16 @@ build:
 configuration:
   - 2017
 
+
+#TEMPORARY
+environment:
+  APPVEYOR_RDP_PASSWORD: DiagnoseDrMExits
+
+init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#ENDTEMPORARY
+
+
 install:
   ##################################################
   # Install ninja so we have readable output.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,15 +43,15 @@ branches:
 
 platform: x64
 
-image: Visual Studio 2013
+image: Visual Studio 2017
 
 build:
   verbosity: detailed
 
-# We stick with just one config (we've dropped VS2010 support) to speed
-# up the build (xref DRi#2406).
+# We stick with just one config (we've dropped VS2010 support, and no
+# longer actively support VS2013) to speed up the build (xref DRi#2406).
 configuration:
-  - 2013
+  - 2017
 
 install:
   ##################################################
@@ -81,7 +81,7 @@ install:
   # XXX i#2145: point at Qt5 for testing drheapstat visualizer.
 
 before_build:
-  - if "%configuration%"=="2013" call "c:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
+  - if "%configuration%"=="2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
   - cd c:\projects\drmemory
 
 build_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,9 @@ if (WIN32)
   else ()
     set(PROGFILES "$ENV{PROGRAMW6432}")
     set(PROGFILES32 "$ENV{PROGRAMFILES(x86)}")
+    if ("${PROGFILES32}" STREQUAL "")
+      set(PROGFILES32 "$ENV{PROGRAMFILES}")
+    endif ()
     if (X64)
       set(ARCH_SFX "x64")
       set(DDK_SFX "amd64")
@@ -568,7 +571,8 @@ if (WIN32)
     # Visual Studio put dbghelp.dll in progfiles (especially 2008) and some in progfiles32.
     "${PROGFILES}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
     "${PROGFILES32}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
-    "${PROGFILES32}/Microsoft Visual Studio */Common7/Packages/Debugger/${ARCH_SFX}/dbghelp.dll")
+    "${PROGFILES32}/Microsoft Visual Studio */Common7/Packages/Debugger/${ARCH_SFX}/dbghelp.dll"
+    "${PROGFILES32}/Microsoft Visual Studio/*/Professional/Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll")
 
   if (X64)
     set(dbghelp_paths ${dbghelp_paths}

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2011 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2009 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -53,31 +53,16 @@
 set(CTEST_PROJECT_NAME "DrMemory") # must match project() name
 
 if (SUBMIT_LOCAL)
-  set(CTEST_DROP_METHOD "scp")
-  if (WIN32)
-    # Cygwin scp won't take : later in path (and interprets drive as host like
-    # unix scp would) so we use cp, which is ok with drive-letter paths.
-    # Note that CTEST_SCP_COMMAND must be a single executable so we can't
-    # use "cmake -E copy".
-    if (EXISTS "${CTEST_SCRIPT_DIRECTORY}/tests/copy.bat")
-      set(CTEST_SCP_COMMAND "${CTEST_SCRIPT_DIRECTORY}/tests/copy.bat")
-    elseif (EXISTS "${CTEST_SCRIPT_DIRECTORY}/copy.bat")
-      set(CTEST_SCP_COMMAND "${CTEST_SCRIPT_DIRECTORY}/copy.bat")
-    else ()
-      message(FATAL_ERROR "cannot find copy.bat")
-    endif ()
-  else (WIN32)
-    find_program(CTEST_SCP_COMMAND scp DOC "scp command for local copy of results")
-  endif (WIN32)
+  # There is no longer support for "cp" or "scp methods in cmake 3.14+: there is no
+  # way to copy locally using ctest_submit().  We copy ourselves manually.
+  set(CTEST_SUBMIT_URL "none")
+  set(CTEST_DROP_METHOD "none")
   set(CTEST_TRIGGER_SITE "")
   set(CTEST_DROP_SITE_USER "")
-  # CTest does "scp file ${CTEST_DROP_SITE}:${CTEST_DROP_LOCATION}" so for
-  # local copy w/o needing sshd on localhost we arrange to have : in the
-  # absolute filepath (when absolute, scp interprets as local even if : later)
   if (NOT EXISTS "${CTEST_DROP_SITE}:${CTEST_DROP_LOCATION}")
     message(FATAL_ERROR
       "must set ${CTEST_DROP_SITE}:${CTEST_DROP_LOCATION} to an existing directory")
-  endif (NOT EXISTS "${CTEST_DROP_SITE}:${CTEST_DROP_LOCATION}")
+  endif ()
 else (SUBMIT_LOCAL)
   # Nightly runs will use sources as of this time
   set(CTEST_NIGHTLY_START_TIME "04:00:00 EST")


### PR DESCRIPTION
Updates the Appveyor image to Win10 1607 with VS2017.

Removes the CTest xml copying via scp which is no longer supported.
DR's runsuite code, which we're using, has already replaced it
with manual copying (DRi#14057).

Mirrors DR's PR#3999 improvements to dbghelp locating for VS2017.

Fixes #2250