### PR TITLE
Fix error in official release step

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -248,6 +248,7 @@ jobs:
           export PREFIX="cronbuild-"
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
+          export OSX_VERSION_NUMBER=${{ github.event.inputs.version }}
           export PREFIX="release_"
         fi
         if [ "${{ github.event.inputs.build }}" -ne 0 ]; then


### PR DESCRIPTION
The Mac build for an official release has a regression where
OSX_VERSION_NUMBER is not net.  We fix that here.