### PR TITLE
i#2317: Fix shadow_check_range() crash

### DIFF
--- a/drmemory/annotations.c
+++ b/drmemory/annotations.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -69,6 +69,21 @@ handle_make_mem_defined_if_addressable(dr_vg_client_request_t *request)
 }
 
 static ptr_uint_t
+handle_make_unaddressable(void *start, size_t len)
+{
+# ifdef TOOL_DR_MEMORY
+    LOG(2, "%s: "PFX"-"PFX"\n", __FUNCTION__, start, start + len);
+
+    /* No-op if we're not tracking addressability. */
+    if (!options.shadowing)
+        return 1;
+
+    shadow_set_range(start, start+len, SHADOW_UNADDRESSABLE);
+# endif
+    return 1;
+}
+
+static ptr_uint_t
 handle_do_leak_check(dr_vg_client_request_t *request)
 {
     LOG(2, "%s\n", __FUNCTION__);
@@ -107,6 +122,14 @@ annotate_init(void)
         dr_abort();
     }
     dr_annotation_pass_pc(dumpmem_name);
+
+    const char *make_unaddr_name = "drmemory_make_unaddressable";
+    if (!dr_annotation_register_call(make_unaddr_name,
+                                     handle_make_unaddressable, false, 2,
+                                     DR_ANNOTATION_CALL_TYPE_FASTCALL)) {
+        NOTIFY_ERROR("ERROR: Failed to register annotations"NL);
+        dr_abort();
+    }
 #endif
 }
 

--- a/drmemory/annotations.c
+++ b/drmemory/annotations.c
@@ -72,13 +72,13 @@ static ptr_uint_t
 handle_make_unaddressable(void *start, size_t len)
 {
 # ifdef TOOL_DR_MEMORY
-    LOG(2, "%s: "PFX"-"PFX"\n", __FUNCTION__, start, start + len);
+    LOG(2, "%s: "PFX"-"PFX"\n", __FUNCTION__, start, (byte*)start + len);
 
     /* No-op if we're not tracking addressability. */
     if (!options.shadowing)
         return 1;
 
-    shadow_set_range(start, start+len, SHADOW_UNADDRESSABLE);
+    shadow_set_range(start, (byte*)start+len, SHADOW_UNADDRESSABLE);
 # endif
     return 1;
 }

--- a/drmemory/annotations_public.c
+++ b/drmemory/annotations_public.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -22,3 +22,5 @@
 #include "dr_annotations.h"
 
 DR_DEFINE_ANNOTATION(void, drmemory_dump_memory_layout, (void),)
+
+DR_DEFINE_ANNOTATION(void, drmemory_make_unaddressable, (void *start, size_t len),)

--- a/drmemory/annotations_public.h
+++ b/drmemory/annotations_public.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -31,12 +31,15 @@
 
 #define DRMEMORY_ANNOTATE_DUMP_MEMORY_LAYOUT() \
     DR_ANNOTATION(drmemory_dump_memory_layout)
+#define DRMEMORY_ANNOTATE_MAKE_UNADDRESSABLE(start, len)    \
+    DR_ANNOTATION(drmemory_make_unaddressable, start, len)
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 DR_DECLARE_ANNOTATION(void, drmemory_dump_memory_layout, (void));
+DR_DECLARE_ANNOTATION(void, drmemory_make_unaddressable, (void *start, size_t len));
 
 #ifdef __cplusplus
 }

--- a/drmemory/shadow.c
+++ b/drmemory/shadow.c
@@ -119,14 +119,6 @@ bitmapx2_ushort(bitmap_t bm, uint i)
 }
 #endif
 
-/* returns the uint corresponding to offset i */
-static inline uint
-bitmapx2_dword(bitmap_t bm, uint i)
-{
-    ASSERT(BITMAPx2_SHIFT(i) == 0, "bitmapx2_dword: index not aligned");
-    return bm[BITMAPx2_IDX(i)];
-}
-
 /***************************************************************************
  * BYTE-TO-BYTE SHADOWING SUPPORT
  */

--- a/drmemory/shadow.c
+++ b/drmemory/shadow.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -811,7 +811,7 @@ shadow_check_range(app_pc start, size_t size, uint expect,
         } else if (SHADOW_IS_SHARED_ONLY(info.shadow_type)) {
             incr = info.app_base + info.app_size - pc;
         } else {
-            val = bitmapx2_dword((bitmap_t)info.shadow_base, pc-info.app_base);
+            val = shadow_get_byte(&info, pc);
             val = dqword_to_val(val);
             if (val == UINT_MAX) {
                 /* mixed: have to drop to per-byte */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -507,6 +507,10 @@ newtest_ex(operators operators.cpp "" "${operators_drm_ops}" "${operators_dr_ops
   "ANY")
 newtest(float float.c)
 newtest(selfmod selfmod.c)
+if (UNIX)
+  newtest(mmap mmap.c)
+  target_link_libraries(mmap drmemory_annotations)
+endif ()
 newtest(patterns patterns.c)
 newtest_ex(state state.c "" "" "" OFF "" "ANY")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -507,7 +507,7 @@ newtest_ex(operators operators.cpp "" "${operators_drm_ops}" "${operators_dr_ops
   "ANY")
 newtest(float float.c)
 newtest(selfmod selfmod.c)
-if (UNIX)
+if (LINUX)
   newtest(mmap mmap.c)
   target_link_libraries(mmap drmemory_annotations)
 endif ()

--- a/tests/mmap.c
+++ b/tests/mmap.c
@@ -1,0 +1,58 @@
+/* **********************************************************
+ * Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/* Dr. Memory: the memory debugger
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License, and no later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Library General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "drmemory_annotations.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#ifdef UNIX
+# include <sys/mman.h>
+# include <stdint.h>
+# include <malloc.h>
+#else
+# include <windows.h>
+#endif
+
+#define ALIGN_FORWARD(x, alignment) \
+    ((((uintptr_t)x) + ((alignment)-1)) & (~((uintptr_t)(alignment)-1)))
+
+int
+main()
+{
+    /* To reproduce i#2317, we need a large heap alloc that will use an mmap.
+     * We then use annotations to mark it unaddr, and then touch the top.
+     */
+    static const int malloc_size = 1*1024*1024;
+    void *ptr1 = NULL;
+    int res = posix_memalign(&ptr1, 256*1024, malloc_size);
+    assert(res == 0 && ptr1 != NULL);
+    void *ptr2 = NULL;
+    res = posix_memalign(&ptr2, 256*1024, malloc_size);
+    assert(res == 0 && ptr2 != NULL);
+    DRMEMORY_ANNOTATE_MAKE_UNADDRESSABLE(ptr2, malloc_size);
+    char *end = (char*) ALIGN_FORWARD((char*)ptr2 + malloc_size, 256*1024);
+    *(end - 1) = 1;
+    free(ptr1);
+    free(ptr2);
+    printf("all done\n");
+    return 0;
+}

--- a/tests/mmap.out
+++ b/tests/mmap.out
@@ -1,0 +1,28 @@
+# **********************************************************
+# Copyright (c) 2021 Google, Inc.  All rights reserved.
+# **********************************************************
+#
+# Dr. Memory: the memory debugger
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation;
+# version 2.1 of the License, and no later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+all done
+~~Dr.M~~ ERRORS FOUND:
+~~Dr.M~~       1 unique,     1 total unaddressable access(es)
+~~Dr.M~~       0 unique,     0 total uninitialized access(es)
+~~Dr.M~~       0 unique,     0 total invalid heap argument(s)
+~~Dr.M~~       0 unique,     0 total warning(s)
+~~Dr.M~~       0 unique,     0 total,      0 byte(s) of leak(s)
+~~Dr.M~~       0 unique,     0 total,      0 byte(s) of possible leak(s)

--- a/tests/mmap.res
+++ b/tests/mmap.res
@@ -1,0 +1,22 @@
+# **********************************************************
+# Copyright (c) 2021 Google, Inc.  All rights reserved.
+# **********************************************************
+#
+# Dr. Memory: the memory debugger
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation;
+# version 2.1 of the License, and no later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+Error #1: UNADDRESSABLE ACCESS beyond heap bounds: writing 1 byte(s)
+mmap.c:53


### PR DESCRIPTION
Fixes a bug where shadow_check_range() bypasses the shadow layer that
handles lazily-allocated shadow mappings and thus can crash.

Adds a test that reproduces the bug.

Adds a new DRMEMORY_ANNOTATE_MAKE_UNADDRESSABLE annotation to make it
easier to write the test.

Updates the allocator to use uint instead of ushort for its header's
request_diff field, as ushort is too small for a large allocation like
the one used in the test.  Since that affects the layout, goes ahead
and updates the prev_size_shr field to uint as well.

Fixes #2317