### PR TITLE
i#2323 GA CI: Add release package building and uploading

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -23,6 +23,7 @@
 name: ci-package
 on:
   # Our weekly cronbuild: 9pm on Fridays.
+  # Presumably this is only triggered by this .yml file on the master branch.
   schedule:
     - cron: '0 21 * * FRI'
   # Manual trigger using the Actions page.
@@ -31,7 +32,8 @@ on:
       version:
         description: 'Package version number'
         required: true
-        default: '0.0.0'
+        # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+        default: '2.3.99999'
       build:
         description: 'Package build number'
         required: true
@@ -42,6 +44,7 @@ defaults:
     shell: bash
 
 jobs:
+  ###########################################################################
   # Linux tarball with 64-bit and 32-bit builds:
   x86:
     runs-on: ubuntu-16.04
@@ -60,25 +63,26 @@ jobs:
 
     - name: Get Version
       id: version
-      # XXX: for now we duplicate this version number here with CMakeLists.txt.
+      # XXX: For now we duplicate this version number here with CMakeLists.txt.
       # We should find a way to share (xref DRi#1565).
-      # We support setting the version for manual builds to override all
-      # parts of the version.  If a build is included (leading dash and number
-      # at the end), it will be parsed and passed to package.cmake.  We only
-      # use a non-zero build number when making multiple manual builds in one day.
+      # We support setting the version and build for manual builds.
+      # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
           export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export GIT_TAG="cronbuild-2.3.${VERSON_NUMBER}"
+          export BUILD_NUMBER=0
+          export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
+          export BUILD_NUMBER=${{ github.event.inputs.build }}
           if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
-            export GIT_TAG="release_${VERSON_NUMBER}"
+            export GIT_TAG="release_${VERSION_NUMBER}"
           else
-            export GIT_TAG="release_${VERSON_NUMBER}-${{ github.event.inputs.build }}"
+            export GIT_TAG="release_${VERSION_NUMBER}-${BUILD_NUMBER}"
           fi
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
+        echo "::set-output name=build_number::${BUILD_NUMBER}"
         echo "::set-output name=version_string::${GIT_TAG}"
 
     - name: Build Package
@@ -87,6 +91,7 @@ jobs:
       env:
         CI_TARGET: package
         VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+        BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
 
     - name: Create Release
       id: create_release
@@ -109,5 +114,172 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         # This action doesn't seem to support a glob so we need the exact name.
         asset_path: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: drmemory.tar.gz
+        asset_name: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
         asset_content_type: application/x-gzip
+
+  ###########################################################################
+  # Mac tarball with x86-64 build:
+  osx-x86-64:
+    runs-on: macos-10.15
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Fetch Sources
+      run: git fetch --no-tags --depth=1 origin master
+
+    - name: Create Build Environment
+      run: brew install nasm
+
+    - name: Get Version
+      id: version
+      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+      run: |
+        if test -z "${{ github.event.inputs.version }}"; then
+          export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export BUILD_NUMBER=0
+          export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
+        else
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+          export BUILD_NUMBER=${{ github.event.inputs.build }}
+          if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
+            export GIT_TAG="release_${VERSION_NUMBER}"
+          else
+            export GIT_TAG="release_${VERSION_NUMBER}-${BUILD_NUMBER}"
+          fi
+        fi
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+        echo "::set-output name=build_number::${BUILD_NUMBER}"
+        echo "::set-output name=version_string::${GIT_TAG}"
+
+    - name: Build Package
+      working-directory: ${{ github.workspace }}
+      run: ./tests/runsuite_wrapper.pl travis
+      env:
+        CI_TARGET: package
+        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+        BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+        # See ci-osx.yml comments: we need to set the xcode version.
+        DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.version.outputs.version_string }}
+        release_name: ${{ steps.version.outputs.version_string }}
+        body: |
+          Auto-generated periodic build.
+        draft: false
+        prerelease: false
+
+    - name: Upload Package
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_name: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_content_type: application/x-gzip
+
+  ###########################################################################
+  # Windows .zip and .msi with 32-bit and 64-bit x86 builds:
+  windows:
+    runs-on: windows-2016
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Fetch Sources
+      run: git fetch --no-tags --depth=1 origin master
+
+    - name: Download Packages
+      shell: powershell
+      run: |
+        md c:\projects\install
+        (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip", "c:\projects\install\ninja.zip")
+        (New-Object System.Net.WebClient).DownloadFile("http://doxygen.nl/files/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
+
+    - name: Get Version
+      id: version
+      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+      run: |
+        if test -z "${{ github.event.inputs.version }}"; then
+          export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export BUILD_NUMBER=0
+          export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
+        else
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+          export BUILD_NUMBER=${{ github.event.inputs.build }}
+          if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
+            export GIT_TAG="release_${VERSION_NUMBER}"
+          else
+            export GIT_TAG="release_${VERSION_NUMBER}-${BUILD_NUMBER}"
+          fi
+        fi
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+        echo "::set-output name=build_number::${BUILD_NUMBER}"
+        echo "::set-output name=version_string::${GIT_TAG}"
+
+    - name: Build Package
+      working-directory: ${{ github.workspace }}
+      run: |
+        echo ------ Setting up paths ------
+        7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
+        set PATH=c:\projects\install\ninja;%PATH%
+        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
+        set PATH=c:\projects\install\doxygen;%PATH%
+        dir "c:\Program Files (x86)\WiX Toolset"*
+        set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;%PATH%
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        echo ------ Running suite ------
+        echo PATH is "%PATH%"
+        echo Running in directory "%CD%"
+        perl tests/runsuite_wrapper.pl travis use_ninja
+      env:
+        CI_TARGET: package
+        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+        BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.version.outputs.version_string }}
+        release_name: ${{ steps.version.outputs.version_string }}
+        body: |
+          Auto-generated periodic build.
+        draft: false
+        prerelease: false
+
+    - name: Upload Zip
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DrMemory-Windows-${{ steps.version.outputs.version_number }}.zip
+        asset_name: DrMemory-Windows-${{ steps.version.outputs.version_number }}.zip
+        asset_content_type: application/zip
+
+    - name: Upload Msi
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DrMemory-Windows-${{ steps.version.outputs.version_number }}.msi
+        asset_name: DrMemory-Windows-${{ steps.version.outputs.version_number }}.msi
+        asset_content_type: application/octet-stream

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -32,6 +32,10 @@ on:
         description: 'Package version number'
         required: true
         default: '0.0.0'
+      build:
+        description: 'Package build number'
+        required: true
+        default: '0'
 
 defaults:
   run:
@@ -55,12 +59,6 @@ jobs:
     - name: Create Build Environment
       run: sudo apt-get -y install doxygen jsonlint g++-multilib
 
-    - name: Build Package
-      working-directory: ${{ github.workspace }}
-      run: ./tests/runsuite_wrapper.pl travis
-      env:
-        TRAVIS_EVENT_TYPE: cron
-
     - name: Get Version
       id: version
       # XXX: for now we duplicate this version number here with CMakeLists.txt.
@@ -71,11 +69,25 @@ jobs:
       # use a non-zero build number when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export GIT_TAG="cronbuild-2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export GIT_TAG="cronbuild-2.3.${VERSON_NUMBER}"
         else
-          export GIT_TAG="release_${{ github.event.inputs.version }}"
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+          if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
+            export GIT_TAG="release_${VERSON_NUMBER}"
+          else
+            export GIT_TAG="release_${VERSON_NUMBER}-${{ github.event.inputs.build }}"
+          fi
         fi
-        echo "::set-output name=version::${GIT_TAG}"
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+        echo "::set-output name=version_string::${GIT_TAG}"
+
+    - name: Build Package
+      working-directory: ${{ github.workspace }}
+      run: ./tests/runsuite_wrapper.pl travis
+      env:
+        CI_TARGET: package
+        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
 
     - name: Create Release
       id: create_release
@@ -83,8 +95,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.version.outputs.version }}
-        release_name: ${{ steps.version.outputs.version }}
+        tag_name: ${{ steps.version.outputs.version_string }}
+        release_name: ${{ steps.version.outputs.version_string }}
         body: |
           Auto-generated periodic build.
         draft: false
@@ -96,6 +108,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: DrMemory*.tar.gz
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
         asset_name: drmemory.tar.gz
         asset_content_type: application/x-gzip

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -70,19 +70,16 @@ jobs:
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
           export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export BUILD_NUMBER=0
           export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
         else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-          export BUILD_NUMBER=${{ github.event.inputs.build }}
           if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
-            export GIT_TAG="release_${VERSION_NUMBER}"
+            export VERSION_NUMBER=${{ github.event.inputs.version }}
           else
-            export GIT_TAG="release_${VERSION_NUMBER}-${BUILD_NUMBER}"
+            export VERSION_NUMBER=${{ github.event.inputs.version }}-${{ github.event.inputs.build }}
           fi
+          export GIT_TAG="release_${VERSION_NUMBER}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=build_number::${BUILD_NUMBER}"
         echo "::set-output name=version_string::${GIT_TAG}"
 
     - name: Build Package
@@ -91,35 +88,16 @@ jobs:
       env:
         CI_TARGET: package
         VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-        BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
       with:
-        tag_name: ${{ steps.version.outputs.version_string }}
-        release_name: ${{ steps.version.outputs.version_string }}
-        body: |
-          Auto-generated periodic build.
-        draft: false
-        prerelease: false
-
-    - name: Upload Package
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_content_type: application/x-gzip
+        name: linux-tarball
+        path: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
 
   ###########################################################################
   # Mac tarball with x86-64 build:
-  osx-x86-64:
+  osx:
     runs-on: macos-10.15
 
     steps:
@@ -139,19 +117,16 @@ jobs:
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
           export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export BUILD_NUMBER=0
           export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
         else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-          export BUILD_NUMBER=${{ github.event.inputs.build }}
           if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
-            export GIT_TAG="release_${VERSION_NUMBER}"
+            export VERSION_NUMBER=${{ github.event.inputs.version }}
           else
-            export GIT_TAG="release_${VERSION_NUMBER}-${BUILD_NUMBER}"
+            export VERSION_NUMBER=${{ github.event.inputs.version }}-${{ github.event.inputs.build }}
           fi
+          export GIT_TAG="release_${VERSION_NUMBER}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=build_number::${BUILD_NUMBER}"
         echo "::set-output name=version_string::${GIT_TAG}"
 
     - name: Build Package
@@ -160,33 +135,14 @@ jobs:
       env:
         CI_TARGET: package
         VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-        BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
         # See ci-osx.yml comments: we need to set the xcode version.
         DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
       with:
-        tag_name: ${{ steps.version.outputs.version_string }}
-        release_name: ${{ steps.version.outputs.version_string }}
-        body: |
-          Auto-generated periodic build.
-        draft: false
-        prerelease: false
-
-    - name: Upload Package
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_content_type: application/x-gzip
+        name: mac-tarball
+        path: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
 
   ###########################################################################
   # Windows .zip and .msi with 32-bit and 64-bit x86 builds:
@@ -214,23 +170,21 @@ jobs:
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
           export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export BUILD_NUMBER=0
           export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
         else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-          export BUILD_NUMBER=${{ github.event.inputs.build }}
           if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
-            export GIT_TAG="release_${VERSION_NUMBER}"
+            export VERSION_NUMBER=${{ github.event.inputs.version }}
           else
-            export GIT_TAG="release_${VERSION_NUMBER}-${BUILD_NUMBER}"
+            export VERSION_NUMBER=${{ github.event.inputs.version }}-${{ github.event.inputs.build }}
           fi
+          export GIT_TAG="release_${VERSION_NUMBER}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=build_number::${BUILD_NUMBER}"
         echo "::set-output name=version_string::${GIT_TAG}"
 
     - name: Build Package
       working-directory: ${{ github.workspace }}
+      shell: cmd
       run: |
         echo ------ Setting up paths ------
         7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
@@ -247,7 +201,49 @@ jobs:
       env:
         CI_TARGET: package
         VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-        BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+
+    - name: Upload Zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows-zip
+        path: DrMemory-Windows-${{ steps.version.outputs.version_number }}.zip
+
+    - name: Upload Msi
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows-msi
+        path: DrMemory-Windows-${{ steps.version.outputs.version_number }}.msi
+
+  ###########################################################################
+  # Create release and populate with files.
+  # We can't have each OS job create the release because only the first
+  # succeeds and the others fail: there is no check in the create-release
+  # action to use an existing release if it already exists.
+  # Thus, our strategy is to share files from the build jobs with this
+  # single relese job via artifacts.
+
+  create_release:
+    needs: [x86, osx, windows]
+    runs-on: ubuntu-16.04
+
+    steps:
+    - name: Get Version
+      id: version
+      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
+      run: |
+        if test -z "${{ github.event.inputs.version }}"; then
+          export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
+        else
+          if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
+            export VERSION_NUMBER=${{ github.event.inputs.version }}
+          else
+            export VERSION_NUMBER=${{ github.event.inputs.version }}-${{ github.event.inputs.build }}
+          fi
+          export GIT_TAG="release_${VERSION_NUMBER}"
+        fi
+        echo "::set-output name=version_number::${VERSION_NUMBER}"
+        echo "::set-output name=version_string::${GIT_TAG}"
 
     - name: Create Release
       id: create_release
@@ -262,6 +258,40 @@ jobs:
         draft: false
         prerelease: false
 
+    - name: Download Linux
+      uses: actions/download-artifact@v2
+      with:
+        name: linux-tarball
+    - name: Upload Linux
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_name: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_content_type: application/x-gzip
+
+    - name: Download Mac
+      uses: actions/download-artifact@v2
+      with:
+        name: mac-tarball
+    - name: Upload Mac
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        # This action doesn't seem to support a glob so we need the exact name.
+        asset_path: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_name: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_content_type: application/x-gzip
+
+    - name: Download Zip
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-zip
     - name: Upload Zip
       uses: actions/upload-release-asset@v1
       env:
@@ -273,6 +303,10 @@ jobs:
         asset_name: DrMemory-Windows-${{ steps.version.outputs.version_number }}.zip
         asset_content_type: application/zip
 
+    - name: Download Msi
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-msi
     - name: Upload Msi
       uses: actions/upload-release-asset@v1
       env:

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -49,7 +49,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: 'master'
         submodules: true
 
     - name: Fetch Sources

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -96,6 +96,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: $(echo DrMemory*.tar.gz)
+        asset_path: DrMemory*.tar.gz
         asset_name: drmemory.tar.gz
         asset_content_type: application/x-gzip

--- a/tests/runsuite.cmake
+++ b/tests/runsuite.cmake
@@ -141,8 +141,7 @@ if (arg_travis)
     set(run_tests OFF)
     message("Detected a Travis clang suite: disabling running of tests")
   endif ()
-  if ("$ENV{TRAVIS_EVENT_TYPE}" STREQUAL "cron" OR
-      "$ENV{APPVEYOR_REPO_TAG}" STREQUAL "true")
+  if ("$ENV{CI_TARGET}" STREQUAL "package")
     # We don't want flaky tests to derail package deployment.  We've already run
     # the tests for this same commit via regular master-push triggers: these
     # package builds are coming from a cron trigger (Travis) or a tag addition

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -96,7 +96,7 @@ if ($child) {
 } elsif ($ENV{'CI_TARGET'} eq 'package') {
     # A package build.
     my $build = "0";
-    if ($ENV{'VERSION_NUMBER'} =~ /-(\d+)$/) {
+    if ($ENV{'BUILD_NUMBER'} =~ /(\d+)/) {
         $build = $1;
     }
     if ($args eq '') {

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -93,15 +93,9 @@ if ($child) {
         }
     }
     close(CHILD);
-} elsif ($ENV{'TRAVIS_EVENT_TYPE'} eq 'cron' ||
-         $ENV{'APPVEYOR_REPO_TAG'} eq 'true') {
+} elsif ($ENV{'CI_TARGET'} eq 'package') {
     # A package build.
     my $build = "0";
-    # We trigger by setting VERSION_NUMBER in Travis.
-    # That sets a tag and we propagate the name into the Appveyor build from the tag:
-    if ($ENV{'APPVEYOR_REPO_TAG_NAME'} =~ /release_(.*)/) {
-        $ENV{'VERSION_NUMBER'} = $1;
-    }
     if ($ENV{'VERSION_NUMBER'} =~ /-(\d+)$/) {
         $build = $1;
     }

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -96,7 +96,7 @@ if ($child) {
 } elsif ($ENV{'CI_TARGET'} eq 'package') {
     # A package build.
     my $build = "0";
-    if ($ENV{'BUILD_NUMBER'} =~ /(\d+)/) {
+    if ($ENV{'VERSION_NUMBER'} =~ /-(\d+)$/) {
         $build = $1;
     }
     if ($args eq '') {


### PR DESCRIPTION
Finishes the release package setup started in PR #2348.
Uses 3 parallel jobs to build 4 packages: Linux, Mac, and Windows zip+msi.
Each job uploads its binaries as an artifact, allowing sharing between jobs (having each
build job racily create and upload to a release failed: there is no check for an existing release).
Then a separate job waits for the 3 jobs to finish, creates a release (which includes adding
a tag), downloads the 4 artifacts, and uploads them to the release.

Tested via manual trigger which resulted in a successful tag and release: https://github.com/DynamoRIO/drmemory/releases/tag/release_2.3.18609-6

Issue: #2323