### PR TITLE
i#2285: Update DR and drcontainers for compatibility change

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,9 +73,7 @@ install:
   # We first print out all versions to make it easier to update this if
   # the version changes.
   - dir "c:\Program Files (x86)\WiX Toolset"*
-  # DRi#4108: Work around runsuite_common_pre.cmake appending x64 to bin here.
-  - ps: $wixpath=& c:\cygwin64\bin\cygpath -d 'C:\Program Files (x86)\WiX Toolset v3.11\bin'
-  - ps: $env:PATH="$wixpath;$env:PATH"
+  - set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;%PATH%
 
   ##################################################
   # XXX i#2145: point at Qt5 for testing drheapstat visualizer.

--- a/common/alloc.c
+++ b/common/alloc.c
@@ -4336,14 +4336,13 @@ static void
 malloc_wrap_init(void)
 {
     if (alloc_ops.track_allocs) {
-        hashtable_config_t hashconfig = {};
+        hashtable_config_t hashconfig = {sizeof(hashconfig),};
         hashtable_init_ex(&malloc_table, ALLOC_TABLE_HASH_BITS, HASH_INTPTR,
                           false/*!str_dup*/, false/*!synch*/, malloc_entry_free,
                           malloc_hash, NULL);
         /* hash lookup can be a bottleneck so it's worth taking some extra space
          * to reduce the collision chains
          */
-        hashconfig.size = sizeof(hashconfig);
         hashconfig.resizable = true;
         hashconfig.resize_threshold = 50; /* default is 75 */
         hashtable_configure(&malloc_table, &hashconfig);

--- a/common/alloc.c
+++ b/common/alloc.c
@@ -4336,7 +4336,7 @@ static void
 malloc_wrap_init(void)
 {
     if (alloc_ops.track_allocs) {
-        hashtable_config_t hashconfig;
+        hashtable_config_t hashconfig = {};
         hashtable_init_ex(&malloc_table, ALLOC_TABLE_HASH_BITS, HASH_INTPTR,
                           false/*!str_dup*/, false/*!synch*/, malloc_entry_free,
                           malloc_hash, NULL);

--- a/common/callstack.c
+++ b/common/callstack.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -331,7 +331,7 @@ callstack_init(callstack_options_t *options)
     module_tree = rb_tree_create(NULL);
 
     if (!TEST(FP_SEARCH_ALLOW_UNSEEN_RETADDR, ops.fp_flags)) {
-        hashtable_config_t hashconfig;
+        hashtable_config_t hashconfig = {};
         hashtable_init(&retaddr_table, RETADDR_TABLE_HASH_BITS,
                        HASH_INTPTR, false/*!str_dup*/);
         hashconfig.size = sizeof(hashconfig);

--- a/common/callstack.c
+++ b/common/callstack.c
@@ -331,10 +331,9 @@ callstack_init(callstack_options_t *options)
     module_tree = rb_tree_create(NULL);
 
     if (!TEST(FP_SEARCH_ALLOW_UNSEEN_RETADDR, ops.fp_flags)) {
-        hashtable_config_t hashconfig = {};
+        hashtable_config_t hashconfig = {sizeof(hashconfig),};
         hashtable_init(&retaddr_table, RETADDR_TABLE_HASH_BITS,
                        HASH_INTPTR, false/*!str_dup*/);
-        hashconfig.size = sizeof(hashconfig);
         hashconfig.resizable = true;
         hashconfig.resize_threshold = 60; /* default is 75 */
         hashtable_configure(&retaddr_table, &hashconfig);

--- a/tests/runsuite.cmake
+++ b/tests/runsuite.cmake
@@ -267,7 +267,7 @@ foreach (tool ${tools})
           " ON ON "") # no release tests in short suite
       endif ()
     endif ()
-  endif (NOT arg_vmk_only)
+  endif ()
   if (UNIX)
     if (arg_vmk_only OR arg_test_vmk)
       testbuild_ex("${name}-vmk-dbg-32" OFF "


### PR DESCRIPTION
Updates DR to 1d711b47 and addresses a source compatibility change in
hashtable_config_t by setting the structure to zeroes.

Issue: #2285