### PR TITLE
Fix VS2019 warnings in drcachesim

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -136,6 +136,7 @@ set(base_cache "
   UNIQUE_BUILD_NUMBER:STRING=${arg_ubuild}
   BUILD_TOOL_TESTS:BOOL=OFF
   BUILDING_PACKAGE:BOOL=ON
+  AUTOMATED_TESTING:BOOL=ON
   ${sub_entry}
   ${arg_cacheappend}
   ${base_cache}

--- a/tests/runsuite.cmake
+++ b/tests/runsuite.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2020 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -213,7 +213,8 @@ endforeach ()
 
 
 # i#1099: avoid absolute path complaint on package build step
-set(base_cache "BUILDING_PACKAGE:BOOL=ON")
+set(base_cache "BUILDING_PACKAGE:BOOL=ON
+  AUTOMATED_TESTING:BOOL=ON")
 
 if (arg_travis AND WIN32)
   # XXX i#1938: AppVeyor's MinGW g++ crashes for as-yet-unknown reasons.


### PR DESCRIPTION
Updates DR to 1f40176ae to fix VS2019 warnings.

Issue: DynamoRIO/dynamorio#5767