### PR TITLE
i#2425: Add Ubuntu21 support

### DIFF
--- a/drsyscall/table_linux.c
+++ b/drsyscall/table_linux.c
@@ -974,7 +974,15 @@ syscall_info_t syscall_info[] = {
          {2,2 * sizeof(struct timeval), R},
      }
     },
-    {{PACKNUM(-1,300,327),0},"fstatat64", OK, RLONG, 4, /* FIXME 1, sizeof(char), U, 2, sizeof(struct stat64), U, */},
+#ifndef X64
+    /* XXX i#1013: we'll need our own defs of stat64 for mixed-mode */
+    {{PACKNUM(-1,300,327),0},"fstatat64", OK, RLONG, 4,
+     {
+         {1,0, R|CT, CSTRING},
+         {2,sizeof(struct stat64),W},
+     }
+    },
+#endif
     {{PACKNUM(263,301,328),0},"unlinkat", OK, RLONG, 3,
      {
          {1,0, R|CT, CSTRING},
@@ -1248,7 +1256,12 @@ syscall_info_t syscall_info[] = {
      }
     },
     {{PACKNUM(236,-1,-1),0},"vserver", UNKNOWN, RLONG, 0, },
-    {{PACKNUM(262,-1,-1),0},"newfstatat", UNKNOWN, RLONG, 0, },
+    {{PACKNUM(262,-1,-1),0},"newfstatat", OK, RLONG, 4,
+     {
+         {1,0, R|CT, CSTRING},
+         {2,sizeof(struct stat),W},
+     }
+    },
     {{PACKNUM(288,-1,366),0},"paccept", OK, RLONG, 4,
      {
          {1,-2,WI|CT,SYSARG_TYPE_SOCKADDR},


### PR DESCRIPTION
Updates DR to f3d907d7 to fix DynamoRIO/dynamorio#5133: call
__libc_eary_init for private libc.  This fixes crashes in Dr. Memory
when it uses libc routines on glibc 2.32+..

Fills in the table entry for SYS_newfstatat to avoid false positives
from the loader's munmaps.

Fixes #2425