### PR TITLE
i#2283: Adds a method for retrieving granularity info about an Umbra Map.

### DIFF
--- a/tests/framework/umbra_client_allscales.c
+++ b/tests/framework/umbra_client_allscales.c
@@ -46,7 +46,7 @@
 
 static void
 test_umbra_mapping(client_id_t id, umbra_map_scale_t scale, const char *label,
-                   const int scale_val, const bool is_scale_down)
+                   int scale_val, bool is_scale_down)
 {
     dr_printf("\n====================\ntesting scale %d == %s\n", scale, label);
     umbra_map_t *umbra_map;

--- a/tests/framework/umbra_client_allscales.c
+++ b/tests/framework/umbra_client_allscales.c
@@ -63,7 +63,7 @@ test_umbra_mapping(client_id_t id, umbra_map_scale_t scale, const char *label,
         CHECK(false, "failed to init umbra");
     if (umbra_create_mapping(&umbra_map_ops, &umbra_map) != DRMF_SUCCESS)
         CHECK(false, "failed to create shadow memory mapping");
-    if (umbra_get_granularity(umbra_map, &scale_val_out,&is_scale_down_out) != DRMF_SUCCESS)
+    if (umbra_get_granularity(umbra_map, &scale_val_out, &is_scale_down_out) != DRMF_SUCCESS)
             CHECK(false, "failed to get granularity info umbra");
     CHECK(scale_val == scale_val_out, "incorrect scale");
     CHECK(is_scale_down == is_scale_down_out, "incorrect scale granularity");

--- a/tests/framework/umbra_client_allscales.c
+++ b/tests/framework/umbra_client_allscales.c
@@ -45,10 +45,13 @@
                 __FILE__, __LINE__, #cond, msg), dr_abort(), 0)))
 
 static void
-test_umbra_mapping(client_id_t id, umbra_map_scale_t scale, const char *label)
+test_umbra_mapping(client_id_t id, umbra_map_scale_t scale, const char *label,
+                   const int scale_val, const bool is_scale_down)
 {
     dr_printf("\n====================\ntesting scale %d == %s\n", scale, label);
     umbra_map_t *umbra_map;
+    int scale_val_out;
+    bool is_scale_down_out;
     umbra_map_options_t umbra_map_ops;
     memset(&umbra_map_ops, 0, sizeof(umbra_map_ops));
     umbra_map_ops.scale = scale;
@@ -60,6 +63,10 @@ test_umbra_mapping(client_id_t id, umbra_map_scale_t scale, const char *label)
         CHECK(false, "failed to init umbra");
     if (umbra_create_mapping(&umbra_map_ops, &umbra_map) != DRMF_SUCCESS)
         CHECK(false, "failed to create shadow memory mapping");
+    if (umbra_get_granularity(umbra_map, &scale_val_out,&is_scale_down_out) != DRMF_SUCCESS)
+            CHECK(false, "failed to get granularity info umbra");
+    CHECK(scale_val == scale_val_out, "incorrect scale");
+    CHECK(is_scale_down == is_scale_down_out, "incorrect scale granularity");
     if (umbra_destroy_mapping(umbra_map) != DRMF_SUCCESS)
         CHECK(false, "failed to destroy shadow memory mapping");
     umbra_exit();
@@ -68,9 +75,9 @@ test_umbra_mapping(client_id_t id, umbra_map_scale_t scale, const char *label)
 DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
 {
-    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_8X, "down 8x");
-    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_4X, "down 4x");
-    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_2X, "down 2x");
-    test_umbra_mapping(id, UMBRA_MAP_SCALE_SAME_1X, "one-to-one");
-    test_umbra_mapping(id, UMBRA_MAP_SCALE_UP_2X, "up 2x");
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_8X, "down 8x", 8, true);
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_4X, "down 4x", 4, true);
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_DOWN_2X, "down 2x", 2, true);
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_SAME_1X, "one-to-one", 1, false);
+    test_umbra_mapping(id, UMBRA_MAP_SCALE_UP_2X, "up 2x", 2, false);
 }

--- a/umbra/umbra.c
+++ b/umbra/umbra.c
@@ -760,33 +760,33 @@ umbra_get_shared_shadow_block(IN  umbra_map_t *map,
 }
 
 DR_EXPORT
-drmf_status_t umbra_get_granularity(const umbra_map_t *map, OUT int *scale,
-                                    OUT bool *is_scale_down) {
+drmf_status_t
+umbra_get_granularity(const umbra_map_t *map, OUT int *scale, OUT bool *is_scale_down)
+{
+    if (map == NULL || scale == NULL || is_scale_down == NULL)
+        return DRMF_ERROR_INVALID_PARAMETER;
 
-  if (map == NULL || scale == NULL || is_scale_down == NULL)
-    return DRMF_ERROR_INVALID_PARAMETER;
+    *is_scale_down = UMBRA_MAP_SCALE_IS_DOWN(map->options.scale);
 
-  *is_scale_down = UMBRA_MAP_SCALE_IS_DOWN(map->options.scale);
+    switch (map->options.scale) {
+    case UMBRA_MAP_SCALE_DOWN_8X:
+        *scale = 8;
+        break;
+    case UMBRA_MAP_SCALE_DOWN_4X:
+        *scale = 4;
+        break;
+    case UMBRA_MAP_SCALE_DOWN_2X:
+        *scale = 2;
+        break;
+    case UMBRA_MAP_SCALE_SAME_1X:
+        *scale = 1;
+        break;
+    case UMBRA_MAP_SCALE_UP_2X:
+        *scale = 2;
+        break;
+    default:
+        return DRMF_ERROR;
+    }
 
-  switch (map->options.scale) {
-  case UMBRA_MAP_SCALE_DOWN_8X:
-    *scale = 8;
-    break;
-  case UMBRA_MAP_SCALE_DOWN_4X:
-    *scale = 4;
-    break;
-  case UMBRA_MAP_SCALE_DOWN_2X:
-    *scale = 2;
-    break;
-  case UMBRA_MAP_SCALE_SAME_1X:
-    *scale = 1;
-    break;
-  case UMBRA_MAP_SCALE_UP_2X:
-    *scale = 2;
-    break;
-  default:
-    return DRMF_ERROR;
-  }
-
-  return DRMF_SUCCESS;
+    return DRMF_SUCCESS;
 }

--- a/umbra/umbra.c
+++ b/umbra/umbra.c
@@ -758,3 +758,35 @@ umbra_get_shared_shadow_block(IN  umbra_map_t *map,
         return DRMF_ERROR_INVALID_PARAMETER;
     return umbra_get_shared_shadow_block_arch(map, value, value_size, block);
 }
+
+DR_EXPORT
+drmf_status_t umbra_get_granularity(const umbra_map_t *map, OUT int *scale,
+                                    OUT bool *is_scale_down) {
+
+  if (map == NULL || scale == NULL || is_scale_down == NULL)
+    return DRMF_ERROR_INVALID_PARAMETER;
+
+  *is_scale_down = UMBRA_MAP_SCALE_IS_DOWN(map->options.scale);
+
+  switch (map->options.scale) {
+  case UMBRA_MAP_SCALE_DOWN_8X:
+    *scale = 8;
+    break;
+  case UMBRA_MAP_SCALE_DOWN_4X:
+    *scale = 4;
+    break;
+  case UMBRA_MAP_SCALE_DOWN_2X:
+    *scale = 2;
+    break;
+  case UMBRA_MAP_SCALE_SAME_1X:
+    *scale = 1;
+    break;
+  case UMBRA_MAP_SCALE_UP_2X:
+    *scale = 2;
+    break;
+  default:
+    return DRMF_ERROR;
+  }
+
+  return DRMF_SUCCESS;
+}

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -734,8 +734,9 @@ DR_EXPORT
  * @param[out] is_scale_down    The pointer where to store the returned flag
  * indicating whether shadow memory is scaled down or up.
  */
-drmf_status_t umbra_get_granularity(const umbra_map_t *map, OUT int *scale,
-                                    bool *is_scale_down);
+drmf_status_t
+umbra_get_granularity(const umbra_map_t *map, OUT int *scale,
+                      bool *is_scale_down);
 
 /*@}*/ /* end doxygen group */
 

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -732,7 +732,8 @@ DR_EXPORT
  * @param[in]  map              The mapping object to use.
  * @param[out] scale            The pointer where to store the returned scale.
  * @param[out] is_scale_down    The pointer where to store the returned flag
- * indicating whether shadow memory is scaled down or up.
+ *                              indicating whether shadow memory is scaled down
+ *                              or up.
  */
 drmf_status_t
 umbra_get_granularity(const umbra_map_t *map, OUT int *scale,

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -727,7 +727,10 @@ umbra_shadow_memory_info_init(umbra_shadow_memory_info_t *info)
 
 DR_EXPORT
 /**
- * Returns granularity information of the passed Umbra map.
+ * A convenience routine that returns granularity information of the passed Umbra map.
+ *
+ * Note that the returned scale is the numerical value representation, and not of
+ * type #umbra_map_scale_t.
  *
  * @param[in]  map              The mapping object to use.
  * @param[out] scale            The pointer where to store the returned scale.

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -725,6 +725,18 @@ umbra_shadow_memory_info_init(umbra_shadow_memory_info_t *info)
     info->app_size = 0;
 }
 
+DR_EXPORT
+/**
+ * Returns granularity information of the passed Umbra map.
+ *
+ * @param[in]  map              The mapping object to use.
+ * @param[out] scale            The pointer where to store the returned scale.
+ * @param[out] is_scale_down    The pointer where to store the returned flag
+ * indicating whether shadow memory is scaled down or up.
+ */
+drmf_status_t umbra_get_granularity(const umbra_map_t *map, OUT int *scale,
+                                    bool *is_scale_down);
+
 /*@}*/ /* end doxygen group */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Adds a new function umbra_get_granularity() which returns information about the granularity of an Umbra Map.

Issue: #2283 