### PR TITLE
i#2370: Increase -callstack_max_scan from 2048 to 4096

### DIFF
--- a/common/callstack.c
+++ b/common/callstack.c
@@ -637,8 +637,8 @@ dump_app_stack(void *drcontext, tls_callstack_t *pt, dr_mcontext_t *mc, size_t a
                app_pc pc)
 {
     byte *xsp = (byte *) MC_SP_REG(mc);
-    LOG(1, "callstack stack pc="PFX" xsp="PFX" xbp="PFX":\n", pc, MC_SP_REG(mc),
-        MC_FP_REG(mc));
+    LOG(1, "callstack stack pc="PFX" xsp="PFX" xbp="PFX" low="PFX":\n", pc, MC_SP_REG(mc),
+        MC_FP_REG(mc), pt->stack_lowest_frame);
     DR_TRY_EXCEPT(dr_get_current_drcontext(), {
         while (xsp < (byte *)MC_SP_REG(mc) + amount && xsp < pt->stack_lowest_frame) {
             void *val = *(void **)xsp;
@@ -1440,6 +1440,7 @@ find_next_fp(void *drcontext, tls_callstack_t *pt, app_pc fp, app_pc prior_ra,
         /* Scan one page worth and look for potential fp,retaddr pair */
         STATS_INC(find_next_fp_scans);
         /* We only look at fp if TEST(FP_SEARCH_REQUIRE_FP, ops.fp_flags) */
+        LOG(4, "find_next_fp: scanning %p-%p\n", tos, stop);
         for (sp = tos; sp < stop; sp+=sizeof(app_pc)) {
             match = false;
             match_next_frame = false;
@@ -1586,6 +1587,7 @@ find_next_fp(void *drcontext, tls_callstack_t *pt, app_pc fp, app_pc prior_ra,
                 match = false;
             }
         }
+        LOG(4, "find_next_fp: returning NULL b/c didn't find fp,ra pair\n");
     } else
         LOG(4, "find_next_fp: returning NULL b/c couldn't read stack page\n");
     return NULL;

--- a/drmemory/optionsx.h
+++ b/drmemory/optionsx.h
@@ -296,7 +296,7 @@ OPTION_CLIENT_BOOL(client, callstack_conservative, false,
 /* by default scan forward a fraction of a page: good compromise bet perf (scanning
  * can be the bottleneck) and good callstacks
  */
-OPTION_CLIENT(client, callstack_max_scan, uint, 2048, 0, 16384,
+OPTION_CLIENT(client, callstack_max_scan, uint, 4096, 0, 16384,
               "How far to scan to locate the first or next stack frame",
               "How far to scan to locate the first stack frame when starting in a frameless function, or to locate the next stack frame when crossing loader or glue stub thunks or a signal or exception frame.  Increasing this can produce better callstacks but may incur noticeable overhead for applications that make many allocation calls.")
 OPTION_CLIENT_STRING(client, callstack_bad_fp_list, IF_WINDOWS_ELSE("", "libstdc++*"),


### PR DESCRIPTION
Increases -callstack_max_scan from 2048 to 4096 to lower the
probability of not finding a frame, particularly with
-no_callstack_use_top_fp.  We need to scan 2408 bytes on my Linux
machine to find the ld-linux.so frame for the #1711 known-leak
suppression.

Fixes #2370