### PR TITLE
Relax precise error counts in cs2bug.cpp to fix Travis

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -657,7 +657,7 @@ if (TOOL_DR_MEMORY)
     newtest_nobuild(addronly-reg registers "" "-no_check_uninitialized" "" OFF "")
   endif ()
   newtest_nobuild(addronly free "" "-light" "" OFF "")
-  newtest_nobuild(reachable cs2bug "" "-show_reachable" "" OFF ${cs2bug_res})
+  newtest_nobuild(reachable cs2bug "" "-show_reachable" "" OFF "")
   newtest_nobuild(malloc_callstacks cs2bug "" "-light;-malloc_callstacks" ""
     OFF "cs2bug.light")
   if (USE_DRSYMS)

--- a/tests/cs2bug.light.out
+++ b/tests/cs2bug.light.out
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2016 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -41,6 +41,7 @@ bye
 %ANYLINE
 # Linux/MinGW
 ~~Dr.M~~      11 unique,    12 total invalid heap argument(s)
+~~Dr.M~~       8 unique,    10 total invalid heap argument(s)
 # MinGW xp64
 ~~Dr.M~~      10 unique,    11 total invalid heap argument(s)
 # MSVC

--- a/tests/cs2bug.out
+++ b/tests/cs2bug.out
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -57,7 +57,11 @@ bye
 # Windows: FIXME PR 587093: string code disabled for now
 # MSVC: mismatches don't end up freeing anything
 ~~Dr.M~~       4 unique,     4 total,    551 byte(s) of leak(s)
-# Linux/MinGW
+# Linux/MinGW.  Total count varies by compiler version.
 ~~Dr.M~~       5 unique,     5 total,    574 byte(s) of leak(s)
+~~Dr.M~~       5 unique,     5 total,    682 byte(s) of leak(s)
 %ENDANYLINE
+%ANYLINE
 ~~Dr.M~~       0 unique,     0 total,      0 byte(s) of possible leak(s)
+~~Dr.M~~       1 unique,     1 total,     40 byte(s) of possible leak(s)
+%ENDANYLINE

--- a/tests/cs2bug.out
+++ b/tests/cs2bug.out
@@ -56,12 +56,12 @@ bye
 %ANYLINE
 # Windows: FIXME PR 587093: string code disabled for now
 # MSVC: mismatches don't end up freeing anything
-~~Dr.M~~       4 unique,     4 total,    551 byte(s) of leak(s)
+~~Dr.M~~       4 unique,     4 total,   %ANY% byte(s) of leak(s)
 # Linux/MinGW.  Total count varies by compiler version.
-~~Dr.M~~       5 unique,     5 total,    574 byte(s) of leak(s)
-~~Dr.M~~       5 unique,     5 total,    682 byte(s) of leak(s)
+~~Dr.M~~       5 unique,     5 total,   %ANY% byte(s) of leak(s)
 %ENDANYLINE
 %ANYLINE
 ~~Dr.M~~       0 unique,     0 total,      0 byte(s) of possible leak(s)
-~~Dr.M~~       1 unique,     1 total,     40 byte(s) of possible leak(s)
+# Recent Linux g++ ends up with a possible.
+~~Dr.M~~       1 unique,     1 total,   %ANY% byte(s) of possible leak(s)
 %ENDANYLINE

--- a/tests/reachable.out
+++ b/tests/reachable.out
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2013 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -47,6 +47,8 @@ bye
 %ANYLINE
 # Linux/MinGW
 ~~Dr.M~~      11 unique,    12 total invalid heap argument(s)
+# MinGW xp64
+~~Dr.M~~      10 unique,    11 total invalid heap argument(s)
 # MSVC
 ~~Dr.M~~       9 unique,    12 total invalid heap argument(s)
 %ENDANYLINE
@@ -54,9 +56,13 @@ bye
 %ANYLINE
 # Windows: FIXME PR 587093: string code disabled for now
 # MSVC: mismatches don't end up freeing anything
-~~Dr.M~~       4 unique,     4 total,    551 byte(s) of leak(s)
-# Linux/MinGW
-~~Dr.M~~       5 unique,     5 total,    574 byte(s) of leak(s)
+~~Dr.M~~       4 unique,     4 total,   %ANY% byte(s) of leak(s)
+# Linux/MinGW.  Total count varies by compiler version.
+~~Dr.M~~       5 unique,     5 total,   %ANY% byte(s) of leak(s)
 %ENDANYLINE
+%ANYLINE
 ~~Dr.M~~       0 unique,     0 total,      0 byte(s) of possible leak(s)
+# Recent Linux g++ ends up with a possible.
+~~Dr.M~~       1 unique,     1 total,   %ANY% byte(s) of possible leak(s)
+%ENDANYLINE
 still-reachable allocation(s)

--- a/tests/reachable.res
+++ b/tests/reachable.res
@@ -49,22 +49,32 @@ cs2bug.cpp:195
 cs2bug.cpp:200
 memory was allocated here:
 cs2bug.cpp:198
+%OPTIONAL # only when wrapping
 : UNINITIALIZED READ
 cs2bug.cpp:116
 cs2bug.cpp:203
+%ENDOPTIONAL
 : INVALID HEAP ARGUMENT: allocated with malloc, freed with operator delete
 cs2bug.cpp:203
 memory was allocated here:
 cs2bug.cpp:201
 %OPTIONAL # VS2008 Win7
 : UNINITIALIZED READ
+cs2bug.cpp:203
 %ENDOPTIONAL
 : UNADDRESSABLE ACCESS
 cs2bug.cpp:206
+%OPTIONAL
+# MinGW xp64 crashes rather than reporting final mismatch
+: UNADDRESSABLE ACCESS
+cs2bug.cpp:206
+%ENDOPTIONAL
+%OPTIONAL
 : INVALID HEAP ARGUMENT: allocated with malloc, freed with operator delete[]
 cs2bug.cpp:206
 memory was allocated here:
 cs2bug.cpp:204
+%ENDOPTIONAL
 %OPTIONAL # Linux
 : INVALID HEAP ARGUMENT to free
 %ENDOPTIONAL
@@ -96,7 +106,8 @@ cs2bug.cpp:86
 # std::string can have different sizes so we're not picky.
 : LEAK
 cs2bug.cpp:172
-%endif
+# Nested %if is only supported with "endif UNIX".
+%endif UNIX
 %OPTIONAL # Linux/VS2005
 %if X32
 : LEAK 88 direct bytes + 168 indirect bytes

--- a/tests/runtest.cmake
+++ b/tests/runtest.cmake
@@ -353,6 +353,10 @@ foreach (str ${patterns})
   # remove comments
   string(REGEX REPLACE "(^|\n)#[^\n]*\n" "\\1" ${str} "${${str}}")
 
+  # Support for ".*" (should we instead switch to full regex support
+  # and make all the files escape their own literals?)
+  string(REGEX REPLACE "%ANY%" ".*" ${str} "${${str}}")
+
   # evaluate conditionals
   # cmake's regex matcher is maximal unfortunately: for now we disallow %
   # inside conditional


### PR DESCRIPTION
cs2bug.cpp has slightly different results due to Travis compiler
upgrades.  We allow more variation in the output to get the cs2bug,
reachable, and malloc_callstacks tests green.