### PR TITLE
i#1019 linux syscalls: Add prlimit64

### DIFF
--- a/drsyscall/linux_defines.h
+++ b/drsyscall/linux_defines.h
@@ -138,6 +138,7 @@
 # define EXT2_IOC_SETVERSION             FS_IOC_SETVERSION
 #endif
 
+#ifndef ANDROID /* Android headers already have this. */
 /* Including linux/resource.h leads to conflicts with other types so we define
  * this struct ourselves:
  */
@@ -145,6 +146,7 @@ struct rlimit64 {
     __u64 rlim_cur;
     __u64 rlim_max;
 };
+#endif
 
 #include <linux/fd.h>
 #include <linux/hdreg.h>

--- a/drsyscall/linux_defines.h
+++ b/drsyscall/linux_defines.h
@@ -138,6 +138,14 @@
 # define EXT2_IOC_SETVERSION             FS_IOC_SETVERSION
 #endif
 
+/* Including linux/resource.h leads to conflicts with other types so we define
+ * this struct ourselves:
+ */
+struct rlimit64 {
+    __u64 rlim_cur;
+    __u64 rlim_max;
+};
+
 #include <linux/fd.h>
 #include <linux/hdreg.h>
 #include <linux/if.h>

--- a/drsyscall/table_linux.c
+++ b/drsyscall/table_linux.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1082,7 +1082,12 @@ syscall_info_t syscall_info[] = {
     {{PACKNUM(299,337,365),0},"recvmmsg", UNKNOWN, RLONG, 0, },
     {{PACKNUM(300,338,367),0},"fanotify_init", UNKNOWN, RLONG, 0, },
     {{PACKNUM(301,339,368),0},"fanotify_mark", UNKNOWN, RLONG, 0, },
-    {{PACKNUM(302,340,369),0},"prlimit64", UNKNOWN, RLONG, 0, },
+    {{PACKNUM(302,340,369),0},"prlimit64", OK, RLONG, 4,
+     {
+      {2, sizeof(struct rlimit64), R},
+      {3, sizeof(struct rlimit64), W},
+     }
+    },
     {{PACKNUM(303,341,370),0},"name_to_handle_at", UNKNOWN, RLONG, 0, },
     {{PACKNUM(304,342,371),0},"open_by_handle_at", UNKNOWN, RLONG, 0, },
     {{PACKNUM(305,343,372),0},"clock_adjtime", UNKNOWN, RLONG, 0, },


### PR DESCRIPTION
Adds SYS_prlimit64 to the Linux table.  This eliminates a false
positive running "ls" on newer distros.

Issue: #1019