### PR TITLE
Fix stale doc links

### DIFF
--- a/README
+++ b/README
@@ -75,7 +75,7 @@ Full Documentation
 If you are viewing this file, you have already successfully unpacked the
 Dr. Memory distribution archive.  To view the documention, point your web
 browser at the drmemory/docs/html/index.html file, or online at
-http://drmemory.org/docs/.
+http://drmemory.org/.
 
 ===========================================================================
 Contact

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ suite:
 ## Documentation
 
 Documentation is included in the release package.  We also maintain a copy
-for [online browsing](http://drmemory.org/docs/).
+for [online browsing](http://drmemory.org/).
 
 ## System call tracer for Windows
 

--- a/drheapstat/drheapstat_frontend.c
+++ b/drheapstat/drheapstat_frontend.c
@@ -141,7 +141,7 @@ print_usage(bool full)
                 "your application onto drheapstat.exe.  To pass arguments you must\n"
                 "instead invoke drheapstat.exe from an existing shell.\n");
 #endif
-        fprintf(stderr, "See http://drmemory.org/docs/ for more information.\n");
+        fprintf(stderr, "See http://drmemory.org/ for more information.\n");
         return;
     }
 #define OPTION_CLIENT_EX(scope, name, altname, type, defval, min, max, short, long) \

--- a/drltrace/README.md
+++ b/drltrace/README.md
@@ -1,3 +1,3 @@
-[drltrace](http://drmemory.org/docs/page_drltrace.html) is a standalone tool for Windows
-based on the Dr. Memory framework that records calls to shared libraries. It reports all
-invocations of exported functions in all shared libraries loaded into the target process.
+drltrace is a standalone tool for Windows based on the Dr. Memory framework
+that records calls to shared libraries. It reports all invocations of
+exported functions in all shared libraries loaded into the target process.

--- a/drmemory/frontend.c
+++ b/drmemory/frontend.c
@@ -238,7 +238,7 @@ print_usage(bool full)
                 "your application onto drmemory.exe.  To pass arguments you must\n"
                 "instead invoke drmemory.exe from an existing shell.\n");
 #endif
-        fprintf(stderr, "See http://drmemory.org/docs/ for more information.\n");
+        fprintf(stderr, "See http://drmemory.org/ for more information.\n");
         pause_if_in_cmd();
         return;
     }


### PR DESCRIPTION
Updates old links that pointed to drmemory.org/docs/