### PR TITLE
i#2323: Fix cronbuild tag computation

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -233,6 +233,11 @@ jobs:
     runs-on: ubuntu-16.04
 
     steps:
+      # We need a checkout to run git log for the version.
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
     - name: Get Version
       id: version
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
@@ -250,10 +255,9 @@ jobs:
         if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
           export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
-        export TAG_NAME="${PREFIX}${VERSION_NUMBER}"
         echo "::set-output name=version_number::${VERSION_NUMBER}"
         echo "::set-output name=osx_version_number::${OSX_VERSION_NUMBER}"
-        echo "::set-output name=version_string::${TAG_NAME}"
+        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
 
     - name: Create Release
       id: create_release

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -245,7 +245,7 @@ jobs:
         if test -z "${{ github.event.inputs.version }}"; then
           export VERSION_NUMBER="2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
           export OSX_PATCHLEVEL=$((`git log -n 1 --format=%ct` / (60*60*24)))
-          export OSX_PATCHLEVEL=$(((PATCHLEVEL %200) + 56))
+          export OSX_PATCHLEVEL=$(((OSX_PATCHLEVEL % 200) + 56))
           export OSX_VERSION_NUMBER="2.3.${OSX_PATCHLEVEL}"
           export PREFIX="cronbuild-"
         else

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -71,14 +71,13 @@ jobs:
           export VERSION_NUMBER="2.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
           export PREFIX="cronbuild-"
         else
-            export VERSION_NUMBER=${{ github.event.inputs.version }}
-            export PREFIX="release_"
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+          export PREFIX="release_"
         fi
         if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-            export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
 
     - name: Build Package
       working-directory: ${{ github.workspace }}
@@ -130,14 +129,13 @@ jobs:
           export VERSION_NUMBER="2.3.${PATCHLEVEL}"
           export PREFIX="cronbuild-"
         else
-            export VERSION_NUMBER=${{ github.event.inputs.version }}
-            export PREFIX="release_"
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+          export PREFIX="release_"
         fi
         if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-            export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
 
     - name: Build Package
       working-directory: ${{ github.workspace }}
@@ -189,7 +187,6 @@ jobs:
             export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
         echo "::set-output name=version_number::${VERSION_NUMBER}"
-        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
 
     - name: Build Package
       working-directory: ${{ github.workspace }}
@@ -247,15 +244,16 @@ jobs:
           export OSX_VERSION_NUMBER="2.3.${OSX_PATCHLEVEL}"
           export PREFIX="cronbuild-"
         else
-            export VERSION_NUMBER=${{ github.event.inputs.version }}
-            export PREFIX="release_"
+          export VERSION_NUMBER=${{ github.event.inputs.version }}
+          export PREFIX="release_"
         fi
         if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-            export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
+          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
         fi
+        export TAG_NAME="${PREFIX}${VERSION_NUMBER}"
         echo "::set-output name=version_number::${VERSION_NUMBER}"
         echo "::set-output name=osx_version_number::${OSX_VERSION_NUMBER}"
-        echo "::set-output name=version_string::${PREFIX}${VERSION_NUMBER}"
+        echo "::set-output name=version_string::${TAG_NAME}"
 
     - name: Create Release
       id: create_release

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -23,7 +23,6 @@
 name: ci-package
 on:
   # Our weekly cronbuild: 9pm EST on Fridays.
-  # Presumably this is only triggered by this .yml file on the master branch.
   schedule:
     - cron: '0 2 * * SAT'
   # Manual trigger using the Actions page.


### PR DESCRIPTION
Adds a source checkout to the release job, needed to run "git log"
to compute the version.

Issue: #2323
