### PR TITLE
i#2323 GA CI: Add auto-cancellation of prior PR jobs

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -47,6 +47,12 @@ jobs:
       with:
         submodules: true
 
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 
@@ -71,6 +77,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
 
     - run: git fetch --no-tags --depth=1 origin master
 

--- a/.github/workflows/ci-clang.yml
+++ b/.github/workflows/ci-clang.yml
@@ -47,6 +47,12 @@ jobs:
       with:
         submodules: true
 
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -47,6 +47,12 @@ jobs:
       with:
         submodules: true
 
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -47,6 +47,12 @@ jobs:
       with:
         submodules: true
 
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 
@@ -82,6 +88,12 @@ jobs:
       with:
         submodules: true
 
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 
@@ -116,6 +128,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
 
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -47,6 +47,12 @@ jobs:
       with:
         submodules: true
 
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
     # We also need origin/master for pre-commit source file checks in runsuite.cmake.
     # But fetching multiple branches isn't supported yet: actions/checkout#214
     # Pending PR that adds this support actions/checkout#155


### PR DESCRIPTION
Follows the lead of DynamoRIO/dynamorio#4585 and adds
auto-cancellation of a prior running job on a PR CI trigger.  Pushes
to master are never canceled.

Issue: #2323, DynamoRIO/dynamorio#4585