### PR TITLE
Fix drwrap crash by updating DR

### DIFF
--- a/tests/addronly-reg.res
+++ b/tests/addronly-reg.res
@@ -24,13 +24,13 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1418
+registers.c_asm.asm:1422
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1430
+registers.c_asm.asm:1434
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1443
+registers.c_asm.asm:1447
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1444
+registers.c_asm.asm:1448
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/bitfield.strict.res
+++ b/tests/bitfield.strict.res
@@ -24,29 +24,29 @@ Error #2: UNINITIALIZED READ
 bitfield.cpp:54
 %if WINDOWS
 Error #3: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:912
+bitfield.cpp_asm.asm:916
 Error #4: UNINITIALIZED READ: reading register bl
-bitfield.cpp_asm.asm:925
+bitfield.cpp_asm.asm:929
 Error #5: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:933
+bitfield.cpp_asm.asm:937
 Error #6: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:938
+bitfield.cpp_asm.asm:942
 Error #7: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:947
+bitfield.cpp_asm.asm:951
 Error #8: UNINITIALIZED READ: reading register cl
-bitfield.cpp_asm.asm:950
+bitfield.cpp_asm.asm:954
 Error #9: UNINITIALIZED READ: reading register ch
-bitfield.cpp_asm.asm:955
+bitfield.cpp_asm.asm:959
 Error #10: UNINITIALIZED READ: reading register ecx
-bitfield.cpp_asm.asm:958
+bitfield.cpp_asm.asm:962
 Error #11: UNINITIALIZED READ: reading register dl
-bitfield.cpp_asm.asm:982
+bitfield.cpp_asm.asm:986
 Error #12: UNINITIALIZED READ: reading register esi
-bitfield.cpp_asm.asm:983
+bitfield.cpp_asm.asm:987
 Error #13: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:997
+bitfield.cpp_asm.asm:1001
 Error #14: UNINITIALIZED READ: reading 1 byte
-bitfield.cpp_asm.asm:1008
+bitfield.cpp_asm.asm:1012
 %endif
 %if UNIX
 Error #3: UNINITIALIZED READ: reading register ecx

--- a/tests/registers.blocklist.res
+++ b/tests/registers.blocklist.res
@@ -21,13 +21,13 @@
 #
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1418
+registers.c_asm.asm:1422
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1430
+registers.c_asm.asm:1434
 Error #3: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1443
+registers.c_asm.asm:1447
 Error #4: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1444
+registers.c_asm.asm:1448
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)

--- a/tests/registers.pattern.res
+++ b/tests/registers.pattern.res
@@ -24,9 +24,9 @@
 # while pattern mode reports "writing 1 byte(s)" error.
 %if WINDOWS
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1418
+registers.c_asm.asm:1422
 Error #2: UNADDRESSABLE ACCESS beyond heap bounds:
-registers.c_asm.asm:1430
+registers.c_asm.asm:1434
 %endif
 %if UNIX
 Error #1: UNADDRESSABLE ACCESS beyond heap bounds:

--- a/tests/registers.res
+++ b/tests/registers.res
@@ -21,39 +21,39 @@
 #
 %if WINDOWS
 Error #1: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1391
+registers.c_asm.asm:1395
 Error #2: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1398
+registers.c_asm.asm:1402
 Error #3: UNINITIALIZED READ: reading 2 byte(s)
 registers.c:104
 Error #4: UNINITIALIZED READ: reading register ax
-registers.c_asm.asm:1618
+registers.c_asm.asm:1622
 Error #5: UNINITIALIZED READ: reading register dx
-registers.c_asm.asm:1635
+registers.c_asm.asm:1639
 Error #6: UNINITIALIZED READ: reading register ah
-registers.c_asm.asm:1665
+registers.c_asm.asm:1669
 Error #7: UNINITIALIZED READ: reading 1 byte(s)
 registers.c:187
 Error #8: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1367
+registers.c_asm.asm:1371
 Error #9: UNINITIALIZED READ: reading register eflags
-registers.c_asm.asm:1192
-Error #10: UNINITIALIZED READ: reading register eflags
 registers.c_asm.asm:1196
+Error #10: UNINITIALIZED READ: reading register eflags
+registers.c_asm.asm:1200
 Error #11: UNINITIALIZED READ: reading register cl
-registers.c_asm.asm:1201
+registers.c_asm.asm:1205
 Error #12: UNINITIALIZED READ: reading register xcx
-registers.c_asm.asm:1221
+registers.c_asm.asm:1225
 Error #13: UNINITIALIZED READ: reading 8 byte(s)
-registers.c_asm.asm:1252
+registers.c_asm.asm:1256
 Error #14: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1418
+registers.c_asm.asm:1422
 Error #15: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1430
+registers.c_asm.asm:1434
 Error #16: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1443
+registers.c_asm.asm:1447
 Error #17: UNADDRESSABLE ACCESS beyond heap bounds: reading 1 byte(s)
-registers.c_asm.asm:1444
+registers.c_asm.asm:1448
 %endif
 %if UNIX
 Error #1: UNINITIALIZED READ: reading register eflags
@@ -99,7 +99,7 @@ registers.c_asm.asm:970
 %endif
 %if WINDOWS
 Error #19: UNINITIALIZED READ: reading register ecx
-registers.c_asm.asm:1760
+registers.c_asm.asm:1764
 %endif
 Error #20: UNINITIALIZED READ: reading register
 registers.c:267
@@ -107,15 +107,15 @@ Error #21: UNINITIALIZED READ: reading register
 registers.c:288
 %if WINDOWS
 Error #22: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1845
+registers.c_asm.asm:1849
 Error #23: UNINITIALIZED READ: reading 1 byte(s)
-registers.c_asm.asm:1859
+registers.c_asm.asm:1863
 Error #24: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1873
+registers.c_asm.asm:1877
 Error #25: UNINITIALIZED READ: reading 2 byte(s)
-registers.c_asm.asm:1887
+registers.c_asm.asm:1891
 Error #26: UNINITIALIZED READ: reading register eax
-registers.c_asm.asm:1922
+registers.c_asm.asm:1926
 %endif
 %if UNIX
 Error #22: UNINITIALIZED READ: reading 1 byte(s)


### PR DESCRIPTION
Updates DR to 795c8498 to bring in fix for
a drwrap crash which could affect Dr. Memory.

The DR update includes changes to asm_defines.asm,
which requires bumping Windows line numbers in some
test output patterns.

Issue: DynamoRIO/dynamorio#4607