### PR TITLE
Update runner to macos-12

### DIFF
--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2024 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # 64-bit OSX build with clang and tests:
   osx-x86-64:
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Upgrades to macos-12 for the ci-osx runner, as macos-11 is now deprecated.

Issue: DynamoRIO/dynamorio#6864