### PR TITLE
DRi#4370: CMake 3.19 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1307,7 +1307,7 @@ endmacro()
 
 add_library(${client_target} SHARED ${srcs})
 set_library_version(${client_target} ${TOOL_VERSION_NUMBER})
-set_property(TARGET ${client_target} PROPERTY COMPILE_DEFINITIONS
+_DR_append_property_list(TARGET ${client_target} COMPILE_DEFINITIONS
   # If we end up wanting this for other DEFINES uses above we'll have to set
   # client_target earlier.  For now we only need for the C code.
   "${DEFINES_NO_D};CLIENT_LIBNAME=${client_target};RC_IS_TOOLLIB")
@@ -1325,7 +1325,7 @@ if (WIN32)
   # our addr2line for Windows
   add_executable(winsyms tools/winsyms.c make/resources.rc)
   target_link_libraries(winsyms dbghelp)
-  set_property(TARGET winsyms PROPERTY COMPILE_DEFINITIONS
+  _DR_append_property_list(TARGET winsyms COMPILE_DEFINITIONS
     # We need full defines to get version values for resources
     "${DEFINES_NO_D};RC_IS_WINSYMS")
   # configure_DynamoRIO_client clears global flags so add as additional
@@ -1338,12 +1338,12 @@ if (WIN32)
   # Helper tool to ensure we have version info in our binaries:
   add_executable(verinfo tools/verinfo.c make/resources.rc)
   target_link_libraries(verinfo version)
-  set_property(TARGET verinfo PROPERTY COMPILE_DEFINITIONS
+  _DR_append_property_list(TARGET verinfo COMPILE_DEFINITIONS
     "${DEFINES_NO_D};RC_IS_VERINFO")
 
   # i#1009c#4: auto-register Dr. Memory as a Visual Studio External Tool
   add_executable(vs_external_tool tools/vs_external_tool.c make/resources.rc)
-  set_property(TARGET vs_external_tool PROPERTY COMPILE_DEFINITIONS
+  _DR_append_property_list(TARGET vs_external_tool COMPILE_DEFINITIONS
     "${DEFINES_NO_D};RC_IS_VS_EXTERNAL_TOOL")
 endif (WIN32)
 
@@ -1420,12 +1420,13 @@ if (USE_DRSYMS)
     drsyscall_static)
   if (WIN32)
     set_target_properties(${toolname} PROPERTIES
-      VERSION ${TOOL_VERSION_NUMBER}
+      VERSION ${TOOL_VERSION_NUMBER})
+    _DR_append_property_list(TARGET ${toolname}
       COMPILE_DEFINITIONS "${DEFINES_NO_D};RC_IS_FRONTEND")
   else (WIN32)
     DynamoRIO_add_rel_rpaths(${toolname} drinjectlib)
     DynamoRIO_add_rel_rpaths(${toolname} drconfiglib)
-    set_property(TARGET ${toolname} PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+    _DR_append_property_list(TARGET ${toolname} COMPILE_DEFINITIONS "${DEFINES_NO_D}")
   endif (WIN32)
   if (STATIC_DRSYMS)
     use_DynamoRIO_extension(${client_target} drsyms_static)
@@ -1526,8 +1527,8 @@ set(DynamoRIO_RPATH ${old_rpath})
 # drfrontendlib depends on drinjectlib, DR-i#1409 should be the solution
 target_link_libraries(symquery drinjectlib drfrontendlib)
 if (WIN32)
-  set_target_properties(symquery PROPERTIES VERSION ${TOOL_VERSION_NUMBER}
-    COMPILE_DEFINITIONS
+  set_target_properties(symquery PROPERTIES VERSION ${TOOL_VERSION_NUMBER})
+  _DR_append_property_list(TARGET symquery COMPILE_DEFINITIONS
     # We need full defines to get version values for resources
     "${DEFINES_NO_D};RC_IS_SYMQUERY")
 else (WIN32)
@@ -1970,7 +1971,7 @@ if (BUILD_TOOL_TESTS)
   if (TOOL_DR_MEMORY)
     # unit tests
     add_executable(unit_tests ${srcs})
-    set_property(TARGET unit_tests PROPERTY COMPILE_DEFINITIONS
+    _DR_append_property_list(TARGET unit_tests COMPILE_DEFINITIONS
       "${DEFINES_NO_D};BUILD_UNIT_TESTS;RC_IS_UNITTESTS")
     if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
       # ensure race-free parallel builds

--- a/common/utils.c
+++ b/common/utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -78,7 +78,9 @@ static thread_id_t primary_thread = INVALID_THREAD_ID;
  * UTILITIES
  */
 
-#ifndef MACOS /* Mac has builtin -- though should verify in all builds */
+/* Mac has builtin -- though should verify in all builds. */
+/* AArchXX has memset from DR memfuncs. */
+#if !defined(MACOS) && !defined(AARCHXX)
 /* FIXME: VC8 uses intrinsic memset yet has it call out, so /nodefaultlib
  * gets a link error missing _memset.  This does not help, nor does /Oi:
  *   #pragma intrinsic ( memset)

--- a/drfuzz/CMakeLists.txt
+++ b/drfuzz/CMakeLists.txt
@@ -63,7 +63,7 @@ macro(configure_drfuzz_target target drwrap drmgr)
     # Avoid tolower from the strcasestr in utils_shared.c, which we don't call
     append_property_string(TARGET ${target} COMPILE_FLAGS "-fPIC -DNOLINK_STRCASESTR")
   endif (UNIX)
-  set_property(TARGET ${target} PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+  _DR_append_property_list(TARGET ${target} COMPILE_DEFINITIONS "${DEFINES_NO_D}")
 endmacro(configure_drfuzz_target)
 
 macro(export_drfuzz_target target drwrap drmgr)
@@ -116,7 +116,7 @@ use_DynamoRIO_extension(drfuzz_mutator drmgr_static)
 use_DynamoRIO_extension(drfuzz_mutator drcontainers)
 # Not bothering to remove RC_IS_DRFUZZ: resources.rc has this one first:
 set(DEFINES_NO_D ${DEFINES_NO_D} RC_IS_DRFUZZ_MUTATOR)
-set_property(TARGET drfuzz_mutator PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+_DR_append_property_list(TARGET drfuzz_mutator COMPILE_DEFINITIONS "${DEFINES_NO_D}")
 # We treat as a regular lib for use as a dynamically loaded plugin
 # XXX: better to use export_drfuzz_target()?
 install(TARGETS drfuzz_mutator DESTINATION ${DRMF_INSTALL_BIN})

--- a/drheapstat/visualizer/CMakeLists.txt
+++ b/drheapstat/visualizer/CMakeLists.txt
@@ -24,7 +24,7 @@
 # Configures dhvis build
 #
 
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.7)
 
 if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.11" OR
     "${CMAKE_VERSION}" VERSION_GREATER "2.8.11")

--- a/drltrace/CMakeLists.txt
+++ b/drltrace/CMakeLists.txt
@@ -53,10 +53,10 @@ add_library(drltracelib SHARED ${srcs})
 set_library_version(drltracelib ${DRMF_VERSION_MAJOR_MINOR})
 
 if (WIN32)
-  set_property(TARGET drltracelib PROPERTY COMPILE_DEFINITIONS
+  _DR_append_property_list(TARGET drltracelib COMPILE_DEFINITIONS
     "${DEFINES_NO_D};RC_IS_DRLTRACELIB")
 else ()
-  set_property(TARGET drltracelib PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+  _DR_append_property_list(TARGET drltracelib COMPILE_DEFINITIONS "${DEFINES_NO_D}")
 endif ()
 
 set(DynamoRIO_RPATH ON)
@@ -126,10 +126,10 @@ target_link_libraries(drltrace drinjectlib drconfiglib drfrontendlib drsyscall_s
 set_library_version(drltrace ${DRMF_VERSION})
 
 if (WIN32)
-  set_property(TARGET drltrace PROPERTY COMPILE_DEFINITIONS
-               ${DEFINES_NO_D} RC_IS_DRLTRACE)
+  _DR_append_property_list(TARGET drltrace COMPILE_DEFINITIONS
+    "${DEFINES_NO_D};RC_IS_DRLTRACE")
 else ()
-  set_property(TARGET drltrace PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+   _DR_append_property_list(TARGET drltrace COMPILE_DEFINITIONS "${DEFINES_NO_D}")
 endif ()
 
 # XXX: see DR's i#2429 and comment above.

--- a/drstrace/CMakeLists.txt
+++ b/drstrace/CMakeLists.txt
@@ -18,7 +18,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
 include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 
@@ -45,10 +45,10 @@ add_library(drstracelib SHARED ${srcs})
 set_library_version(drstracelib ${DRMF_VERSION_MAJOR_MINOR})
 
 if (WIN32)
-  set_property(TARGET drstracelib PROPERTY COMPILE_DEFINITIONS
+  _DR_append_property_list(TARGET drstracelib COMPILE_DEFINITIONS
     "${DEFINES_NO_D};RC_IS_DRSTRACELIB")
 else ()
-  set_property(TARGET drstracelib PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+  _DR_append_property_list(TARGET drstracelib COMPILE_DEFINITIONS "${DEFINES_NO_D}")
 endif ()
 
 set_target_properties(drstracelib PROPERTIES
@@ -143,12 +143,12 @@ configure_DynamoRIO_standalone(drstrace)
 target_link_libraries(drstrace drinjectlib drconfiglib drfrontendlib drsyscall_static)
 set_library_version(drstrace ${DRMF_VERSION})
 if (WIN32)
-  set_property(TARGET drstrace PROPERTY COMPILE_DEFINITIONS
-    ${DEFINES_NO_D} RC_IS_DRSTRACE SYMBOL_DLL_NAME="$<TARGET_FILE_NAME:symfetch>")
+  _DR_append_property_list(TARGET drstrace COMPILE_DEFINITIONS
+    "${DEFINES_NO_D};RC_IS_DRSTRACE;SYMBOL_DLL_NAME=\"$<TARGET_FILE_NAME:symfetch>\"")
   # DRi#1409/DRi#1503/i#1805: Avoid dup symbol _isdigit with VS2017.
   append_property_string(TARGET drstrace LINK_FLAGS "/force:multiple")
 else ()
-  set_property(TARGET drstrace PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+  _DR_append_property_list(TARGET drstrace COMPILE_DEFINITIONS "${DEFINES_NO_D}")
 endif ()
 
 install(TARGETS drstrace DESTINATION "${INSTALL_BIN}"

--- a/drsymcache/CMakeLists.txt
+++ b/drsymcache/CMakeLists.txt
@@ -60,7 +60,7 @@ macro(configure_drsymcache_target target drmgr drsyms)
   use_DynamoRIO_extension(${target} drcontainers)
   use_DynamoRIO_extension(${target} ${drmgr})
   use_DynamoRIO_extension(${target} ${drsyms})
-  set_property(TARGET ${target} PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+  _DR_append_property_list(TARGET ${target} COMPILE_DEFINITIONS "${DEFINES_NO_D}")
 endmacro(configure_drsymcache_target)
 
 macro(export_drsymcache_target target drmgr drsyms)

--- a/drsyscall/CMakeLists.txt
+++ b/drsyscall/CMakeLists.txt
@@ -93,7 +93,7 @@ macro(configure_drsyscall_target target)
   # create a final static library, for DR_EXT_DRSYSCALL_STATIC: and that's
   # a pain to export w/ the proper link rules.  But we at least use the
   # same flags and avoid compiling the same file differently.
-  set_property(TARGET ${target} PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+  _DR_append_property_list(TARGET ${target} COMPILE_DEFINITIONS "${DEFINES_NO_D}")
   target_link_libraries(${target} drfrontendlib ${ntimp_lib})
   if (NOT USER_SPECIFIED_DynamoRIO_DIR AND "${CMAKE_GENERATOR}" MATCHES "Visual Studio")
     add_dependencies(${target} ntdll_imports)

--- a/package.cmake
+++ b/package.cmake
@@ -26,7 +26,7 @@
 #
 # Invoke like this: "ctest -S package.cmake,dr=<path-to-DynamoRIO>\;build=<build#>"
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
 # set from an including package script
 if (NOT DEFINED arg_sub_package)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
 include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 
@@ -112,8 +112,8 @@ function(set_props target)
   if (X86)
     set(defs ${defs} X86)
   endif ()
-  set_property(TARGET ${target} PROPERTY COMPILE_DEFINITIONS
-    ${defs} ${DEFINES_NO_D} ${DR_DEFINES_NO_D})
+  _DR_append_property_list(TARGET ${target} COMPILE_DEFINITIONS
+    "${defs};${DEFINES_NO_D};${DR_DEFINES_NO_D}")
   # enough tests need this (malloc, free, registers, cs2bug, float, etc.)
   # that we add to all tests
   if (nounused_avail)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,6 +121,16 @@ function(set_props target)
   endif (nounused_avail)
 endfunction(set_props)
 
+function(append_link_flags target newflags)
+  get_target_property(cur_ldflags ${target} LINK_FLAGS)
+  # cmake should add an APPEND option
+  if (NOT cur_ldflags)
+    set(cur_ldflags "")
+  endif (NOT cur_ldflags)
+  set_target_properties(${target} PROPERTIES
+    LINK_FLAGS "${cur_ldflags} ${newflags}")
+endfunction(append_link_flags)
+
 function(tobuild name source)
   set(srcs ${source} ${ARGN})
 
@@ -136,6 +146,12 @@ function(tobuild name source)
 
   add_executable(${name} ${srcs})
   set_props(${name})
+  if (UNIX)
+    # Older CMake would add this for us, but no longer.  We want global syms
+    # in .dynsym for all our executables, so our tests can use dr_get_proc_address()
+    # to find them.
+    append_link_flags(${name} "-rdynamic")
+  endif ()
 
   if ("${srccode}" MATCHES "ifndef ASM_CODE_ONLY")
     if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
@@ -144,16 +160,6 @@ function(tobuild name source)
   endif ()
   copy_target_to_device(${name})
 endfunction(tobuild)
-
-function(append_link_flags target newflags)
-  get_target_property(cur_ldflags ${target} LINK_FLAGS)
-  # cmake should add an APPEND option
-  if (NOT cur_ldflags)
-    set(cur_ldflags "")
-  endif (NOT cur_ldflags)
-  set_target_properties(${target} PROPERTIES
-    LINK_FLAGS "${cur_ldflags} ${newflags}")
-endfunction(append_link_flags)
 
 function(tobuild_lib name source cust_flags cust_link)
   add_library(${name} SHARED ${source})

--- a/tests/addronly-reg.res
+++ b/tests/addronly-reg.res
@@ -24,13 +24,13 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1398
+registers.c_asm.asm:1418
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1410
+registers.c_asm.asm:1430
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1423
+registers.c_asm.asm:1443
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1424
+registers.c_asm.asm:1444
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/app_suite/CMakeLists.txt
+++ b/tests/app_suite/CMakeLists.txt
@@ -18,7 +18,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
 # tests are always built w/o optimizations and with symbols,
 # regardless of DrMem library settings

--- a/tests/bitfield.strict.res
+++ b/tests/bitfield.strict.res
@@ -24,29 +24,29 @@ Error #2: UNINITIALIZED READ
 bitfield.cpp:54
 %if WINDOWS
 Error #3: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:892
+bitfield.cpp_asm.asm:912
 Error #4: UNINITIALIZED READ: reading register bl
-bitfield.cpp_asm.asm:905
+bitfield.cpp_asm.asm:925
 Error #5: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:913
+bitfield.cpp_asm.asm:933
 Error #6: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:918
-Error #7: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:927
-Error #8: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:930
-Error #9: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:935
-Error #10: UNINITIALIZED READ: reading register ecx
 bitfield.cpp_asm.asm:938
+Error #7: UNINITIALIZED READ: reading register ch
+bitfield.cpp_asm.asm:947
+Error #8: UNINITIALIZED READ: reading register cl
+bitfield.cpp_asm.asm:950
+Error #9: UNINITIALIZED READ: reading register ch
+bitfield.cpp_asm.asm:955
+Error #10: UNINITIALIZED READ: reading register ecx
+bitfield.cpp_asm.asm:958
 Error #11: UNINITIALIZED READ: reading register dl
-bitfield.cpp_asm.asm:962
+bitfield.cpp_asm.asm:982
 Error #12: UNINITIALIZED READ: reading register esi
-bitfield.cpp_asm.asm:963
+bitfield.cpp_asm.asm:983
 Error #13: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:977
+bitfield.cpp_asm.asm:997
 Error #14: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:988
+bitfield.cpp_asm.asm:1008
 %endif
 %if UNIX
 Error #3: UNINITIALIZED READ: reading register ecx

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -20,7 +20,7 @@
 
 # XXX i#1652: make this a separate project and use --build-and-test
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
 include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 
@@ -59,7 +59,7 @@ endfunction(add_drmf_test_app)
 function(add_drmf_test test_name app_name src_client ext_list client_options pass_regex)
   set(client_name ${test_name}.client)
   add_library(${client_name} SHARED ${src_client})
-  set_property(TARGET ${client_name} PROPERTY COMPILE_DEFINITIONS ${arch_defs})
+  _DR_append_property_list(TARGET ${client_name} COMPILE_DEFINITIONS "${arch_defs}")
   # We rely on i#955's "rpath file" to locate the extension on Windows
   set(DynamoRIO_RPATH ON)
   configure_DynamoRIO_client(${client_name})

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -18,7 +18,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
 include(${PROJECT_SOURCE_DIR}/make/policies.cmake NO_POLICY_SCOPE)
 

--- a/tests/nightly.cmake
+++ b/tests/nightly.cmake
@@ -50,7 +50,7 @@
 # DAMAGE.
 
 # We need 2.8.2 for ctest_update() to update git submodules
-cmake_minimum_required (VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.7)
 
 # Instructions to set up a machine to run nightly regression tests:
 #

--- a/tests/registers.blacklist.res
+++ b/tests/registers.blacklist.res
@@ -21,13 +21,13 @@
 #
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1398
+registers.c_asm.asm:1418
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1410
+registers.c_asm.asm:1430
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1423
+registers.c_asm.asm:1443
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1424
+registers.c_asm.asm:1444
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)

--- a/tests/registers.pattern.res
+++ b/tests/registers.pattern.res
@@ -24,9 +24,9 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1398
+registers.c_asm.asm:1418
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1410
+registers.c_asm.asm:1430
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -21,39 +21,39 @@
 #
 %if WINDOWS
 Error #1: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1371
+registers.c_asm.asm:1391
 Error #2: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1378
+registers.c_asm.asm:1398
 Error #3: UNINITIALIZED READ: reading 2 byte(s)
 registers.c:104
 Error #4: UNINITIALIZED READ: reading register ax
-registers.c_asm.asm:1598
+registers.c_asm.asm:1618
 Error #5: UNINITIALIZED READ: reading register dx
-registers.c_asm.asm:1615
+registers.c_asm.asm:1635
 Error #6: UNINITIALIZED READ: reading register ah
-registers.c_asm.asm:1645
+registers.c_asm.asm:1665
 Error #7: UNINITIALIZED READ: reading 1 byte(s)
 registers.c:187
 Error #8: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1347
+registers.c_asm.asm:1367
 Error #9: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1172
+registers.c_asm.asm:1192
 Error #10: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1176
+registers.c_asm.asm:1196
 Error #11: UNINITIALIZED READ: reading register cl
-registers.c_asm.asm:1181
-Error #12: UNINITIALIZED READ: reading register xcx
 registers.c_asm.asm:1201
+Error #12: UNINITIALIZED READ: reading register xcx
+registers.c_asm.asm:1221
 Error #13: UNINITIALIZED READ: reading 8 byte(s)
-registers.c_asm.asm:1232
+registers.c_asm.asm:1252
 Error #14: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1398
+registers.c_asm.asm:1418
 Error #15: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1410
+registers.c_asm.asm:1430
 Error #16: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1423
+registers.c_asm.asm:1443
 Error #17: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1424
+registers.c_asm.asm:1444
 %endif
 %if UNIX
 Error #1: UNINITIALIZED READ: reading register eflags
@@ -99,7 +99,7 @@ registers.c_asm.asm:970
 %endif
 %if WINDOWS
 Error #19: UNINITIALIZED READ: reading register ecx
-registers.c_asm.asm:1740
+registers.c_asm.asm:1760
 %endif
 Error #20: UNINITIALIZED READ: reading register
 registers.c:267
@@ -107,15 +107,15 @@ Error #21: UNINITIALIZED READ: reading register
 registers.c:288
 %if WINDOWS
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1825
+registers.c_asm.asm:1845
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1839
+registers.c_asm.asm:1859
 Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1853
+registers.c_asm.asm:1873
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1867
+registers.c_asm.asm:1887
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1902
+registers.c_asm.asm:1922
 %endif
 %if UNIX
 Error #22: UNINITIALIZED READ: reading 1 byte(s)

--- a/tests/runsuite.cmake
+++ b/tests/runsuite.cmake
@@ -19,7 +19,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 
 # The pre-commit suite is a short suite.
 # Automated testing machines should pass the "long" parameter to enable

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -190,6 +190,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                 'cs2bugMTdZI' => 1,
                 'cs2bugMD' => 1,
                 'cs2bugMDd' => 1,
+                'redzone16' => 1,
                 'gdi' => 1,
                 'syscalls_win' => 1,
                 'handle_only' => 1,
@@ -217,7 +218,6 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'app_suite.pattern' => 1,
                                    'app_suite' => 1);
             %ignore_failures_64 = ('pcache' => 1, # i#2243
-                                   'redzone16' => 1,
                                    'app_suite.pattern' => 1);
         }
         # Read ahead to examine the test failures:

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -164,6 +164,10 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'winthreads' => 1,
                                    'malloc_callstacks' => 1,
                                    'wrap_wincrt' => 1, # i#1741: flaky.
+                                   'wrap_malloc' => 1,
+                                   'wrap_operators' => 1,
+                                   'wrap_wincrtdbg' => 1,
+                                   'wrap_cs2bugMTd' => 1,
                                    'app_suite.pattern' => 1,
                                    'app_suite' => 1);
             # FIXME i#2180: ignoring certain AppVeyor x64-full-mode failures until
@@ -213,6 +217,7 @@ for (my $i = 0; $i < $#lines; ++$i) {
                                    'app_suite.pattern' => 1,
                                    'app_suite' => 1);
             %ignore_failures_64 = ('pcache' => 1, # i#2243
+                                   'redzone16' => 1,
                                    'app_suite.pattern' => 1);
         }
         # Read ahead to examine the test failures:

--- a/umbra/CMakeLists.txt
+++ b/umbra/CMakeLists.txt
@@ -60,7 +60,7 @@ macro(configure_umbra_target target)
   # create a final static library, for DR_EXT_UMBRA_STATIC: and that's
   # a pain to export w/ the proper link rules.  But we at least use the
   # same flags and avoid compiling the same file differently.
-  set_property(TARGET ${target} PROPERTY COMPILE_DEFINITIONS ${DEFINES_NO_D})
+  _DR_append_property_list(TARGET ${target} COMPILE_DEFINITIONS "${DEFINES_NO_D}")
   target_link_libraries(${target} ${ntimp_lib})
 endmacro(configure_umbra_target)
 


### PR DESCRIPTION
Updates DR to 24ba9f3 to pull in CMake 3.19 support which is required
after Github Actions upgrades.

Updates CMake code:
1) Raises the minimum version to 3.7 everywhere to avoid warnings.
2) Changes all absolute setting of COMPILE_DEFINITIONS to instead append,
   since DR now puts its defines in that property.