### PR TITLE
i#2183: Fix 8-byte load2x assert

### DIFF
--- a/drmemory/fastpath_x86.c
+++ b/drmemory/fastpath_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -630,7 +630,7 @@ instr_ok_for_instrument_fastpath(instr_t *inst, fastpath_info_t *mi, bb_info_t *
             mi->check_definedness = true;
         } else {
             mi->src[1].app = instr_get_src(inst, 1);
-            if (!memop_ok_for_fastpath(mi->src[1].app, true))
+            if (!memop_ok_for_fastpath(mi->src[1].app, false/*no 8-byte*//*XXX i#111*/))
                 return false;
             mi->load2x = true;
         }

--- a/tests/asmtest_x86.c
+++ b/tests/asmtest_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -464,6 +464,8 @@ GLOBAL_LABEL(FUNCNAME:)
         END_PROLOG
         mov      eax, 0
         movdqu   XMMWORD [8 + REG_XSP + REG_XAX], xmm0
+        push     PTRSZ [REG_XSP]
+        pop      REG_XAX
         ret
         END_FUNC(FUNCNAME)
 #undef FUNCNAME

--- a/tests/asmtest_x86.c
+++ b/tests/asmtest_x86.c
@@ -464,8 +464,28 @@ GLOBAL_LABEL(FUNCNAME:)
         END_PROLOG
         mov      eax, 0
         movdqu   XMMWORD [8 + REG_XSP + REG_XAX], xmm0
-        push     PTRSZ [REG_XSP]
-        pop      REG_XAX
+        ret
+        END_FUNC(FUNCNAME)
+#undef FUNCNAME
+
+
+#define FUNCNAME asm_test_load2x
+/* Tests i#2118 reachability. */
+/* void asm_test_reach(); */
+        DECLARE_FUNC_SEH(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        END_PROLOG
+        mov      REG_XDI, REG_XSP
+        add      REG_XSI, 10*ARG_SZ
+        mov      REG_XSI, REG_XSP
+        add      REG_XSI, 12*ARG_SZ
+#ifdef X64
+        cmpsq
+        scasq
+#else
+        cmpsd
+        scasd
+#endif
         ret
         END_FUNC(FUNCNAME)
 #undef FUNCNAME


### PR DESCRIPTION
Pulls scasq and cmpsq off the fast path to avoid an assert for load2x
with the 2nd operand 8 bytes.  Adding the fastpath support we'd like
long-term is under the general #111.

Adds test cases to asmtest, which reproduce the assert.

Fixes #2183
