### PR TITLE
i#2016: Port the umbra_64.c class to work on aarch64

### DIFF
--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1263,8 +1263,8 @@ umbra_insert_app_to_shadow_arch(void *drcontext,
                                 int num_scratch_regs)
 {
 #if defined(AARCH64)
-    ASSERT(num_scratch_regs > umbra_num_scratch_regs_for_translation_arch(),
-        "umbra_insert_app_to_shadow_arch requires at least one scracth register provided");
+    if (num_scratch_regs >= umbra_num_scratch_regs_for_translation_arch())
+        return DRMF_ERROR_INVALID_PARAMETER;
 
     reg_id_t tmp = *scratch_regs;
 

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -262,6 +262,7 @@ static dr_os_version_info_t os_version = {sizeof(os_version),};
 /* Each unit has 16 segments, which could be used for app or shadow. */
 #define NUM_SEGMENTS      16 /* 16 segments per unit */
 
+
 static ptr_uint_t seg_index_mask(uint num_seg_bits)
 {
     return (ptr_uint_t)(NUM_SEGMENTS - 1) << num_seg_bits;
@@ -1247,7 +1248,7 @@ umbra_value_in_shadow_memory_arch(IN    umbra_map_t *map,
 int
 umbra_num_scratch_regs_for_translation_arch()
 {
-    return 0;
+    return IF_AARCH64_ELSE(1, 0);
 }
 
 /* code sequence:
@@ -1263,6 +1264,9 @@ umbra_insert_app_to_shadow_arch(void *drcontext,
                                 int num_scratch_regs)
 {
 #if defined(AARCH64)
+    ASSERT(num_scratch_regs > umbra_num_scratch_regs_for_translation_arch(),
+        "umbra_insert_app_to_shadow_arch requires at least one scracth register provided");
+
     reg_id_t tmp = *scratch_regs;
 
     instru_insert_mov_pc(drcontext, ilist, where, opnd_create_reg(tmp),

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1263,7 +1263,7 @@ umbra_insert_app_to_shadow_arch(void *drcontext,
                                 int num_scratch_regs)
 {
 #if defined(AARCH64)
-    if (num_scratch_regs >= umbra_num_scratch_regs_for_translation_arch())
+    if (num_scratch_regs < umbra_num_scratch_regs_for_translation_arch())
         return DRMF_ERROR_INVALID_PARAMETER;
 
     reg_id_t tmp = *scratch_regs;

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -26,6 +26,7 @@
  */
 
 #include "dr_api.h"
+#include "instru.h"
 #include "umbra.h"
 #include "umbra_private.h"
 #include "drmemory_framework.h"
@@ -261,10 +262,13 @@ static dr_os_version_info_t os_version = {sizeof(os_version),};
 /* Each unit has 16 segments, which could be used for app or shadow. */
 #define NUM_SEGMENTS      16 /* 16 segments per unit */
 
+
+#ifndef AARCH64
 static ptr_uint_t seg_index_mask(uint num_seg_bits)
 {
     return (ptr_uint_t)(NUM_SEGMENTS - 1) << num_seg_bits;
 }
+#endif
 
 static ptr_uint_t segment_size(uint num_seg_bits)
 {
@@ -354,6 +358,37 @@ static ptr_uint_t map_disp_win81[] = {
  * We check conflicts later when creating shadow memory.
  */
 #ifdef LINUX
+#ifdef AARCH64
+static const app_segment_t app_segments_initial[] = {
+    /* We split app3 [0x7F0000000000, 0x800000000000) into two parts:
+     * [0x7F0000000000, 0x7FFFFF400000) and [0x7FFFFF800000, 0x800000000000).
+     * And we skip [0x7FFFFF400000-0x7FFFFF800000)
+     * for app4 [0xFFFFFFFFFF400000,  0xFFFFFFFFFF800000) because current
+     * mapping schema maps app3 and app4 to the same segment.
+     * We cannot use smaller size due to the block allocation size
+     * (ALLOC_UNIT_SIZE) and the correspoinding bitmap for the shadow memory
+     * allocation tracking.
+     *
+     * We assume [0x7FFFFF400000-0x7FFFFF800000) will not be used by app.
+     * If app allocates memory from that region, umbra_add_app_segment
+     * will fail because umbra_add_shadow_segment fails to add corresponding
+     * shadow memory segment.
+     * FIXME i#1782, i#1798: we can proactively track memory allocation and
+     * use more expensive instrumentation when necessary to get rid of the
+     * assumption and segment split.
+     */
+    {(app_pc)0x0000ff0000000000,  (app_pc)0x0001000000000000, 0},
+    {(app_pc)0x0000000000000000,  (app_pc)0x0000010000000000, 0},
+    /* app4: [0xFFFFFFFF'FF600000, 0xFFFFFFFF'FF601000] */
+    /* for all additional segments */
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
+};
+
+#else
 static const app_segment_t app_segments_initial[] = {
     /* We split app3 [0x7F0000000000, 0x800000000000) into two parts:
      * [0x7F0000000000, 0x7FFFFF400000) and [0x7FFFFF800000, 0x800000000000).
@@ -387,6 +422,7 @@ static const app_segment_t app_segments_initial[] = {
     { NULL, NULL, 0 },
     { NULL, NULL, 0 },
 };
+#endif
 static const app_segment_t app_segments_initial_no_vsyscall[] = {
     /* We do not need any gaps or splitting without vsyscall. */
     /* for all additional segments */
@@ -839,7 +875,7 @@ umbra_map_arch_init(umbra_map_t *map, umbra_map_options_t *ops)
     ASSERT(map->shadow_block_size >= ALLOC_UNIT_SIZE &&
            map->app_block_size    >= ALLOC_UNIT_SIZE,
            "block size too small");
-    map->mask = segment_mask(num_seg_bits) | seg_index_mask(num_seg_bits);
+    map->mask = IF_AARCH64_ELSE(0xfffffffffffffffc, segment_mask(num_seg_bits) | seg_index_mask(num_seg_bits));
 #ifdef WINDOWS
     if (UMBRA_MAP_SCALE_IS_UP(map->options.scale)) {
         /* The only way we can avoid reserves from wrapping around or overlapping
@@ -1261,6 +1297,28 @@ umbra_insert_app_to_shadow_arch(void *drcontext,
                                 reg_id_t *scratch_regs,
                                 int num_scratch_regs)
 {
+#if defined(AARCH64)
+    reg_id_t tmp = *scratch_regs;
+    instru_insert_mov_pc(drcontext, ilist, where, opnd_create_reg(tmp),
+                                OPND_CREATE_INT64(map->disp));
+    PRE(ilist, where, INSTR_CREATE_add(drcontext,
+                                       opnd_create_reg(reg_addr), opnd_create_reg(reg_addr),
+                                       opnd_create_reg(tmp)));
+    if (map->options.scale == UMBRA_MAP_SCALE_UP_2X) {
+        PRE(ilist, where, INSTR_CREATE_lsl(drcontext,
+                                           opnd_create_reg(reg_addr), opnd_create_reg(reg_addr),
+                                           OPND_CREATE_INT8(map->shift)));
+    } else if (map->options.scale <= UMBRA_MAP_SCALE_DOWN_2X) {
+        PRE(ilist, where, XINST_CREATE_slr_s(drcontext,
+                                           opnd_create_reg(reg_addr),
+                                           OPND_CREATE_INT8(map->shift)));
+    }
+    instru_insert_mov_pc(drcontext, ilist, where, opnd_create_reg(tmp),
+                             OPND_CREATE_INT64(map->mask));
+    PRE(ilist, where, INSTR_CREATE_and(drcontext,
+                                       opnd_create_reg(reg_addr), opnd_create_reg(reg_addr),
+                                       opnd_create_reg(tmp)));
+#else
     PRE(ilist, where, INSTR_CREATE_and(drcontext,
                                        opnd_create_reg(reg_addr),
                                        OPND_CREATE_ABSMEM(&map->mask,
@@ -1278,6 +1336,7 @@ umbra_insert_app_to_shadow_arch(void *drcontext,
                                            opnd_create_reg(reg_addr),
                                            OPND_CREATE_INT8(map->shift)));
     }
+#endif
     return DRMF_SUCCESS;
 }
 

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1286,8 +1286,8 @@ umbra_insert_app_to_shadow_arch(void *drcontext,
                                            OPND_CREATE_INT8(map->shift)));
     } else if (map->options.scale <= UMBRA_MAP_SCALE_DOWN_2X) {
         PRE(ilist, where, XINST_CREATE_slr_s(drcontext,
-                                           opnd_create_reg(reg_addr),
-                                           OPND_CREATE_INT8(map->shift)));
+                                             opnd_create_reg(reg_addr),
+                                             OPND_CREATE_INT8(map->shift)));
     }
 #else
     PRE(ilist, where, INSTR_CREATE_and(drcontext,

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -262,7 +262,6 @@ static dr_os_version_info_t os_version = {sizeof(os_version),};
 /* Each unit has 16 segments, which could be used for app or shadow. */
 #define NUM_SEGMENTS      16 /* 16 segments per unit */
 
-
 static ptr_uint_t seg_index_mask(uint num_seg_bits)
 {
     return (ptr_uint_t)(NUM_SEGMENTS - 1) << num_seg_bits;

--- a/umbra/umbra_64.c
+++ b/umbra/umbra_64.c
@@ -1269,13 +1269,13 @@ umbra_insert_app_to_shadow_arch(void *drcontext,
     reg_id_t tmp = *scratch_regs;
 
     instru_insert_mov_pc(drcontext, ilist, where, opnd_create_reg(tmp),
-                             OPND_CREATE_INT64(map->mask));
+                         OPND_CREATE_INT64(map->mask));
     PRE(ilist, where, INSTR_CREATE_and(drcontext,
                                        opnd_create_reg(reg_addr), opnd_create_reg(reg_addr),
                                        opnd_create_reg(tmp)));
 
     instru_insert_mov_pc(drcontext, ilist, where, opnd_create_reg(tmp),
-                                OPND_CREATE_INT64(map->disp));
+                         OPND_CREATE_INT64(map->disp));
 
     PRE(ilist, where, INSTR_CREATE_add(drcontext,
                                        opnd_create_reg(reg_addr), opnd_create_reg(reg_addr),


### PR DESCRIPTION
Enables shadow memory tracking on AArch64.

This is a subsection of the larger ongoing AArch64 port of DRMemory.

Issue: #2016