### PR TITLE
i#2333: False positives in RtlCaptureContext

### DIFF
--- a/drmemory/suppress-default.win.txt
+++ b/drmemory/suppress-default.win.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -1079,3 +1079,12 @@ UNINITIALIZED READ
 name=default i#2237 __strncnt
 *!__strncnt
 *!__acrt*
+
+##################################################
+# i#2333: RtlCaptureContext
+# This needs more analysis but we are suppressing for
+# now as this is not in user app code.
+
+UNINITIALIZED READ
+name=default i#2333 RtlCaptureContext
+ntdll.dll!RtlCaptureContext


### PR DESCRIPTION
Adds RtlCaptureContext to the default Windows suppressions.  Errors
assumed to be false positives are showing up on Server 2016 and this
will help get our tests green.  We should investigate and improve our
CONTEXT handling to avoid needing this for a beter long-term solution.

Issue: #2333