### PR TITLE
Fix Android CI build

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -105,6 +105,7 @@ jobs:
         cd /tmp
         wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
         unzip -q android-ndk-r10e-linux-x86_64.zip
+        export ANDROID_NDK_ROOT=/tmp/android-ndk-r10e
         android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
           --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
           --install-dir=/tmp/android-gcc-arm-ndk-10e


### PR DESCRIPTION
Mirrors the DynamoRIO/dynamorio#5527 fix by setting ANDROID_NDK_ROOT.