### PR TITLE
i#2016 AArch64: add initial testing for non-pattern mode

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -445,7 +445,7 @@ if (ARM)
   append_test_compile_flags(free_arm "-marm")
 endif (ARM)
 newtest(badjmp badjmp.c)
-if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
   newtest(registers registers.c)
 endif ()
 if (ARM)
@@ -459,7 +459,7 @@ if (TOOL_DR_MEMORY)
   # Doesn't make sense for DrHeapstat
   newtest(multierror multierror.cpp)
 endif (TOOL_DR_MEMORY)
-if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
   newtest_custbuild(bitfield bitfield.cpp "-DBITFIELD_ASM" bitfield)
   if (WIN32)
     # i#489: building /GL results in a double-xor sequence
@@ -643,7 +643,7 @@ CHECK_C_COMPILER_FLAG("-Wno-alloc-size-larger-than=4294967295"
   HAVE_ALLOC_SIZE_WARNING_INTERNAL)
 
 if (TOOL_DR_MEMORY)
-  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
     # PR 525807: test malloc stacks
     newtest(varstack varstack.c)
   endif ()
@@ -654,7 +654,7 @@ if (TOOL_DR_MEMORY)
   if (NOT X64) # XXX i#111: -esp_fastpath not supported yet
     newtest_nobuild(leaks-only malloc "" "-leaks_only" "" OFF "")
   endif ()
-  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
     if (NOT X64) # FIXME i#111: failing on Travis
       newtest_nobuild(slowpath registers "" "-no_fastpath" "" OFF "registers")
     endif ()
@@ -668,7 +668,7 @@ if (TOOL_DR_MEMORY)
   if (NOT X64) # FIXME i#111: failing on Travis
     newtest_nobuild(nosymcache malloc "" "-no_use_symcache" "" OFF malloc)
   endif ()
-  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
     newtest_nobuild(strict_bitops bitfield "" "-strict_bitops" "" OFF "bitfield.strict")
   endif ()
   # test this option to exercise the realloc handling code.
@@ -683,7 +683,7 @@ if (TOOL_DR_MEMORY)
   newtest_nobuild(redzone1024 malloc "" "-redzone_size;1024" "" OFF "malloc")
   newtest_nobuild_ex(free.exitcode free "" "-exit_code_if_errors;42" "" OFF "free" 42 "")
   newtest_nobuild_ex(hello.exitcode hello "" "-exit_code_if_errors;4" "" OFF "hello" 0 "")
-  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
     newtest_nobuild_ex(blocklist_uninit.op registers ""
       "-check_uninit_blocklist;registers*" "" OFF "registers.blocklist" 0 "")
     newtest_nobuild_ex(blocklist_uninit.supp registers ""
@@ -899,13 +899,13 @@ if (TOOL_DR_MEMORY)
   # pattern mode testing.
   newtest_nobuild(free.pattern free "" "-unaddr_only" "" OFF "addronly")
   newtest_nobuild(malloc.pattern malloc "" "-unaddr_only" "" OFF "")
-  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
     newtest_nobuild(registers.pattern registers "" "-unaddr_only" "" OFF
       "registers.pattern")
   endif ()
   newtest_nobuild(track_origins.pattern track_origins ""
     "-unaddr_only;-track_origins_unaddr" "" OFF "track_origins")
-  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
     newtest_nobuild_ex(state.pattern state "" "-unaddr_only" "" OFF "" "ANY" "")
   endif ()
 
@@ -935,7 +935,7 @@ else (TOOL_DR_MEMORY)
   set(nudge_test_args "")
 endif (TOOL_DR_MEMORY)
 
-if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
   # nudge test: runs infloop in background and runtest.cmake nudges it
   tobuild(infloop infloop.c)
   get_target_path_for_execution(infloop_path infloop)
@@ -1024,7 +1024,7 @@ else ()
     newtest(malloc malloc.c)
     newtest(leak_indirect leak_indirect.c)
   endif ()
-  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
     newtest_custbuild(bitfield bitfield.cpp "-DBITFIELD_ASM" bitfield)
   endif ()
   newtest(patterns patterns.c)
@@ -1044,7 +1044,7 @@ else ()
   if (NOT ANDROID) # FIXME i#1860: fix for Android
     newtest_ex(malloc.pattern malloc.c "" "-unaddr_only" "" OFF "" 0)
   endif ()
-  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM + i#2016 port to AArch64
     newtest_ex(registers.pattern registers.c "" "-unaddr_only" "" OFF
       "registers.pattern" 0)
   endif ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,8 @@ function(set_props target)
   # DrMem itself gets ARM from dr_api.h but tests need it on their own:
   if (ARM)
     set(defs ${defs} ARM)
+  elseif (AARCH64)
+    set(defs ${defs} AARCH64)
   endif ()
   if (X86)
     set(defs ${defs} X86)
@@ -432,7 +434,7 @@ function(newtest_gcc test source depender gcc_ops test_ops drmem_ops dr_ops
 endfunction(newtest_gcc)
 
 # i#1726: ARM is only supported in pattern mode.
-if (NOT ARM)
+if (NOT ARM AND NOT AARCH64)
 # Leaving indentation as-is to avoid code churn
 newtest(hello hello.c)
 newtest(malloc malloc.c)
@@ -443,11 +445,13 @@ if (ARM)
   append_test_compile_flags(free_arm "-marm")
 endif (ARM)
 newtest(badjmp badjmp.c)
-if (NOT ARM) # XXX i#1726: port to ARM
+if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
   newtest(registers registers.c)
 endif ()
 if (ARM)
   newtest(asmtest asmtest_arm.c)
+elseif (AARCH64)
+  newtest(asmtest asmtest_aarch64.c)
 else ()
   newtest(asmtest asmtest_x86.c)
 endif ()
@@ -455,7 +459,7 @@ if (TOOL_DR_MEMORY)
   # Doesn't make sense for DrHeapstat
   newtest(multierror multierror.cpp)
 endif (TOOL_DR_MEMORY)
-if (NOT ARM) # XXX i#1726: port to ARM
+if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
   newtest_custbuild(bitfield bitfield.cpp "-DBITFIELD_ASM" bitfield)
   if (WIN32)
     # i#489: building /GL results in a double-xor sequence
@@ -639,7 +643,7 @@ CHECK_C_COMPILER_FLAG("-Wno-alloc-size-larger-than=4294967295"
   HAVE_ALLOC_SIZE_WARNING_INTERNAL)
 
 if (TOOL_DR_MEMORY)
-  if (NOT ARM) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
     # PR 525807: test malloc stacks
     newtest(varstack varstack.c)
   endif ()
@@ -650,7 +654,7 @@ if (TOOL_DR_MEMORY)
   if (NOT X64) # XXX i#111: -esp_fastpath not supported yet
     newtest_nobuild(leaks-only malloc "" "-leaks_only" "" OFF "")
   endif ()
-  if (NOT ARM) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
     if (NOT X64) # FIXME i#111: failing on Travis
       newtest_nobuild(slowpath registers "" "-no_fastpath" "" OFF "registers")
     endif ()
@@ -664,7 +668,7 @@ if (TOOL_DR_MEMORY)
   if (NOT X64) # FIXME i#111: failing on Travis
     newtest_nobuild(nosymcache malloc "" "-no_use_symcache" "" OFF malloc)
   endif ()
-  if (NOT ARM) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
     newtest_nobuild(strict_bitops bitfield "" "-strict_bitops" "" OFF "bitfield.strict")
   endif ()
   # test this option to exercise the realloc handling code.
@@ -679,7 +683,7 @@ if (TOOL_DR_MEMORY)
   newtest_nobuild(redzone1024 malloc "" "-redzone_size;1024" "" OFF "malloc")
   newtest_nobuild_ex(free.exitcode free "" "-exit_code_if_errors;42" "" OFF "free" 42 "")
   newtest_nobuild_ex(hello.exitcode hello "" "-exit_code_if_errors;4" "" OFF "hello" 0 "")
-  if (NOT ARM) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
     newtest_nobuild_ex(blocklist_uninit.op registers ""
       "-check_uninit_blocklist;registers*" "" OFF "registers.blocklist" 0 "")
     newtest_nobuild_ex(blocklist_uninit.supp registers ""
@@ -895,13 +899,13 @@ if (TOOL_DR_MEMORY)
   # pattern mode testing.
   newtest_nobuild(free.pattern free "" "-unaddr_only" "" OFF "addronly")
   newtest_nobuild(malloc.pattern malloc "" "-unaddr_only" "" OFF "")
-  if (NOT ARM) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
     newtest_nobuild(registers.pattern registers "" "-unaddr_only" "" OFF
       "registers.pattern")
   endif ()
   newtest_nobuild(track_origins.pattern track_origins ""
     "-unaddr_only;-track_origins_unaddr" "" OFF "track_origins")
-  if (NOT ARM) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
     newtest_nobuild_ex(state.pattern state "" "-unaddr_only" "" OFF "" "ANY" "")
   endif ()
 
@@ -931,7 +935,7 @@ else (TOOL_DR_MEMORY)
   set(nudge_test_args "")
 endif (TOOL_DR_MEMORY)
 
-if (NOT ARM) # XXX i#1726: port to ARM
+if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
   # nudge test: runs infloop in background and runtest.cmake nudges it
   tobuild(infloop infloop.c)
   get_target_path_for_execution(infloop_path infloop)
@@ -1016,7 +1020,11 @@ else ()
   # default mode == pattern + leaks
   newtest(hello hello.c)
   newtest(free free.c)
-  if (NOT ARM) # XXX i#1726: port to ARM
+  if (AARCH64)
+    newtest(malloc malloc.c)
+    newtest(leak_indirect leak_indirect.c)
+  endif ()
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
     newtest_custbuild(bitfield bitfield.cpp "-DBITFIELD_ASM" bitfield)
   endif ()
   newtest(patterns patterns.c)
@@ -1036,7 +1044,7 @@ else ()
   if (NOT ANDROID) # FIXME i#1860: fix for Android
     newtest_ex(malloc.pattern malloc.c "" "-unaddr_only" "" OFF "" 0)
   endif ()
-  if (NOT ARM) # XXX i#1726: port to ARM
+  if (NOT ARM AND NOT AARCH64) # XXX i#1726: port to ARM
     newtest_ex(registers.pattern registers.c "" "-unaddr_only" "" OFF
       "registers.pattern" 0)
   endif ()
@@ -1064,7 +1072,7 @@ endif ()
 
 # XXX i#1660: gtest is not building with clang 6.0
 # XXX i#1726: need to port app_suite to ARM.
-if (NOT APPLE AND NOT ARM)
+if (NOT APPLE AND NOT ARM AND NOT AARCH64)
   add_subdirectory(app_suite)
   if (TOOL_DR_HEAPSTAT)
     # i#1358: Dr. Heapstat currently can't handle code in the heap

--- a/tests/framework/drsyscall_client.c
+++ b/tests/framework/drsyscall_client.c
@@ -70,14 +70,15 @@ check_mcontext(void *drcontext)
     mc_DR.size = sizeof(mc_DR);
     mc_DR.flags = DR_MC_INTEGER|DR_MC_CONTROL;
     dr_get_mcontext(drcontext, &mc_DR);
-    ASSERT(mc->IF_ARM_ELSE(r7,xdi) == mc_DR.IF_ARM_ELSE(r7,xdi), "mc check");
-    ASSERT(mc->IF_ARM_ELSE(r6,xsi) == mc_DR.IF_ARM_ELSE(r6,xsi), "mc check");
-    ASSERT(mc->IF_ARM_ELSE(r5,xbp) == mc_DR.IF_ARM_ELSE(r5,xbp), "mc check");
-    ASSERT(mc->IF_ARM_ELSE(r4,xsp) == mc_DR.IF_ARM_ELSE(r4,xsp), "mc check");
-    ASSERT(mc->IF_ARM_ELSE(r3,xbx) == mc_DR.IF_ARM_ELSE(r3,xbx), "mc check");
-    ASSERT(mc->IF_ARM_ELSE(r2,xdx) == mc_DR.IF_ARM_ELSE(r2,xdx), "mc check");
-    ASSERT(mc->IF_ARM_ELSE(r1,xcx) == mc_DR.IF_ARM_ELSE(r1,xcx), "mc check");
-    ASSERT(mc->IF_ARM_ELSE(r0,xax) == mc_DR.IF_ARM_ELSE(r0,xax), "mc check");
+    //TODO: add more asserts for aarch64?
+    ASSERT(mc->IF_AARCHXX_ELSE(r7,xdi) == mc_DR.IF_AARCHXX_ELSE(r7,xdi), "mc check");
+    ASSERT(mc->IF_AARCHXX_ELSE(r6,xsi) == mc_DR.IF_AARCHXX_ELSE(r6,xsi), "mc check");
+    ASSERT(mc->IF_AARCHXX_ELSE(r5,xbp) == mc_DR.IF_AARCHXX_ELSE(r5,xbp), "mc check");
+    ASSERT(mc->IF_AARCHXX_ELSE(r4,xsp) == mc_DR.IF_AARCHXX_ELSE(r4,xsp), "mc check");
+    ASSERT(mc->IF_AARCHXX_ELSE(r3,xbx) == mc_DR.IF_AARCHXX_ELSE(r3,xbx), "mc check");
+    ASSERT(mc->IF_AARCHXX_ELSE(r2,xdx) == mc_DR.IF_AARCHXX_ELSE(r2,xdx), "mc check");
+    ASSERT(mc->IF_AARCHXX_ELSE(r1,xcx) == mc_DR.IF_AARCHXX_ELSE(r1,xcx), "mc check");
+    ASSERT(mc->IF_AARCHXX_ELSE(r0,xax) == mc_DR.IF_AARCHXX_ELSE(r0,xax), "mc check");
     ASSERT(mc->xflags == mc_DR.xflags, "mc check");
 }
 

--- a/tests/framework/drsyscall_client.c
+++ b/tests/framework/drsyscall_client.c
@@ -70,7 +70,7 @@ check_mcontext(void *drcontext)
     mc_DR.size = sizeof(mc_DR);
     mc_DR.flags = DR_MC_INTEGER|DR_MC_CONTROL;
     dr_get_mcontext(drcontext, &mc_DR);
-    //TODO: add more asserts for aarch64?
+    /* TODO: add more asserts for aarch64? */
     ASSERT(mc->IF_AARCHXX_ELSE(r7,xdi) == mc_DR.IF_AARCHXX_ELSE(r7,xdi), "mc check");
     ASSERT(mc->IF_AARCHXX_ELSE(r6,xsi) == mc_DR.IF_AARCHXX_ELSE(r6,xsi), "mc check");
     ASSERT(mc->IF_AARCHXX_ELSE(r5,xbp) == mc_DR.IF_AARCHXX_ELSE(r5,xbp), "mc check");

--- a/tests/framework/drsyscall_client.c
+++ b/tests/framework/drsyscall_client.c
@@ -70,7 +70,7 @@ check_mcontext(void *drcontext)
     mc_DR.size = sizeof(mc_DR);
     mc_DR.flags = DR_MC_INTEGER|DR_MC_CONTROL;
     dr_get_mcontext(drcontext, &mc_DR);
-    /* TODO: add more asserts for aarch64? */
+    /* i#2016 aarch64: TODO: add more asserts for aarch64? */
     ASSERT(mc->IF_AARCHXX_ELSE(r7,xdi) == mc_DR.IF_AARCHXX_ELSE(r7,xdi), "mc check");
     ASSERT(mc->IF_AARCHXX_ELSE(r6,xsi) == mc_DR.IF_AARCHXX_ELSE(r6,xsi), "mc check");
     ASSERT(mc->IF_AARCHXX_ELSE(r5,xbp) == mc_DR.IF_AARCHXX_ELSE(r5,xbp), "mc check");

--- a/tests/suppress-genoffs.res
+++ b/tests/suppress-genoffs.res
@@ -185,7 +185,7 @@ Error #15: UNINITIALIZED READ: reading register
 suppress!do_uninit_read
 suppress.c:63
 suppress!do_uninit_cb
-suppress.c:261
+suppress.c:264
 # Drop the dll module name as it's different on Linux, and the source file name
 # tells us which module it was.
 !callback_with_n_frames
@@ -213,7 +213,7 @@ Error #16: UNINITIALIZED READ: reading register
 suppress!do_uninit_read
 suppress.c:63
 suppress!do_uninit_cb
-suppress.c:261
+suppress.c:264
 # Drop the dll module name as it's different on Linux, and the source file name
 # tells us which module it was.
 !callback_with_n_frames

--- a/tests/suppress-gensyms.res
+++ b/tests/suppress-gensyms.res
@@ -185,7 +185,7 @@ Error #15: UNINITIALIZED READ: reading register
 suppress!do_uninit_read
 suppress.c:63
 suppress!do_uninit_cb
-suppress.c:261
+suppress.c:264
 # Drop the dll module name as it's different on Linux, and the source file name
 # tells us which module it was.
 !callback_with_n_frames
@@ -213,7 +213,7 @@ Error #16: UNINITIALIZED READ: reading register
 suppress!do_uninit_read
 suppress.c:63
 suppress!do_uninit_cb
-suppress.c:261
+suppress.c:264
 # Drop the dll module name as it's different on Linux, and the source file name
 # tells us which module it was.
 !callback_with_n_frames

--- a/tests/suppress.c
+++ b/tests/suppress.c
@@ -243,6 +243,9 @@ non_module_test(void)
 #elif defined(ARM)
     /* cmp r0, #0; bx lr */
     int buf[] = { 0xe3500000, 0xe12fff1e };
+#elif defined(AARCH64)
+    /* cmp x0, #0; ret */
+    int buf[] = { 0x1f0000f1, 0xc0035fd6 };
 #endif
     int uninit[2];
     int x = 0; /* avoid compiler warning about uninit var use */

--- a/tests/suppress.res
+++ b/tests/suppress.res
@@ -24,7 +24,7 @@ UNINITIALIZED READ
 suppress!do_uninit_read
 suppress.c:63
 suppress!do_uninit_cb
-suppress.c:261
+suppress.c:264
 # Drop the dll module name as it's different on Linux, and the source file name
 # tells us which module it was.
 !callback_with_n_frames


### PR DESCRIPTION
This patch edits tests/CMakeLists.txt to enable a selection of
existing tests for drmemory aarch64 as supported by the larger
initial aarch64 slowpath patch.