### PR TITLE
i#2417 ubuntu20: Fix new libc unaddr and blocklist error

### DIFF
--- a/drmemory/report.c
+++ b/drmemory/report.c
@@ -1960,6 +1960,7 @@ report_thread_init(void *drcontext)
 {
     tls_report_t *pt = (tls_report_t *)
         thread_alloc(drcontext, sizeof(*pt), HEAPSTAT_MISC);
+    memset(pt, 0, sizeof(*pt));
     drmgr_set_tls_field(drcontext, tls_idx_report, pt);
     pt->errbufsz = MAX_ERROR_INITIAL_LINES + max_callstack_size()*2;
     pt->errbuf = (char *) thread_alloc(drcontext, pt->errbufsz, HEAPSTAT_REPORT);


### PR DESCRIPTION
Fixes two failing tests on Ubuntu18+:

Adds a new string unaddr pattern where recent libc
reads a whole word beyond the allocated bounds.
This fixes a false positive in the loader test
on Ubuntu18+.

Fixes an uninitialized field tls_report_t.last_query_mod_start which
was failing the blocklist_uninit.op test.

Issue: #2417