### PR TITLE
i#2266 memlayout: Add callstack frames to layout dump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1754,11 +1754,12 @@ else ()
       SOURCES ${PROJECT_SOURCE_DIR}/tests/memlayout.cpp
       ${PROJECT_SOURCE_DIR}/drmemory/annotations_public.c CMAKE_FLAGS
       -DINCLUDE_DIRECTORIES=${framework_incdir}
-      -DCMAKE_C_FLAGS:STRING="${annot_cflags}")
+      -DCMAKE_C_FLAGS:STRING="${annot_cflags}"
+      OUTPUT_VARIABLE try_output)
     if (DR_ANNOTATIONS_SUPPORTED)
       message(STATUS "DR annotations are supported")
     else ()
-      message(STATUS "DR annotations are NOT supported: probably this is clang<9.0")
+      message(STATUS "DR annotations are NOT supported: probably this is clang<9.0: |${try_output}|")
     endif ()
   else ()
     set(DR_ANNOTATIONS_SUPPORTED ON)

--- a/common/callstack.c
+++ b/common/callstack.c
@@ -1613,7 +1613,8 @@ find_next_fp(void *drcontext, tls_callstack_t *pt, app_pc fp, app_pc prior_ra,
 void
 print_callstack(char *buf, size_t bufsz, size_t *sofar, dr_mcontext_t *mc,
                 bool print_fps, packed_callstack_t *pcs, int num_frames_printed,
-                bool for_log, uint max_frames)
+                bool for_log, uint max_frames,
+                bool (*frame_cb)(app_pc pc, byte *fp, void *user_data), void *user_data)
 {
     void *drcontext = dr_get_current_drcontext();
     tls_callstack_t *pt = (tls_callstack_t *)
@@ -1768,6 +1769,10 @@ print_callstack(char *buf, size_t bufsz, size_t *sofar, dr_mcontext_t *mc,
                                      !TEST(FP_SHOW_NON_MODULE_FRAMES, ops.fp_flags),
                                      true, pcs->num_frames))) {
             num++;
+            if (frame_cb != NULL) {
+                if (!(*frame_cb)(appdata.retaddr, appdata.next_fp, user_data))
+                    break;
+            }
             if (last_frame)
                 break;
             if (appdata.retaddr == pt->stack_lowest_retaddr &&
@@ -1968,7 +1973,7 @@ print_callstack_to_file(void *drcontext, dr_mcontext_t *mc, app_pc pc, file_t f,
     BUFPRINT(pt->errbuf, pt->errbufsz, sofar, len, "# 0 ");
     print_address(pt->errbuf, pt->errbufsz, &sofar, pc, NULL, true/*for log*/);
     print_callstack(pt->errbuf, pt->errbufsz, &sofar, mc,
-                    true/*incl fp*/, NULL, 1, true, max_frames);
+                    true/*incl fp*/, NULL, 1, true, max_frames, NULL, NULL);
     print_buffer(f == INVALID_FILE ? LOGFILE_GET(drcontext) : f, pt->errbuf);
 }
 #endif /* DEBUG */
@@ -2042,7 +2047,7 @@ packed_callstack_record(packed_callstack_t **pcs_out/*out*/, dr_mcontext_t *mc,
         num_frames_printed = 1;
     }
     print_callstack(NULL, 0, NULL, mc, false, pcs, num_frames_printed, false,
-                    max_frames);
+                    max_frames, NULL, NULL);
     if (pcs->is_packed) {
         packed_frame_t *frames_out;
         sz_out = sizeof(*pcs->frames.packed) * pcs->num_frames;

--- a/common/callstack.h
+++ b/common/callstack.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -458,7 +458,9 @@ print_address(char *buf, size_t bufsz, size_t *sofar,
 void
 print_callstack(char *buf, size_t bufsz, size_t *sofar, dr_mcontext_t *mc,
                 bool print_fps, packed_callstack_t *pcs, int num_frames_printed,
-                bool for_log, uint max_frames);
+                bool for_log, uint max_frames,
+                bool (*frame_cb)(app_pc pc, byte *fp, void *user_data),
+                void *user_data);
 
 void
 print_buffer(file_t f, char *buf);

--- a/drmemory/annotations.c
+++ b/drmemory/annotations.c
@@ -79,7 +79,8 @@ handle_do_leak_check(dr_vg_client_request_t *request)
 void handle_dump_memory_layout(void)
 {
 # ifdef TOOL_DR_MEMORY
-    memlayout_dump_layout();
+    app_pc pc = (app_pc) dr_read_saved_reg(dr_get_current_drcontext(), SPILL_SLOT_2);
+    memlayout_dump_layout(pc);
 # endif
 }
 #endif
@@ -98,13 +99,14 @@ annotate_init(void)
 #endif
 
 #ifndef ARM /* FIXME DRi#1672: add ARM annotation support to DR */
-    /* TODO i#2266: We want to pass the PC to the handler. */
-    if (!dr_annotation_register_call("drmemory_dump_memory_layout",
+    const char *dumpmem_name = "drmemory_dump_memory_layout";
+    if (!dr_annotation_register_call(dumpmem_name,
                                      handle_dump_memory_layout, false, 0,
                                      DR_ANNOTATION_CALL_TYPE_FASTCALL)) {
         NOTIFY_ERROR("ERROR: Failed to register annotations"NL);
         dr_abort();
     }
+    dr_annotation_pass_pc(dumpmem_name);
 #endif
 }
 

--- a/drmemory/memlayout.h
+++ b/drmemory/memlayout.h
@@ -32,6 +32,6 @@ void
 memlayout_handle_alloc(void *drcontext, app_pc base, size_t size);
 
 void
-memlayout_dump_layout(void);
+memlayout_dump_layout(app_pc pc);
 
 #endif /* _MEMLAYOUT_H_ */

--- a/drmemory/report.c
+++ b/drmemory/report.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -3551,7 +3551,7 @@ report_malloc(app_pc start, app_pc end, const char *routine, dr_mcontext_t *mc)
         BUFPRINT(pt->errbuf, pt->errbufsz, sofar, len,
                  "%s "PFX"-"PFX"\n", routine, start, end);
         print_callstack(pt->errbuf, pt->errbufsz, &sofar, mc, false/*no fps*/,
-                        NULL, 0, true, options.callstack_max_frames);
+                        NULL, 0, true, options.callstack_max_frames, NULL, NULL);
         report_error_from_buffer(LOGFILE_GET(drcontext), pt->errbuf, false);
     });
 }
@@ -3579,7 +3579,7 @@ report_heap_region(bool add, app_pc start, app_pc end, dr_mcontext_t *mc)
                  "%s heap region "PFX"-"PFX"\n",
                  add ? "adding" : "removing", start, end);
         print_callstack(buf, bufsz, &sofar, mc, false/*no fps*/, NULL, 0, true,
-                        options.callstack_max_frames);
+                        options.callstack_max_frames, NULL, NULL);
         report_error_from_buffer(f_global, buf, false);
         if (pt == NULL)
             global_free(buf, bufsz, HEAPSTAT_CALLSTACK);
@@ -3626,7 +3626,7 @@ report_child_thread(void *drcontext, thread_id_t child)
             print_timestamp_and_thread(pt->errbuf, pt->errbufsz, &sofar, false);
             BUFPRINT(pt->errbuf, pt->errbufsz, sofar, len, "\n");
             print_callstack(pt->errbuf, pt->errbufsz, &sofar, &mc, false/*no fps*/,
-                            NULL, 0, false, options.callstack_max_frames);
+                            NULL, 0, false, options.callstack_max_frames, NULL, NULL);
             BUFPRINT(pt->errbuf, pt->errbufsz, sofar, len, "\n");
             print_buffer(LOGFILE_GET(drcontext), pt->errbuf);
         } else {

--- a/tests/memlayout.cpp
+++ b/tests/memlayout.cpp
@@ -22,7 +22,16 @@
 #include "drmemory_annotations.h"
 #include <iostream>
 
-int main()
+void
+foo(int x)
+{
+    int *y = new int[2];
+    y[1] = x;
+    DRMEMORY_ANNOTATE_DUMP_MEMORY_LAYOUT();
+}
+
+int
+main()
 {
     int i,**j,k,l,*m;
     i = 0;
@@ -42,7 +51,7 @@ int main()
     char *ch = new char[13];
     ch[4] = 'x';
 
-    DRMEMORY_ANNOTATE_DUMP_MEMORY_LAYOUT();
+    foo(l);
 
     std::cerr << "goodbye\n";
 

--- a/tests/memlayout.out
+++ b/tests/memlayout.out
@@ -27,9 +27,9 @@ goodbye
 ~~Dr.M~~       0 unique,     0 total invalid heap argument(s)
 ~~Dr.M~~       0 unique,     0 total warning(s)
 %if X32
-~~Dr.M~~       2 unique,     2 total,     29 byte(s) of leak(s)
+~~Dr.M~~       3 unique,     3 total,     37 byte(s) of leak(s)
 %endif
 %if X64
-~~Dr.M~~       2 unique,     2 total,     41 byte(s) of leak(s)
+~~Dr.M~~       3 unique,     3 total,     49 byte(s) of leak(s)
 %endif
 ~~Dr.M~~       0 unique,     0 total,      0 byte(s) of possible leak(s)

--- a/tests/memlayout.out
+++ b/tests/memlayout.out
@@ -26,10 +26,5 @@ goodbye
 ~~Dr.M~~       0 unique,     0 total uninitialized access(es)
 ~~Dr.M~~       0 unique,     0 total invalid heap argument(s)
 ~~Dr.M~~       0 unique,     0 total warning(s)
-%if X32
-~~Dr.M~~       3 unique,     3 total,     37 byte(s) of leak(s)
-%endif
-%if X64
-~~Dr.M~~       3 unique,     3 total,     49 byte(s) of leak(s)
-%endif
+~~Dr.M~~   %ANY% unique, %ANY% total, %ANY% byte(s) of leak(s)
 ~~Dr.M~~       0 unique,     0 total,      0 byte(s) of possible leak(s)

--- a/tests/memlayout.res
+++ b/tests/memlayout.res
@@ -27,17 +27,20 @@
         {
           "program_counter": "",
           "frame_pointer": "",
-          "function": "memlayout!drmemory_dump_memory_layout"
+          "function": "%ANY%!drmemory_dump_memory_layout"
         },
         {
           "program_counter": "",
           "frame_pointer": "",
-          "function": "memlayout!foo"
+          "function": "%ANY%!foo"
+# Windows is having callstack troubles.
+%if UNIX
         },
         {
           "program_counter": "",
           "frame_pointer": "",
-          "function": "memlayout!main"
+          "function": "%ANY%!main"
+%endif
         }
       ]
     }

--- a/tests/memlayout.res
+++ b/tests/memlayout.res
@@ -19,6 +19,29 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 {
+  "version": "2",
+  "threads": [
+    {
+      "thread_id": "",
+      "stack_frames": [
+        {
+          "program_counter": "",
+          "frame_pointer": "",
+          "function": "memlayout!drmemory_dump_memory_layout"
+        },
+        {
+          "program_counter": "",
+          "frame_pointer": "",
+          "function": "memlayout!foo"
+        },
+        {
+          "program_counter": "",
+          "frame_pointer": "",
+          "function": "memlayout!main"
+        }
+      ]
+    }
+  ],
   "heap objects": [
     {
       "address": "",


### PR DESCRIPTION
Updates DR to 863a461c for dr_annotation_pass_pc().  Uses it to
acquire the PC for the current thread for the memory layout dump.

Adds callstack frames that overlap with the dumped stack to the layout
dump, with a pc, frame pointer, and function name for each.

Adds a function to tests/memlayout to test an additional frame.

Issue: #2266