### PR TITLE
DRi#4168: Annotations are not supported on ARM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,16 +60,11 @@ jobs:
       os: osx
       compiler: clang
       env: DRMEMORY_INSTALL_MULTILIB=yes
-    # AArchXX cross-compile with gcc, no tests:
-    - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
-      os: linux
-      compiler: gcc
-      env: DRMEMORY_CROSS_AARCHXX_LINUX_ONLY=yes
     - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
       os: linux
       compiler: clang
       # We need clang 9.0 for asm goto support (DRi#1799) for annotations.
-      env: CC=clang-9 CXX=clang++-9
+      env: CC=clang-9 CXX=clang++-9 DRMEMORY_INSTALL_MULTILIB=yes
       addons:
         apt:
           sources:
@@ -78,6 +73,11 @@ jobs:
             key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
           - clang-9
+    # AArchXX cross-compile with gcc, no tests:
+    - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
+      os: linux
+      compiler: gcc
+      env: DRMEMORY_CROSS_AARCHXX_LINUX_ONLY=yes
     # Android ARM cross-compile with gcc, no tests:
     - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ install:
   - if [[ "`uname`" == "Linux" ]]; then sudo apt-get -y install doxygen jsonlint; fi
   # Install multilib for non-cross-compiling Linux builds:
   - >
-      if [[ "`uname`" == "Linux" && "$DRMEMORY_INSTALL_MULTILIB == yes ]]; then
+      if [[ "`uname`" == "Linux" && "$DRMEMORY_INSTALL_MULTILIB" == yes ]]; then
       sudo apt-get -y install g++-multilib; fi
   # Install cross-compilers for cross-compiling Linux build:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,16 @@ jobs:
     - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
       os: linux
       compiler: gcc
+      env: DRMEMORY_INSTALL_MULTILIB=yes
+    - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
+      os: osx
+      compiler: clang
+      env: DRMEMORY_INSTALL_MULTILIB=yes
+    # AArchXX cross-compile with gcc, no tests:
+    - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
+      os: linux
+      compiler: gcc
+      env: DRMEMORY_CROSS_AARCHXX_LINUX_ONLY=yes
     - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
       os: linux
       compiler: clang
@@ -68,9 +78,11 @@ jobs:
             key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
           - clang-9
+    # Android ARM cross-compile with gcc, no tests:
     - if: type != cron AND env(TRAVIS_EVENT_TYPE) != cron
-      os: osx
-      compiler: clang
+      os: linux
+      compiler: gcc
+      env: DRMEMORY_CROSS_ANDROID_ONLY=yes DRMEMORY_ANDROID_TOOLCHAIN='/tmp/android-gcc-arm-ndk-10e'
     #######################################################################
     # Package jobs
     - if: type = cron OR env(TRAVIS_EVENT_TYPE) = cron
@@ -88,7 +100,30 @@ install:
   # XXX: Remove the "brew update" step once Travis fixes their Mac VM's
   # on 11/15/17.  Xref https://github.com/travis-ci/travis-ci/issues/8552.
   - if [[ "`uname`" == "Darwin" ]]; then brew update; brew install nasm; fi
-  - if [[ "`uname`" == "Linux" ]]; then sudo apt-get -y install g++-multilib doxygen jsonlint; fi
+  - if [[ "`uname`" == "Linux" ]]; then sudo apt-get -y install doxygen jsonlint; fi
+  # Install multilib for non-cross-compiling Linux builds:
+  - >
+      if [[ "`uname`" == "Linux" && "$DRMEMORY_INSTALL_MULTILIB == yes ]]; then
+      sudo apt-get -y install g++-multilib; fi
+  # Install cross-compilers for cross-compiling Linux build:
+  - >
+      if [[ "`uname`" == "Linux" && "$DRMEMORY_CROSS_AARCHXX_LINUX_ONLY" == yes ]]; then
+      sudo apt-get -y install g++-arm-linux-gnueabihf; fi
+  # Fetch and install Android NDK for Andoid cross-compile build only.
+  - >
+      if [[ "`uname`" == "Linux" && "$DRMEMORY_CROSS_ANDROID_ONLY" == yes ]]; then
+          cd /tmp
+          wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
+          unzip -q android-ndk-r10e-linux-x86_64.zip
+          android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
+              --toolchain=arm-linux-androideabi-4.9 \
+              --platform=android-21 \
+              --install-dir=/tmp/android-gcc-arm-ndk-10e
+          # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
+          ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
+          ln -sf arm-linux-androideabi-ld.bfd /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
+          cd -
+      fi
 
 script:
   - tests/runsuite_wrapper.pl travis

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1725,36 +1725,44 @@ set(DRMF_VERSION_CUR ${DRMF_VERSION_INTEGER}) # Current version
 
 configure_file(framework/public.h
   ${framework_incdir}/drmemory_framework.h)
-configure_file(drmemory/annotations_public.h
-  ${framework_incdir}/drmemory_annotations.h)
-configure_file(${DynamoRIO_DIR}/../include/annotations/dr_annotations_asm.h
-  ${framework_incdir}/dr_annotations_asm.h)
-configure_file(${DynamoRIO_DIR}/../include/annotations/dr_annotations.h
-  ${framework_incdir}/dr_annotations.h)
+# TODO DRi#1672: Port DR's annotation infrastructure to AArchXX.
+if (X86)
+  configure_file(drmemory/annotations_public.h
+    ${framework_incdir}/drmemory_annotations.h)
+  configure_file(${DynamoRIO_DIR}/../include/annotations/dr_annotations_asm.h
+    ${framework_incdir}/dr_annotations_asm.h)
+  configure_file(${DynamoRIO_DIR}/../include/annotations/dr_annotations.h
+    ${framework_incdir}/dr_annotations.h)
+endif ()
 include_directories(${framework_incdir})
 
-# Annotation support using DR's infrastructure (non-Valgrind-style).
-if (UNIX)
-  set(annot_cflags "-O0 -Wno-unused-variable -Wno-return-type")
+if (NOT X86)
+  # TODO DRi#1672: Port DR's annotation infrastructure to AArchXX.
+  set(DR_ANNOTATIONS_SUPPORTED OFF)
 else ()
-  set(annot_cflags "/Od /Ob0 /GL- /wd4715")
-endif ()
-if (UNIX)
-  # DRi#1799: clang prior to 9.0 does not support "asm goto" which is used by
-  # the DR annotation infrastructure.  But, we can't just do a version check
-  # because Apple's clang has a completely separate version number.
-  try_compile(DR_ANNOTATIONS_SUPPORTED ${PROJECT_BINARY_DIR}/try_annot
-    SOURCES ${PROJECT_SOURCE_DIR}/tests/memlayout.cpp
-    ${PROJECT_SOURCE_DIR}/drmemory/annotations_public.c CMAKE_FLAGS
-    -DINCLUDE_DIRECTORIES=${framework_incdir}
-    -DCMAKE_C_FLAGS:STRING="${annot_cflags}")
-  if (DR_ANNOTATIONS_SUPPORTED)
-    message(STATUS "DR annotations are supported")
+  # Annotation support using DR's infrastructure (non-Valgrind-style).
+  if (UNIX)
+    set(annot_cflags "-O0 -Wno-unused-variable -Wno-return-type")
   else ()
-    message(STATUS "DR annotations are NOT supported: probably this is clang<9.0")
+    set(annot_cflags "/Od /Ob0 /GL- /wd4715")
   endif ()
-else ()
-  set(DR_ANNOTATIONS_SUPPORTED ON)
+  if (UNIX)
+    # DRi#1799: clang prior to 9.0 does not support "asm goto" which is used by
+    # the DR annotation infrastructure.  But, we can't just do a version check
+    # because Apple's clang has a completely separate version number.
+    try_compile(DR_ANNOTATIONS_SUPPORTED ${PROJECT_BINARY_DIR}/try_annot
+      SOURCES ${PROJECT_SOURCE_DIR}/tests/memlayout.cpp
+      ${PROJECT_SOURCE_DIR}/drmemory/annotations_public.c CMAKE_FLAGS
+      -DINCLUDE_DIRECTORIES=${framework_incdir}
+      -DCMAKE_C_FLAGS:STRING="${annot_cflags}")
+    if (DR_ANNOTATIONS_SUPPORTED)
+      message(STATUS "DR annotations are supported")
+    else ()
+      message(STATUS "DR annotations are NOT supported: probably this is clang<9.0")
+    endif ()
+  else ()
+    set(DR_ANNOTATIONS_SUPPORTED ON)
+  endif ()
 endif ()
 
 ###########################################################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -921,8 +921,7 @@ if (TOOL_DR_MEMORY)
     newtest_nobuild_ex(state.pattern state "" "-unaddr_only" "" OFF "" "ANY" "")
   endif ()
 
-  # XXX DRi#1672: add ARM annotation support to DR
-  if (DR_ANNOTATIONS_SUPPORTED AND NOT ARM)
+  if (DR_ANNOTATIONS_SUPPORTED)
     set(memlayout.resmark "Memory layout written to:")
     find_program(JSONLINT jsonlint-php DOC "JSON linter from jsonlint package")
     if (JSONLINT)

--- a/tests/runsuite.cmake
+++ b/tests/runsuite.cmake
@@ -292,7 +292,8 @@ if (UNIX AND ARCH_IS_X86)
   # Optional cross-compilation for ARM/Linux and ARM/Android if the cross
   # compilers are on the PATH.
   # XXX: can we share w/ the DR code this is based on?
-  if (NOT cross_aarchxx_linux_only AND NOT cross_android_only)
+  set(prev_optional_cross_compile ${optional_cross_compile})
+  if (NOT cross_aarchxx_linux_only)
     set(optional_cross_compile ON)
   endif ()
   set(ARCH_IS_X86 OFF)
@@ -314,8 +315,12 @@ if (UNIX AND ARCH_IS_X86)
     CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/dynamorio/make/toolchain-arm32.cmake
     " OFF OFF "")
   set(run_tests ${prev_run_tests}) # restore
+  set(optional_cross_compile ${prev_optional_cross_compile})
 
   # Android cross-compilation and running of tests using "adb shell"
+  if (NOT cross_android_only)
+    set(optional_cross_compile ON)
+  endif ()
   find_program(ADB adb DOC "adb Android utility")
   if (ADB)
     execute_process(COMMAND ${ADB} get-state
@@ -367,7 +372,7 @@ if (UNIX AND ARCH_IS_X86)
     " OFF OFF "")
   set(run_tests ${prev_run_tests}) # restore
 
-  set(optional_cross_compile OFF)
+  set(optional_cross_compile ${prev_optional_cross_compile})
   set(ARCH_IS_X86 ON)
 endif (UNIX AND ARCH_IS_X86)
 


### PR DESCRIPTION
DR does not support annotations on ARM (DRi#1672) so we have to
disable our annotations for non-x86.

Adds ARM and Android builds to Travis.

Issue: DynamoRIO/dynamorio#4168, DynamoRIO/dynamorio#1672
Fixes DynamoRIO/dynamorio#4168