### PR TITLE
i#2269 cmake: Eliminate cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# We need 2.8.10.1 for crbug.com/159092
-# (For multi-export-set support for DRMF, we also need >= 2.8.10.)
-# (For Visual Studio generators, we also need >= 2.8.2 for output dir name control.)
-# (For Linux, we also need 2.6.4+ for cmake bug #8639 (asm support broken).)
-cmake_minimum_required(VERSION 2.8.10.1)
+# DR requires 3.7 which means we must also.
+cmake_minimum_required(VERSION 3.7)
 
 include(make/policies.cmake NO_POLICY_SCOPE)
 
@@ -543,7 +540,7 @@ if (WIN32)
     set(DDK_SFX "i386")
   else ()
     set(PROGFILES "$ENV{PROGRAMW6432}")
-    set(PROGFILES32 "$ENV{PROGRAMFILES(x86)}")
+    set(PROGFILES32 "$ENV{PROGRAMFILES\(x86\)}")
     if (X64)
       set(ARCH_SFX "x64")
       set(DDK_SFX "amd64")
@@ -1437,6 +1434,11 @@ endif (USE_DRSYMS)
 if (WIN32)
   # We need to link with ntdll.lib and dbghelp.lib which we get from DR
   if (USER_SPECIFIED_DynamoRIO_DIR)
+    # XXX i#1651: Replace this LOCATION with a generator expression.
+    # This is the only one left.
+    # We may want to drop support for USER_SPECIFIED_DynamoRIO_DIR in any case
+    # which is why no effort was put in to clean this up earlier.
+    cmake_policy(SET CMP0026 OLD)
     get_target_property(libbase drinjectlib LOCATION)
     get_filename_component(libpath ${libbase} PATH)
     set(ntimp_lib "${libpath}/ntdll_imports.lib")
@@ -1784,29 +1786,29 @@ else ()
 endif ()
 
 function (create_drrun_file frontend file_out name) # option list follows name
-  get_target_property(frontend_path ${frontend} LOCATION${location_suffix})
-  get_filename_component(frontend_name ${frontend_path} NAME)
   if (ANDROID AND TOOL_DR_MEMORY)
     set(frontend_name ${toolname}) # point at script, not launcher
   endif ()
   if (BUILDING_SUB_PACKAGE)
-    set(DRRUN_TOP "FRONTEND_REL=${INSTALL_PREFIX}/${BUILD_BIN}/${frontend_name}")
+    set(DRRUN_TOP "FRONTEND_REL=${INSTALL_PREFIX}/${BUILD_BIN}")
   else ()
-    set(DRRUN_TOP "FRONTEND_REL=../${BUILD_BIN}/${frontend_name}")
+    set(DRRUN_TOP "FRONTEND_REL=../${BUILD_BIN}")
   endif ()
   set(DRRUN_FILE "${DRRUN_DIR}/${name}${DRRUN_SFX}")
-  file(WRITE  ${DRRUN_FILE} "# Dr. Memory tool config file\n")
-  file(APPEND ${DRRUN_FILE} "${DRRUN_TOP}\n")
-  file(APPEND ${DRRUN_FILE} "TOOL_OP=-dr\n")
-  file(APPEND ${DRRUN_FILE} "TOOL_OP_DR_PATH\n")
-  file(APPEND ${DRRUN_FILE} "TOOL_OP_DR_BUNDLE=-dr_ops\n")
-  foreach (op ${ARGN})
-    file(APPEND ${DRRUN_FILE} "TOOL_OP=${op}\n")
-  endforeach ()
-  if (X64)
-    file(APPEND ${DRRUN_FILE}
-      "USER_NOTICE=Support for 64-bit applications under this tool is experimental.  Please report issues to http://drmemory.org/issues.\n")
+  set(DRRUN_CONTENTS "# Dr. Memory tool config file\n")
+  if (ANDROID AND TOOL_DR_MEMORY)
+    # Point at script, not launcher.
+    set(DRRUN_CONTENTS "${DRRUN_CONTENTS}${DRRUN_TOP}/${frontend}>\n")
+  else ()
+    set(DRRUN_CONTENTS "${DRRUN_CONTENTS}${DRRUN_TOP}/$<TARGET_FILE_NAME:${frontend}>\n")
   endif ()
+  set(DRRUN_CONTENTS "${DRRUN_CONTENTS}TOOL_OP=-dr\n")
+  set(DRRUN_CONTENTS "${DRRUN_CONTENTS}TOOL_OP_DR_PATH\n")
+  set(DRRUN_CONTENTS "${DRRUN_CONTENTS}TOOL_OP_DR_BUNDLE=-dr_ops\n")
+  foreach (op ${ARGN})
+    set(DRRUN_CONTENTS "${DRRUN_CONTENTS}TOOL_OP=${op}\n")
+  endforeach ()
+  file(GENERATE OUTPUT ${DRRUN_FILE} CONTENT "${DRRUN_CONTENTS}")
   install(FILES "${DRRUN_FILE}" DESTINATION "${DRRUN_INSTALL}/")
   set(${file_out} ${DRRUN_FILE} PARENT_SCOPE)
 
@@ -1873,7 +1875,10 @@ SET_PROPERTY(TARGET ${ARGV0} PROPERTY MAP_IMPORTED_CONFIG_RELMINSIZE RelWithDebI
   endif (NOT DEBUG_BUILD)
   # For install we want both debug and release:
   set(exported_targets_append "${exported_targets_append}${toadd}")
-  set(exported_targets_append "${exported_targets_append}" PARENT_SCOPE)
+  # Hack to avoid "no parent scope" complaint.
+  if (NOT "${ARGV}" MATCHES "drmemory_annotations")
+    set(exported_targets_append "${exported_targets_append}" PARENT_SCOPE)
+  endif ()
 endmacro(export_target)
 
 if (DR_ANNOTATIONS_SUPPORTED)
@@ -2269,9 +2274,14 @@ install(EXPORT ${exported_targets_name} DESTINATION ${DRMF_INSTALL})
 # We do this at install time once we have all binaries built, as it's a pain
 # to individually add post-build commands.
 if (WIN32)
-  get_target_property(verinfo_path verinfo LOCATION${location_suffix})
   install(CODE "include(\"${PROJECT_SOURCE_DIR}/make/rccheck.cmake\")")
-  install(CODE "check_version_resources(\"${PROJECT_BINARY_DIR}\" \"${verinfo_path}\")")
+  # We'd need cmake 3.14+ and CMP0087=NEW for a generator expression to work
+  # directly in install(CODE).  We instead have to make a file.
+  set(verinfo_locator "verinfo_locator.cmake")
+  file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${verinfo_locator}" CONTENT
+"set(VERINFO \"$<TARGET_FILE:verinfo>\")\n")
+  install(CODE "include(\"${CMAKE_CURRENT_BINARY_DIR}/${verinfo_locator}\")")
+  install(CODE "check_version_resources(\"${PROJECT_BINARY_DIR}\" \"\${VERINFO}\")")
 endif ()
 
 ###########################################################################

--- a/drfuzz/CMakeLists.txt
+++ b/drfuzz/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2017 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2020 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -28,13 +28,9 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.12" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.8.12")
-  # XXX DRi#1481: update to cmake 2.8.12's better handling of interface imports
-  cmake_policy(SET CMP0022 OLD)
-endif ()
+include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 
 set(srcs
   drfuzz.c
@@ -73,11 +69,11 @@ endmacro(configure_drfuzz_target)
 macro(export_drfuzz_target target drwrap drmgr)
   # We need to clear the dependents that come from DR to avoid the prefix
   # from affecting them too.
-  set_target_properties(${target} PROPERTIES LINK_INTERFACE_LIBRARIES "")
+  set_target_properties(${target} PROPERTIES INTERFACE_LINK_LIBRARIES "")
   export_target(${target})
   # Now put in our imports (w/o any namespace on them)
   set_target_properties(${target} PROPERTIES
-    LINK_INTERFACE_LIBRARIES "dynamorio;${drwrap};${drmgr};drcontainers")
+    INTERFACE_LINK_LIBRARIES "dynamorio;${drwrap};${drmgr};drcontainers")
   install(TARGETS ${target} EXPORT ${exported_targets_name}
     DESTINATION ${DRMF_INSTALL_BIN})
   # Top-level installs .debug and .pdb files

--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -29,7 +29,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
 include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 

--- a/drstrace/CMakeLists.txt
+++ b/drstrace/CMakeLists.txt
@@ -99,7 +99,6 @@ install(TARGETS drstracelib
 
 if (WIN32)
   add_library(symfetch SHARED symfetch.c ${PROJECT_SOURCE_DIR}/make/resources.rc)
-  get_target_property(symfetch_path symfetch LOCATION${location_suffix})
 
   # We manually set PDBALTPATH here b/c compiler sets absolute path
   # to pdb which we don't need here. We disable INCREMENTAL b/c we
@@ -122,7 +121,7 @@ if (WIN32)
   endif ()
   add_custom_command(TARGET symfetch POST_BUILD COMMAND ${PERL_EXECUTABLE}
                      "${CMAKE_CURRENT_SOURCE_DIR}/mksymguid.pl"
-                     "${symfetch_path}" VERBATIM)
+                     "$<TARGET_FILE:symfetch>" VERBATIM)
   install(TARGETS symfetch DESTINATION "${INSTALL_BIN}"
     PERMISSIONS ${owner_access} OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
     WORLD_READ WORLD_EXECUTE)
@@ -144,9 +143,8 @@ configure_DynamoRIO_standalone(drstrace)
 target_link_libraries(drstrace drinjectlib drconfiglib drfrontendlib drsyscall_static)
 set_library_version(drstrace ${DRMF_VERSION})
 if (WIN32)
-  get_filename_component(symfetch_name ${symfetch_path} NAME)
   set_property(TARGET drstrace PROPERTY COMPILE_DEFINITIONS
-    ${DEFINES_NO_D} RC_IS_DRSTRACE SYMBOL_DLL_NAME="${symfetch_name}")
+    ${DEFINES_NO_D} RC_IS_DRSTRACE SYMBOL_DLL_NAME="$<TARGET_FILE_NAME:symfetch>")
 else ()
   set_property(TARGET drstrace PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
 endif ()
@@ -173,12 +171,10 @@ if (WIN32)
   # XXX DRi#1409/DRi#1503/i#1805: we get link errors about dup symbols
   # dr_get_stderr_file() in drdecode and dynamorio libs unless we link w/
   # drinjectlib, and if we link w/ drinjectlib we get duplicate IR link errors
-  # w/ drdecode (i#1805).  We solve by moving drfrontendlib earlier via the link
-  # flags.
-  get_target_property(drfront_path drfrontendlib LOCATION${location_suffix})
-  append_property_string(TARGET drstrace_unit_tests LINK_FLAGS ${drfront_path})
-  add_dependencies(drstrace_unit_tests drfrontendlib)
-  add_dependencies(drstrace_unit_tests drsyscall)
+  # w/ drdecode (i#1805).  We used to solve by moving drfrontendlib earlier via
+  # LINK_FLAGS, but generator expressions are not honored there, and we'd need
+  # CMake 3.13 for LINK_OPTIONS.  We instead solve by /force:multiple..
+  target_link_libraries(drstrace_unit_tests drfrontendlib)
   add_test(drstrace_unit_tests
            "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/drstrace_unit_tests")
   # We increase test timeout in case of slow Internet connection, esp now
@@ -187,6 +183,8 @@ if (WIN32)
 
   if (WIN32)
     # i#1805: avoid tolower dup symbol errors.  For VS2017 avoid _isdigit.
+    # Also avoid drfrontendlib duplicate IR link errors as documented above
+    # DRi#1409/DRi#1503/i#1805.
     append_property_string(TARGET drstrace_unit_tests LINK_FLAGS "/force:multiple")
   endif ()
 endif (WIN32)
@@ -195,9 +193,8 @@ endif (WIN32)
 # drstrace test
 
 if (BUILD_TOOL_TESTS)
-  get_target_property(app_path drsyscall_app LOCATION${location_suffix})
-  get_target_property(drstrace_path drstrace LOCATION${location_suffix})
-  add_test(drstrace ${drstrace_path} -dr ${DynamoRIO_DIR}/.. -- ${app_path})
+  add_test(NAME drstrace COMMAND $<TARGET_FILE:drstrace> -dr ${DynamoRIO_DIR}/.. --
+    $<TARGET_FILE:drsyscall_app>)
 endif (BUILD_TOOL_TESTS)
 
 ##################################################

--- a/drsymcache/CMakeLists.txt
+++ b/drsymcache/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -18,13 +18,9 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.12" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.8.12")
-  # XXX DRi#1481: update to cmake 2.8.12's better handling of interface imports
-  cmake_policy(SET CMP0022 OLD)
-endif ()
+include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 
 set_output_dirs(${framework_bindir})
 
@@ -70,11 +66,11 @@ endmacro(configure_drsymcache_target)
 macro(export_drsymcache_target target drmgr drsyms)
   # We need to clear the dependents that come from DR to avoid the prefix
   # from affecting them too.
-  set_target_properties(${target} PROPERTIES LINK_INTERFACE_LIBRARIES "")
+  set_target_properties(${target} PROPERTIES INTERFACE_LINK_LIBRARIES "")
   export_target(${target})
   # Now put in our imports (w/o any namespace)
   set_target_properties(${target} PROPERTIES
-    LINK_INTERFACE_LIBRARIES "dynamorio;${drmgr}")
+    INTERFACE_LINK_LIBRARIES "dynamorio;${drmgr}")
   install(TARGETS ${target} EXPORT ${exported_targets_name}
     DESTINATION ${DRMF_INSTALL_BIN})
   # Top-level installs .debug and .pdb files

--- a/drsyscall/CMakeLists.txt
+++ b/drsyscall/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2018 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -18,13 +18,9 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.12" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.8.12")
-  # XXX DRi#1481: update to cmake 2.8.12's better handling of interface imports
-  cmake_policy(SET CMP0022 OLD)
-endif ()
+include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 
 set_output_dirs(${framework_bindir})
 
@@ -105,14 +101,14 @@ macro(configure_drsyscall_target target)
   copy_target_to_device(${target})
 endmacro(configure_drsyscall_target)
 
-macro(export_drsyscall_target target drmgr)
+macro(export_drsyscall_target target drmgr drsyms)
   # We need to clear the dependents that come from DR to avoid the prefix
   # from affecting them too.
-  set_target_properties(${target} PROPERTIES LINK_INTERFACE_LIBRARIES "")
+  set_target_properties(${target} PROPERTIES INTERFACE_LINK_LIBRARIES "")
   export_target(${target})
   # Now put in our imports (w/o any namespace)
   set_target_properties(${target} PROPERTIES
-    LINK_INTERFACE_LIBRARIES "dynamorio;${drmgr};drcontainers")
+    INTERFACE_LINK_LIBRARIES "dynamorio;${drmgr};${drsyms};drcontainers;drfrontendlib")
   install(TARGETS ${target} EXPORT ${exported_targets_name}
     DESTINATION ${DRMF_INSTALL_BIN})
   # Top-level installs .debug and .pdb files
@@ -129,7 +125,7 @@ use_DynamoRIO_extension(drsyscall drcontainers)
 use_DynamoRIO_extension(drsyscall drsyms)
 set_library_version(drsyscall ${DRMF_VERSION_MAJOR_MINOR})
 configure_drsyscall_target(drsyscall)
-export_drsyscall_target(drsyscall "drmgr")
+export_drsyscall_target(drsyscall "drmgr" "drsyms")
 install(FILES drsyscall.h DESTINATION ${DRMF_INSTALL_INC})
 
 # Since the license is LGPL, SHARED and not STATIC by default.
@@ -144,7 +140,7 @@ use_DynamoRIO_extension(drsyscall_static drcontainers)
 use_DynamoRIO_extension(drsyscall_static drsyms_static)
 configure_drsyscall_target(drsyscall_static)
 add_static_lib_debug_info(drsyscall_static ${DRMF_INSTALL_BIN})
-export_drsyscall_target(drsyscall_static "drmgr_static")
+export_drsyscall_target(drsyscall_static "drmgr_static" "drsyms_static")
 
 # We build a separate static target for internal use that has our
 # log/assert/notify infrastructure.

--- a/framework/samples/CMakeLists.txt
+++ b/framework/samples/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2014-2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -18,13 +18,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required(VERSION 2.8)
-
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  # XXX i#1663: put in actual changes to support CMake 3.x
-  cmake_policy(SET CMP0026 OLD)
-endif ()
+cmake_minimum_required(VERSION 3.7)
 
 # Collapse VS generator into a single config, to match Makefiles.
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")

--- a/make/policies.cmake
+++ b/make/policies.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -18,28 +18,13 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.1" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.1")
-  cmake_policy(SET CMP0053 OLD)
-  cmake_policy(SET CMP0054 OLD)
-endif ()
-
 if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
     "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  # XXX i#1651: put in actual changes to support CMake 3.x
-  cmake_policy(SET CMP0026 OLD)
-  # XXX i#1652: update to cmake 2.8.12's better handling of interface exports
+  # TODO i#1652: switch to ctest --build_and_test.
+  # (Unfortunately this is printed for multiple subdirectories: passing
+  # "-Wno-deprecated" to cmake will silence it.)
   cmake_policy(SET CMP0024 OLD)
 endif ()
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.12" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.8.12")
-  # XXX i#1481: update to cmake 2.8.12's better handling of interface imports
-  cmake_policy(SET CMP0022 OLD)
-endif ()
-
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.11" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.8.11")
-  # XXX DRi#1418: update to cmake 2.8.12's better handling of interface imports
-  cmake_policy(SET CMP0020 OLD)
-endif ()
+# i#1418: We are updated to the new scheme.
+cmake_policy(SET CMP0022 NEW)

--- a/make/rccheck.cmake
+++ b/make/rccheck.cmake
@@ -35,6 +35,7 @@ function (check_version_resources BASEDIR VERINFO)
     ${BASEDIR}/drmf/*/*/*.dll
     ${BASEDIR}/drmf/*/*/*.exe)
   foreach (bin ${binaries})
+    message("Running |${VERINFO}| on |${bin}|")
     if (NOT bin MATCHES "dbghelp.dll")
       execute_process(COMMAND
         ${VERINFO} ${bin}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -984,10 +984,14 @@ if (WIN32)
   # only at the end of the file to all targets, and there's no /Zi- or /debug:no,
   # is there any better way to disable symbols than removing the pdb?
   append_property_string(TARGET nosyms LINK_FLAGS "/incremental:no")
-  get_target_property(nosyms_pdb nosyms LOCATION${location_suffix})
-  string(REGEX REPLACE "exe$" "pdb" nosyms_pdb ${nosyms_pdb})
+  set(locvar_name nosymsloc)
+  file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${locvar_name}.cmake" CONTENT
+"set(${locvar_name} \"$<TARGET_FILE:nosyms>\")\n\
+string(REGEX REPLACE \"exe\$\" \"pdb\" ${locvar_name} \${${locvar_name}})\n\
+file(REMOVE \${${locvar_name}})\n")
   add_custom_command(TARGET nosyms POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E remove ${nosyms_pdb} VERBATIM)
+    COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/${locvar_name}.cmake"
+    VERBATIM)
 
 endif (WIN32)
 

--- a/umbra/CMakeLists.txt
+++ b/umbra/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2014-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -19,13 +19,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # UMBRA: the shadow memory framework
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.7)
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.12" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "2.8.12")
-  # XXX DRi#1481: update to cmake 2.8.12's better handling of interface imports
-  cmake_policy(SET CMP0022 OLD)
-endif ()
+include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 
 set_output_dirs(${framework_bindir})
 
@@ -71,11 +67,11 @@ endmacro(configure_umbra_target)
 macro(export_umbra_target target drmgr)
   # We need to clear the dependents that come from DR to avoid the prefix
   # from affecting them too.
-  set_target_properties(${target} PROPERTIES LINK_INTERFACE_LIBRARIES "")
+  set_target_properties(${target} PROPERTIES INTERFACE_LINK_LIBRARIES "")
   export_target(${target})
   # Now put in our imports (w/o any namespace)
   set_target_properties(${target} PROPERTIES
-    LINK_INTERFACE_LIBRARIES "dynamorio;${drmgr};drcontainers")
+    INTERFACE_LINK_LIBRARIES "dynamorio;${drmgr};drcontainers")
   install(TARGETS ${target} EXPORT ${exported_targets_name}
     DESTINATION ${DRMF_INSTALL_BIN})
   # Top-level installs .debug and .pdb files


### PR DESCRIPTION
Updates the minimum cmake to 3.7, matching DR.

Removes the settings of cmake policies CMP0053 and CMP0054 to OLD
since they do not affect the code at all.

Removes the setting of CMP0029 to OLD.  This only affects Qt and in a
minor way and we are not actively supporting the Qt visualizer
anymore.

Sets CMP0022 to NEW and
s/LINK_INTERFACE_LIBRARIES/INTERFACE_LINK_LIBRARIES/.  All other
needed changes have already been done as part of #1481.

Replaces all LOCATION property uses with generator expressions, except
for one tricky case with a user-specified DR dir.  Moves the CMP0026
setting of OLD to just that condition, avoiding it for normal uses
cases.  We may want to remove user-specified DR support in any case.

Fixes a warning about no parent scope for the recent annotation target.

Issue: Dynamorio/dynamorio#1418, #1481, #2269, #1651
Fixes #1651
Fixes #2269