### PR TITLE
i#2323 GA CI: Deploy docs when posting a new release

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -95,6 +95,16 @@ jobs:
         name: linux-tarball
         path: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
 
+    - name: Deploy Docs
+      uses: JamesIves/github-pages-deploy-action@3.7.1
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        FOLDER: html
+        REPOSITORY_NAME: DynamoRIO/drmemory_docs
+        BRANCH: master
+        # Automatically remove deleted files from the deploy branch.
+        CLEAN: true
+
   ###########################################################################
   # Mac tarball with x86-64 build:
   osx:

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -103,6 +103,7 @@ jobs:
         repo: DynamoRIO/drmemory_docs
         target_branch: master
       env:
+        # We need a personal access token for write access to another repo.
         GH_PAT: ${{ secrets.DOCS_TOKEN }}
 
   ###########################################################################

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Deploy Docs
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ACCESS_TOKEN: ${{ secrets.DOCS_TOKEN }}
         FOLDER: html
         REPOSITORY_NAME: DynamoRIO/drmemory_docs
         BRANCH: master

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -88,6 +88,7 @@ jobs:
       env:
         CI_TARGET: package
         VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
+        DEPLOY_DOCS: yes
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -97,14 +97,13 @@ jobs:
         path: DrMemory-Linux-${{ steps.version.outputs.version_number }}.tar.gz
 
     - name: Deploy Docs
-      uses: JamesIves/github-pages-deploy-action@3.7.1
+      uses: crazy-max/ghaction-github-pages@v2
       with:
-        ACCESS_TOKEN: ${{ secrets.DOCS_TOKEN }}
-        FOLDER: html
-        REPOSITORY_NAME: DynamoRIO/drmemory_docs
-        BRANCH: master
-        # Automatically remove deleted files from the deploy branch.
-        CLEAN: true
+        build_dir: html
+        repo: DynamoRIO/drmemory_docs
+        target_branch: master
+      env:
+        GH_PAT: ${{ secrets.DOCS_TOKEN }}
 
   ###########################################################################
   # Mac tarball with x86-64 build:


### PR DESCRIPTION
Adds a step to the Linux package job to deploy the html documentation
to our Github Pages docs site.

Fixes: #2323
