### PR TITLE
i#2323 GA CI: Fix cronbuild version errors

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -22,10 +22,10 @@
 
 name: ci-package
 on:
-  # Our weekly cronbuild: 8:30pm EST on Fridays.
+  # Our weekly cronbuild: 9pm EST on Fridays.
   # Presumably this is only triggered by this .yml file on the master branch.
   schedule:
-    - cron: '30 1 * * SAT'
+    - cron: '0 2 * * SAT'
   # Manual trigger using the Actions page.
   workflow_dispatch:
     inputs:
@@ -69,17 +69,16 @@ jobs:
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
           export VERSION_NUMBER="2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
-          export GIT_TAG="cronbuild-${VERSION_NUMBER}"
+          export PREFIX="cronbuild-"
         else
-          if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
             export VERSION_NUMBER=${{ github.event.inputs.version }}
-          else
-            export VERSION_NUMBER=${{ github.event.inputs.version }}-${{ github.event.inputs.build }}
-          fi
-          export GIT_TAG="release_${VERSION_NUMBER}"
+            export PREFIX="release_"
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+            export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=version_string::${GIT_TAG}"
+        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
 
     - name: Build Package
       working-directory: ${{ github.workspace }}
@@ -129,17 +128,16 @@ jobs:
           export PATCHLEVEL=$((`git log -n 1 --format=%ct` / (60*60*24)))
           export PATCHLEVEL=$(((PATCHLEVEL %200) + 56))
           export VERSION_NUMBER="2.3.${PATCHLEVEL}"
-          export GIT_TAG="cronbuild-${VERSION_NUMBER}"
+          export PREFIX="cronbuild-"
         else
-          if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
             export VERSION_NUMBER=${{ github.event.inputs.version }}
-          else
-            export VERSION_NUMBER=${{ github.event.inputs.version }}-${{ github.event.inputs.build }}
-          fi
-          export GIT_TAG="release_${VERSION_NUMBER}"
+            export PREFIX="release_"
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+            export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=version_string::${GIT_TAG}"
+        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
 
     - name: Build Package
       working-directory: ${{ github.workspace }}
@@ -182,17 +180,16 @@ jobs:
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
           export VERSION_NUMBER="2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
-          export GIT_TAG="cronbuild-${VERSION_NUMBER}"
+          export PREFIX="cronbuild-"
         else
-          if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
             export VERSION_NUMBER=${{ github.event.inputs.version }}
-          else
-            export VERSION_NUMBER=${{ github.event.inputs.version }}-${{ github.event.inputs.build }}
-          fi
-          export GIT_TAG="release_${VERSION_NUMBER}"
+            export PREFIX="release_"
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+            export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=version_string::${GIT_TAG}"
+        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
 
     - name: Build Package
       working-directory: ${{ github.workspace }}
@@ -245,21 +242,20 @@ jobs:
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
           export VERSION_NUMBER="2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
-          export GIT_TAG="cronbuild-${VERSION_NUMBER}"
           export OSX_PATCHLEVEL=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export OSX_PATCHLEVEL=$(((OSX_PATCHLEVEL %200) + 56))
+          export OSX_PATCHLEVEL=$(((PATCHLEVEL %200) + 56))
           export OSX_VERSION_NUMBER="2.3.${OSX_PATCHLEVEL}"
+          export PREFIX="cronbuild-"
         else
-          if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
             export VERSION_NUMBER=${{ github.event.inputs.version }}
-          else
-            export VERSION_NUMBER=${{ github.event.inputs.version }}-${{ github.event.inputs.build }}
-          fi
-          export GIT_TAG="release_${VERSION_NUMBER}"
+            export PREFIX="release_"
+        fi
+        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
+            export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
         echo "::set-output name=osx_version_number::${OSX_VERSION_NUMBER}"
-        echo "::set-output name=version_string::${GIT_TAG}"
+        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
 
     - name: Create Release
       id: create_release

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -69,8 +69,8 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
+          export VERSION_NUMBER="2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export GIT_TAG="cronbuild-${VERSION_NUMBER}"
         else
           if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
             export VERSION_NUMBER=${{ github.event.inputs.version }}
@@ -127,8 +127,10 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
+          export PATCHLEVEL=$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export PATCHLEVEL=$(((PATCHLEVEL %200) + 56))
+          export VERSION_NUMBER="2.3.${PATCHLEVEL}"
+          export GIT_TAG="cronbuild-${VERSION_NUMBER}"
         else
           if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
             export VERSION_NUMBER=${{ github.event.inputs.version }}
@@ -180,8 +182,8 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
+          export VERSION_NUMBER="2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export GIT_TAG="cronbuild-${VERSION_NUMBER}"
         else
           if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
             export VERSION_NUMBER=${{ github.event.inputs.version }}
@@ -243,8 +245,11 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export GIT_TAG="cronbuild-2.3.${VERSION_NUMBER}"
+          export VERSION_NUMBER="2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export GIT_TAG="cronbuild-${VERSION_NUMBER}"
+          export OSX_PATCHLEVEL=$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export OSX_PATCHLEVEL=$(((OSX_PATCHLEVEL %200) + 56))
+          export OSX_VERSION_NUMBER="2.3.${OSX_PATCHLEVEL}"
         else
           if [ "${{ github.event.inputs.build }}" -eq 0 ]; then
             export VERSION_NUMBER=${{ github.event.inputs.version }}
@@ -254,6 +259,7 @@ jobs:
           export GIT_TAG="release_${VERSION_NUMBER}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
+        echo "::set-output name=osx_version_number::${OSX_VERSION_NUMBER}"
         echo "::set-output name=version_string::${GIT_TAG}"
 
     - name: Create Release
@@ -295,8 +301,8 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: DrMemory-MacOS-${{ steps.version.outputs.version_number }}.tar.gz
+        asset_path: DrMemory-MacOS-${{ steps.version.outputs.osx_version_number }}.tar.gz
+        asset_name: DrMemory-MacOS-${{ steps.version.outputs.osx_version_number }}.tar.gz
         asset_content_type: application/x-gzip
 
     - name: Download Zip

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -22,18 +22,17 @@
 
 name: ci-package
 on:
-  # Our weekly cronbuild: 9pm on Fridays.
+  # Our weekly cronbuild: 8:30pm EST on Fridays.
   # Presumably this is only triggered by this .yml file on the master branch.
   schedule:
-    - cron: '0 21 * * FRI'
+    - cron: '30 1 * * SAT'
   # Manual trigger using the Actions page.
   workflow_dispatch:
     inputs:
       version:
-        description: 'Package version number'
-        required: true
-        # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-        default: '2.3.99999'
+        description: 'Package version number (blank for cronbuild)'
+        required: false
+        default: ''
       build:
         description: 'Package build number'
         required: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,10 +225,11 @@ if (APPLE)
   # clang linker disallows any but major # being >= 256 (1024 for x64) so we do
   # mod 200 (we assume we'll never confuse versions 200 apart) and add 56 (to
   # distinguish from real releases).
+  # If we change this we need to also update .github/workflows/ci-package.yml.
   math(EXPR VERSION_NUMBER_PATCHLEVEL "(${VERSION_NUMBER_PATCHLEVEL} % 200) + 56")
 endif (APPLE)
 
-# N.B.: when updating this, update the git tag in .travis.yml.
+# N.B.: When updating this, update all instances in .github/workflows/ci-package.yml.
 # We should find a way to share (xref DRi#1565).
 set(VERSION_NUMBER_DEFAULT "2.3.${VERSION_NUMBER_PATCHLEVEL}")
 # Do not store the default TOOL_VERSION_NUMBER in the cache to prevent a stale one


### PR DESCRIPTION
Fixes two problems with cronbuild versions:
+ The version was missing the major and minor: that was on the tag only.
+ The OSX version needs an additional computation to satisfy clang linker
  restrictions.
    
Issue: #2323
