### PR TITLE
Fix suppress test failure regression

### DIFF
--- a/tests/runtest.cmake
+++ b/tests/runtest.cmake
@@ -705,6 +705,7 @@ if (resmatch AND NOT TOOL_DR_HEAPSTAT)
       -D TOOL_DR_HEAPSTAT:BOOL=${TOOL_DR_HEAPSTAT}
       -D outpat:STRING=${outpat}
       -D respat:STRING=${respat}
+      -D resmark:STRING=${resmark}
       -D nudge:STRING=${nudge}
       -D VMKERNEL:BOOL=${VMKERNEL}
       -D USE_DRSYMS:BOOL=${USE_DRSYMS}


### PR DESCRIPTION
PR #2267 for #2266 commit af3a7927 broke the suppress-* tests by
adding a new parameter to runtest.cmake but not propagating it to the
sub-run for these tests.