### PR TITLE
i#1652: Update CMake CMP0024 to modern behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,6 +1082,8 @@ add_asm_target(common/${asm_file} asm_utils_src asm_utils_tgt ""
 
 ##################################################
 
+set(DrMemory_INTERNAL ON) # Do not import exported targets.
+
 if (ANDROID)
   # We cache this for us in sub-projects like framework/samples/
   set(TOP_BINARY_DIR ${PROJECT_BINARY_DIR})
@@ -1929,6 +1931,28 @@ endif (TOOL_DR_MEMORY)
 
 if (BUILD_TOOL_TESTS)
   add_subdirectory(tests/framework)
+
+  # Test using our exported config.
+  if (DEBUG)
+    set(debug_cfg -DCMAKE_BUILD_TYPE=Debug)
+  else ()
+    set(debug_cfg -DCMAKE_BUILD_TYPE=RelWithDebInfo)
+  endif ()
+  set(drmf_bindir "${PROJECT_BINARY_DIR}/framework/samples")
+  file(COPY "${PROJECT_SOURCE_DIR}/framework/samples/strace.c"
+    DESTINATION "${drmf_bindir}")
+  add_test(drmf_proj ${CMAKE_CTEST_COMMAND}
+    --build-and-test "${drmf_bindir}"
+    "${PROJECT_BINARY_DIR}/tests/drmf_proj"
+    --build-generator ${CMAKE_GENERATOR}
+    --build-project DRMF_samples # Needed for VS generators.
+    --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+    --build-options ${debug_cfg} -DDrMemoryFramework_DIR:PATH=${framework_dir}
+    -DDynamoRIO_DIR:PATH=${DynamoRIO_DIR})
+  if (UNIX AND X86 AND NOT X64)
+    set_tests_properties(drmf_proj PROPERTIES ENVIRONMENT
+      "CFLAGS=-m32;CXXFLAGS=-m32")
+  endif ()
 
   if (TOOL_DR_MEMORY)
     # unit tests

--- a/drsyscall/CMakeLists.txt
+++ b/drsyscall/CMakeLists.txt
@@ -126,6 +126,8 @@ use_DynamoRIO_extension(drsyscall drsyms)
 set_library_version(drsyscall ${DRMF_VERSION_MAJOR_MINOR})
 configure_drsyscall_target(drsyscall)
 export_drsyscall_target(drsyscall "drmgr" "drsyms")
+# Make a build-dir copy for the drmf_proj test.
+configure_file(drsyscall.h "${framework_incdir}/drsyscall.h" @ONLY)
 install(FILES drsyscall.h DESTINATION ${DRMF_INSTALL_INC})
 
 # Since the license is LGPL, SHARED and not STATIC by default.

--- a/framework/drmf.cmake.in
+++ b/framework/drmf.cmake.in
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -21,13 +21,6 @@
 # Be sure to prefix all global vars with "drmf_" to avoid conflicts
 # with the containing project.
 
-cmake_policy(PUSH)
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  # XXX i#1652: update to cmake 2.8.12's better handling of interface exports
-  cmake_policy(SET CMP0024 OLD)
-endif ()
-
 if (${CMAKE_CXX_SIZEOF_DATA_PTR} EQUAL 4)
   set(drmf_is_x64 OFF)
 elseif (${CMAKE_C_SIZEOF_DATA_PTR} EQUAL 4)
@@ -45,5 +38,6 @@ endif (drmf_is_x64)
 # Be sure to not conflict w/ DR's "cwd" var (i#1105)
 get_filename_component(drmf_cwd "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
-include(${drmf_cwd}/DRMFTarget${drmf_bits}.cmake)
-cmake_policy(POP)
+if (NOT DrMemory_INTERNAL)
+  include(${drmf_cwd}/DRMFTarget${drmf_bits}.cmake)
+endif ()

--- a/framework/samples/CMakeLists.txt
+++ b/framework/samples/CMakeLists.txt
@@ -113,9 +113,9 @@ else ()
   string(REGEX REPLACE "# NON-COMBINED" "" string "${string}")
 endif ()
 string(REGEX REPLACE "# START NON-EXPORTED SECTION.*$" "" string "${string}")
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists-public.txt.in" "${string}")
-configure_file("${CMAKE_CURRENT_BINARY_DIR}/CMakeLists-public.txt.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists-public.txt"
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt.in" "${string}")
+configure_file("${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt"
   @ONLY)
 
 if (BUILD_TOOL_TESTS)
@@ -148,8 +148,8 @@ endif (X64)
 
 install(TARGETS strace DESTINATION ${INSTALL_SAMPLES_BIN})
 install(FILES strace.c DESTINATION ${INSTALL_SAMPLES})
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists-public.txt"
-  DESTINATION "${INSTALL_SAMPLES}" RENAME CMakeLists.txt)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt"
+  DESTINATION "${INSTALL_SAMPLES}")
 
 install(DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/
   DESTINATION ${INSTALL_SAMPLES_BIN}

--- a/make/policies.cmake
+++ b/make/policies.cmake
@@ -18,13 +18,5 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-if ("${CMAKE_VERSION}" VERSION_EQUAL "3.0" OR
-    "${CMAKE_VERSION}" VERSION_GREATER "3.0")
-  # TODO i#1652: switch to ctest --build_and_test.
-  # (Unfortunately this is printed for multiple subdirectories: passing
-  # "-Wno-deprecated" to cmake will silence it.)
-  cmake_policy(SET CMP0024 OLD)
-endif ()
-
 # i#1418: We are updated to the new scheme.
 cmake_policy(SET CMP0022 NEW)


### PR DESCRIPTION
Removes the setting of CMP0024 to OLD.  Guards the inclusion of the
drmf export file in a new DrMemory_INTERNAL variable.

Adds a build-and-test test "drmf_proj" to ensure an external user can
build using our exported config files.

Fixes #1652