### PR TITLE
i#2323 GA CI: Change trigger to support forked repos

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -22,7 +22,13 @@
 
 name: ci-aarchxx
 on:
+  # Run on pushes to master and on pull request changes, including from a
+  # forked repo with no "push" trigger, while avoiding duplicate triggers.
   push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-clang.yml
+++ b/.github/workflows/ci-clang.yml
@@ -22,7 +22,13 @@
 
 name: ci-clang
 on:
+  # Run on pushes to master and on pull request changes, including from a
+  # forked repo with no "push" trigger, while avoiding duplicate triggers.
   push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -22,7 +22,13 @@
 
 name: ci-osx
 on:
+  # Run on pushes to master and on pull request changes, including from a
+  # forked repo with no "push" trigger, while avoiding duplicate triggers.
   push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -22,7 +22,13 @@
 
 name: ci-x86
 on:
+  # Run on pushes to master and on pull request changes, including from a
+  # forked repo with no "push" trigger, while avoiding duplicate triggers.
   push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
 
   # Manual trigger using the Actions page. May remove when integration complete.
   workflow_dispatch:


### PR DESCRIPTION
Updates the Github Actions CI trigger to limit pushes to master and
add pull request open, reopen, and synchronize events.  This supports
PR's from forked repositories without adding duplicate triggers.

Issue: #2323