### PR TITLE
DRi#4830: Downgrade to CMake 3.19.7 to avoid 32-bit failures

### DIFF
--- a/.github/workflows/ci-clang.yml
+++ b/.github/workflows/ci-clang.yml
@@ -62,6 +62,12 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install doxygen jsonlint g++-multilib
 
+    # Downgrade from cmake 3.20 to avoid 32-bit toolchain problems (DRi#4830).
+    - name: Downgrade cmake
+      uses: jwlawson/actions-setup-cmake@v1.8
+      with:
+        cmake-version: '3.19.7'
+
     - name: Run Suite
       working-directory: ${{ github.workspace }}
       run: ./tests/runsuite_wrapper.pl travis

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -61,6 +61,12 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install doxygen jsonlint g++-multilib
 
+    # Downgrade from cmake 3.20 to avoid 32-bit toolchain problems (DRi#4830).
+    - name: Downgrade cmake
+      uses: jwlawson/actions-setup-cmake@v1.8
+      with:
+        cmake-version: '3.19.7'
+
     - name: Get Version
       id: version
       # XXX: For now we duplicate this version number here with CMakeLists.txt.

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -67,6 +67,12 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install doxygen jsonlint g++-multilib
 
+    # Downgrade from cmake 3.20 to avoid 32-bit toolchain problems (DRi#4830).
+    - name: Downgrade cmake
+      uses: jwlawson/actions-setup-cmake@v1.8
+      with:
+        cmake-version: '3.19.7'
+
     - name: Run Suite
       working-directory: ${{ github.workspace }}
       run: ./tests/runsuite_wrapper.pl travis


### PR DESCRIPTION
CMake 3.20 on GA CI fails to link 32-bit binaries, so we downgrade
our jobs to 3.19.7 for now.

Issue: DynamoRIO/dynamorio#4830