### PR TITLE
i#2375: Fix faulty redzone test

### DIFF
--- a/tests/framework/umbra_client_faulty_redzone.c
+++ b/tests/framework/umbra_client_faulty_redzone.c
@@ -148,6 +148,7 @@ instrument_mem(void *drcontext, instrlist_t *ilist, instr_t *where,
         }
     }
 
+    // Found no memory operand to instrument.
     return false;
 }
 
@@ -216,8 +217,15 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *ilist, instr_t *w
                                                  opnd_create_instr(label));
     instrlist_meta_preinsert(ilist, where, jmp_instr);
 
+    /* We need to calculate addresses. Restore scratch registers
+     * back to their original values.
+     */
     drreg_status_t status =
     drreg_get_app_value(drcontext, ilist, where, scratch_reg, scratch_reg);
+    DR_ASSERT_MSG(status == DRREG_SUCCESS, "failed to restore scratch reg");
+
+    status =
+    drreg_get_app_value(drcontext, ilist, where, scratch_reg2, scratch_reg2);
     DR_ASSERT_MSG(status == DRREG_SUCCESS, "failed to restore scratch reg");
 
     instrument_mem(drcontext, ilist, where, scratch_reg, scratch_reg2);

--- a/tests/framework/umbra_client_faulty_redzone.c
+++ b/tests/framework/umbra_client_faulty_redzone.c
@@ -228,7 +228,8 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *ilist, instr_t *w
     drreg_get_app_value(drcontext, ilist, where, scratch_reg2, scratch_reg2);
     DR_ASSERT_MSG(status == DRREG_SUCCESS, "failed to restore scratch reg");
 
-    instrument_mem(drcontext, ilist, where, scratch_reg, scratch_reg2);
+    bool ok = instrument_mem(drcontext, ilist, where, scratch_reg, scratch_reg2);
+    DR_ASSERT_MSG(ok, "failed to instrument a memory operand");
 
     instrlist_meta_preinsert(ilist, where, label);
 
@@ -246,7 +247,7 @@ exit_event(void)
     if (umbra_destroy_mapping(umbra_map) != DRMF_SUCCESS)
         DR_ASSERT(false);
 
-    DR_ASSERT_MSG(*did_redzone_fault, "No redzone faults have been handled");
+    DR_ASSERT_MSG(*did_redzone_fault, "no redzone faults have been handled");
 
     dr_global_free(did_redzone_fault, sizeof(bool));
 


### PR DESCRIPTION
Fixes a bug in the test for faulty red zones. The bug led the test to potentially calculate app addresses with scratch registers not containing their original values.

Issue: #2375