### PR TITLE
i#2361: Add NtContinue uninit to default suppressions

### DIFF
--- a/drmemory/suppress-default.win.txt
+++ b/drmemory/suppress-default.win.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 #
@@ -1116,3 +1116,11 @@ LEAK
 name=default i#2340 VS2017 CRT leak
 ...
 *!_register_onexit_function
+
+##################################################
+# i#2361: NtContinue uninit
+
+UNINITIALIZED READ
+name=default i#2361 NtContinue
+system call NtContinue parameter value #0
+ntdll.dll!LdrInitializeThunk


### PR DESCRIPTION
Further analysis may show a programmatic solution, but for now we
auto-suppress to avoid tests failing on GA CI.

Issue: #2361