### PR TITLE
DRi#4958: Update DR to eliminate DR blocks

### DIFF
--- a/tests/framework/umbra_client_insert_app_to_shadow.c
+++ b/tests/framework/umbra_client_insert_app_to_shadow.c
@@ -259,11 +259,6 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *ilist, instr_t *w
 
     if (!instr_reads_memory(where) && !instr_writes_memory(where))
         return DR_EMIT_DEFAULT;
-    /* XXX: Workaround for DRi#4958 where DR code shows up in blocks
-     * and DR can't handle a fault there.
-     */
-    if (dr_memory_is_dr_internal(dr_fragment_app_pc(tag)))
-        return DR_EMIT_DEFAULT;
 
     if (subtest == UMBRA_TEST_1_C || subtest == UMBRA_TEST_2_C) {
         for (i = 0; i < instr_num_srcs(where); i++) {


### PR DESCRIPTION
Updates DR to 3b4d7485 which fixes DynamoRIO/dynamorio#4958,
eliminating basic blocks coming from the DR library.

This also pulls in a fix for an injection crash from app compatibility
layers: DynamoRIO/dynamorio#5198.

Removes the workaround in the umbra_client_insert_app_to_shadow test
that is now no longer needed.

Issue: DynamoRIO/dynamorio#4958, DynamoRIO/dynamorio#5198