### PR TITLE
i#2417: Upgrade GA CI to Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # AArchXX cross-compile with gcc, no tests:
   aarchxx-cross-compile:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
 
   # Android ARM cross-compile with gcc, no tests:
   android-arm-cross-compile:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-clang.yml
+++ b/.github/workflows/ci-clang.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # 32-bit and 64-bit Linux build with clang, no tests.
   clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-clang.yml
+++ b/.github/workflows/ci-clang.yml
@@ -71,6 +71,3 @@ jobs:
     - name: Run Suite
       working-directory: ${{ github.workspace }}
       run: ./tests/runsuite_wrapper.pl travis
-      env:
-        CC: clang-9
-        CXX: clang++-9

--- a/.github/workflows/ci-clang.yml
+++ b/.github/workflows/ci-clang.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # 32-bit and 64-bit Linux build with clang, no tests.
   clang:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -45,7 +45,7 @@ jobs:
   ###########################################################################
   # Linux tarball with 64-bit and 32-bit builds:
   x86:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -228,7 +228,7 @@ jobs:
 
   create_release:
     needs: [x86, osx, windows]
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
       # We need a checkout to run git log for the version.

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # 64-bit and 32-bit Linux build with gcc and tests:
   x86:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # 64-bit and 32-bit Linux build with gcc and tests:
   x86:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/drmemory/instru.c
+++ b/drmemory/instru.c
@@ -1313,11 +1313,12 @@ instru_event_bb_insert(void *drcontext, void *tag, instrlist_t *bb, instr_t *ins
     if (options.zero_retaddr && !ZERO_STACK() && !options.check_uninitialized)
         insert_zero_retaddr(drcontext, bb, inst, bi);
 
-    /* None of the "goto instru_event_bb_insert_dones" above need to be processed here */
-    if (INSTRUMENT_MEMREFS())
+ instru_event_bb_insert_done:
+    /* We do need to process labels for annotations. */
+    if (INSTRUMENT_MEMREFS() &&
+        (!instr_is_meta(inst) || instr_is_label(inst)))
         fastpath_pre_app_instr(drcontext, bb, inst, bi, &mi);
 
- instru_event_bb_insert_done:
     if (bi->first_instr && instr_is_app(inst))
         bi->first_instr = false;
     if (!used_fastpath && options.shadowing) {

--- a/drmemory/spill.c
+++ b/drmemory/spill.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1564,9 +1564,14 @@ fastpath_pre_app_instr(void *drcontext, instrlist_t *bb, instr_t *inst,
     if ((bi->reg1.reg != DR_REG_NULL || bi->reg2.reg != DR_REG_NULL) &&
         (!result_is_always_defined(inst, true/*natively*/) ||
          /* if sub-dword then we have to restore for rest of bits */
-         opnd_get_size(instr_get_src(inst, 0)) != OPSZ_4)) {
+         opnd_size_in_bytes(opnd_get_size(instr_get_src(inst, 0))) < 4)) {
         /* we don't mark as used: if unused so far, no reason to restore */
         if (instr_reads_from_reg(inst, bi->reg1.reg, DR_QUERY_INCLUDE_ALL) ||
+            /* Restore all app values prior to an annotation to ensure the
+             * arguments passed to the handler are correct.
+             */
+            (instr_is_label(inst) &&
+             (ptr_uint_t)instr_get_note(inst) == DR_NOTE_ANNOTATION) ||
             /* if sub-reg is written we need to restore rest */
             (instr_writes_to_reg(inst, bi->reg1.reg, DR_QUERY_INCLUDE_ALL) &&
              !instr_writes_to_exact_reg(inst, bi->reg1.reg, DR_QUERY_INCLUDE_ALL)) ||
@@ -1599,6 +1604,11 @@ fastpath_pre_app_instr(void *drcontext, instrlist_t *bb, instr_t *inst,
             insert_spill_global(drcontext, bb, inst, &bi->reg1, false/*restore*/);
         }
         if (instr_reads_from_reg(inst, bi->reg2.reg, DR_QUERY_INCLUDE_ALL) ||
+            /* Restore all app values prior to an annotation to ensure the
+             * arguments passed to the handler are correct.
+             */
+            (instr_is_label(inst) &&
+             (ptr_uint_t)instr_get_note(inst) == DR_NOTE_ANNOTATION) ||
             /* if sub-reg is written we need to restore rest */
             (instr_writes_to_reg(inst, bi->reg2.reg, DR_QUERY_INCLUDE_ALL) &&
              !instr_writes_to_exact_reg(inst, bi->reg2.reg, DR_QUERY_INCLUDE_ALL)) ||


### PR DESCRIPTION
Upgrades the VM used for our GA CI from 16.04, which is now
depcreated, to 20.04.

Fixes #2417