### PR TITLE
i#2375,i#2367: Ignore/improve flaky umbra and leak tests

### DIFF
--- a/tests/leak_indirect.out
+++ b/tests/leak_indirect.out
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
 # **********************************************************
 #
 # Dr. Memory: the memory debugger
@@ -25,7 +25,10 @@ all done
 ~~Dr.M~~       0 unique,     0 total invalid heap argument(s)
 ~~Dr.M~~       0 unique,     0 total warning(s)
 %if X32
+%ANYLINE
 ~~Dr.M~~       2 unique,     2 total,     96 byte(s) of leak(s)
+~~Dr.M~~       2 unique,     2 total,     80 byte(s) of leak(s)
+%ENDANYLINE
 ~~Dr.M~~       1 unique,     1 total,     16 byte(s) of possible leak(s)
 %endif
 %if X64

--- a/tests/leak_indirect.out
+++ b/tests/leak_indirect.out
@@ -24,14 +24,14 @@ all done
 ~~Dr.M~~       0 unique,     0 total uninitialized access(es)
 ~~Dr.M~~       0 unique,     0 total invalid heap argument(s)
 ~~Dr.M~~       0 unique,     0 total warning(s)
-%if X32
 %ANYLINE
 ~~Dr.M~~       2 unique,     2 total,     96 byte(s) of leak(s)
 ~~Dr.M~~       2 unique,     2 total,     80 byte(s) of leak(s)
+~~Dr.M~~       2 unique,     2 total,    192 byte(s) of leak(s)
 %ENDANYLINE
+%if X32
 ~~Dr.M~~       1 unique,     1 total,     16 byte(s) of possible leak(s)
 %endif
 %if X64
-~~Dr.M~~       2 unique,     2 total,    192 byte(s) of leak(s)
 ~~Dr.M~~       1 unique,     1 total,     32 byte(s) of possible leak(s)
 %endif

--- a/tests/leak_indirect.res
+++ b/tests/leak_indirect.res
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
 # **********************************************************
 #
 # Dr. Memory: the memory debugger
@@ -24,7 +24,7 @@
 leak_indirect.c:48
 : POSSIBLE LEAK 16 direct bytes + 0 indirect bytes
 leak_indirect.c:53
-: LEAK 16 direct bytes + 16 indirect bytes
+: LEAK 16 direct bytes +
 leak_indirect.c:54
 %endif
 %if X64

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # **********************************************************
-# Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -211,6 +211,8 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'wrap_cs2bugMTd' => 1,
                 'wrap_operatorsMDd' => 1,
                 'leak_string' => 1,
+                # TODO i#2375: Fix DR to avoid test failures.
+                'umbra_client_faulty_redzone' => 1,
                 );
             # FIXME i#2180: ignoring certain AppVeyor x64-full-mode failures until
             # we get all tests passing.


### PR DESCRIPTION
Adds umbra_client_faulty_redzone to the ignore list until it is fixed
(#2375).

Relaxes the leak_indirect output to keep it greener (#2367).

Issue: #2375, #2367