### PR TITLE
i#2283: Adds umbra_clear_redundant_blocks 

### DIFF
--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -727,8 +727,9 @@ umbra_shadow_memory_info_init(umbra_shadow_memory_info_t *info)
 
 DR_EXPORT
 /**
- * Clears and deletes redundant NULL blocks for \p map. This function is typically
- * invoked when low on memory.
+ * Clears and deletes redundant blocks consisting of only default values for \p map.
+ * This function is typically invoked when low on memory. It deletes normal blocks
+ * and sets mapping entries to the special basic block.
  *
  * Assumes that threads are suspended so that Umbra may safely modify shadow memory.
  * It is up to the caller to suspend and resume threads.

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -725,6 +725,17 @@ umbra_shadow_memory_info_init(umbra_shadow_memory_info_t *info)
     info->app_size = 0;
 }
 
+DR_EXPORT
+/**
+ * Clears redundant NULL blocks for \p map.
+ *
+ * Assumes that threads are suspended so that Umbra may safely modify shadow memory.
+ * It is up to the caller to suspend and resume threads.
+ *
+ * This feature is only available on 32-bit.
+ */
+drmf_status_t umbra_clear_redundant_blocks(umbra_map_t *map);
+
 /*@}*/ /* end doxygen group */
 
 #ifdef __cplusplus

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -737,7 +737,8 @@ DR_EXPORT
  * Assumes that threads are suspended so that Umbra may safely modify shadow memory.
  * It is up to the caller to suspend and resume threads.
  *
- * This feature is only available on 32-bit.
+ * This feature is only available on 32-bit and requires that the
+ * create-on-touch optimization (# UMBRA_MAP_CREATE_SHADOW_ON_TOUCH) is enabled.
  */
 drmf_status_t
 umbra_clear_redundant_blocks(umbra_map_t *map, uint *count);

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -727,7 +727,8 @@ umbra_shadow_memory_info_init(umbra_shadow_memory_info_t *info)
 
 DR_EXPORT
 /**
- * Clears redundant NULL blocks for \p map.
+ * Clears and deletes redundant NULL blocks for \p map. This function is typically
+ * invoked when low on memory.
  *
  * Assumes that threads are suspended so that Umbra may safely modify shadow memory.
  * It is up to the caller to suspend and resume threads.

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -738,7 +738,7 @@ DR_EXPORT
  * It is up to the caller to suspend and resume threads.
  *
  * This feature is only available on 32-bit and requires that the
- * create-on-touch optimization (# UMBRA_MAP_CREATE_SHADOW_ON_TOUCH) is enabled.
+ * create-on-touch optimization (#UMBRA_MAP_CREATE_SHADOW_ON_TOUCH) is enabled.
  */
 drmf_status_t
 umbra_clear_redundant_blocks(umbra_map_t *map, uint *count);

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -731,13 +731,16 @@ DR_EXPORT
  * This function is typically invoked when low on memory. It deletes normal blocks
  * and sets mapping entries to the special basic block.
  *
+ * The number of redundant blocks destroyed is returned via \p count. This is an
+ * optional parameter and can be set to NULL if the count is not wanted.
+ *
  * Assumes that threads are suspended so that Umbra may safely modify shadow memory.
  * It is up to the caller to suspend and resume threads.
  *
  * This feature is only available on 32-bit.
  */
 drmf_status_t
-umbra_clear_redundant_blocks(umbra_map_t *map);
+umbra_clear_redundant_blocks(umbra_map_t *map, uint *count);
 
 DR_EXPORT
 /*

--- a/umbra/umbra.h
+++ b/umbra/umbra.h
@@ -735,7 +735,8 @@ DR_EXPORT
  *
  * This feature is only available on 32-bit.
  */
-drmf_status_t umbra_clear_redundant_blocks(umbra_map_t *map);
+drmf_status_t
+umbra_clear_redundant_blocks(umbra_map_t *map);
 
 /*@}*/ /* end doxygen group */
 

--- a/umbra/umbra_32.c
+++ b/umbra/umbra_32.c
@@ -1059,7 +1059,7 @@ umbra_clear_redundant_blocks(umbra_map_t *map)
     if (map == NULL)
         return DRMF_ERROR_INVALID_PARAMETER;
 
-    /* Umbra needs to have create-on-touch optimization enabled */
+    /* Umbra needs to have create-on-touch optimization enabled. */
     if (!TEST(UMBRA_MAP_CREATE_SHADOW_ON_TOUCH, map->options.flags))
         return DRMF_ERROR;
 

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1371,7 +1371,8 @@ umbra_handle_fault(void *drcontext, byte *target, dr_mcontext_t *raw_mc,
 }
 
 drmf_status_t
-umbra_clear_redundant_blocks(umbra_map_t *map) {
+umbra_clear_redundant_blocks(umbra_map_t *map)
+{
     /* No operation needed for x64. */
     return DRMF_ERROR_FEATURE_NOT_AVAILABLE;
 }

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1369,3 +1369,9 @@ umbra_handle_fault(void *drcontext, byte *target, dr_mcontext_t *raw_mc,
     }
     return false;
 }
+
+drmf_status_t
+umbra_clear_redundant_blocks(umbra_map_t *map) {
+    /* No operation needed for x64 */
+    return DRMF_ERROR_FEATURE_NOT_AVAILABLE;
+}

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1372,6 +1372,6 @@ umbra_handle_fault(void *drcontext, byte *target, dr_mcontext_t *raw_mc,
 
 drmf_status_t
 umbra_clear_redundant_blocks(umbra_map_t *map) {
-    /* No operation needed for x64 */
+    /* No operation needed for x64. */
     return DRMF_ERROR_FEATURE_NOT_AVAILABLE;
 }

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1371,7 +1371,7 @@ umbra_handle_fault(void *drcontext, byte *target, dr_mcontext_t *raw_mc,
 }
 
 drmf_status_t
-umbra_clear_redundant_blocks(umbra_map_t *map)
+umbra_clear_redundant_blocks(umbra_map_t *map, uint *count)
 {
     /* No operation needed for x64. */
     return DRMF_ERROR_FEATURE_NOT_AVAILABLE;


### PR DESCRIPTION
Adds a new API function which allows the user to trigger the removal of redundant blocks that consist of only default values.

It is useful when low on memory.

Issue #2283 