### PR TITLE
Fix doxygen and cmake install issues on runners

### DIFF
--- a/.github/workflows/ci-clang.yml
+++ b/.github/workflows/ci-clang.yml
@@ -81,7 +81,7 @@ jobs:
 
     # Downgrade from cmake 3.20 to avoid 32-bit toolchain problems (DRi#4830).
     - name: Downgrade cmake
-      uses: jwlawson/actions-setup-cmake@v1.8
+      uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: '3.19.7'
 

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -80,7 +80,7 @@ jobs:
 
     # Downgrade from cmake 3.20 to avoid 32-bit toolchain problems (DRi#4830).
     - name: Downgrade cmake
-      uses: jwlawson/actions-setup-cmake@v1.8
+      uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: '3.19.7'
 
@@ -136,12 +136,14 @@ jobs:
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 
+    # Install Doxygen.
+    - uses: ssciwr/doxygen-install@v1
+
     - name: Download Packages
       shell: powershell
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Get Version
       id: version
@@ -166,8 +168,6 @@ jobs:
         echo ------ Setting up paths ------
         7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
         set PATH=c:\projects\install\ninja;%PATH%
-        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
-        set PATH=c:\projects\install\doxygen;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
         set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
         call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -56,12 +56,14 @@ jobs:
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 
+    # Install Doxygen.
+    - uses: ssciwr/doxygen-install@v1
+
     - name: Download Packages
       shell: powershell
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -69,8 +71,6 @@ jobs:
         echo ------ Setting up paths ------
         7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
         set PATH=c:\projects\install\ninja;%PATH%
-        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
-        set PATH=c:\projects\install\doxygen;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
         set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
         call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
@@ -97,12 +97,14 @@ jobs:
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 
+    # Install Doxygen.
+    - uses: ssciwr/doxygen-install@v1
+
     - name: Download Packages
       shell: powershell
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -110,8 +112,6 @@ jobs:
         echo ------ Setting up paths ------
         7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
         set PATH=c:\projects\install\ninja;%PATH%
-        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
-        set PATH=c:\projects\install\doxygen;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
         set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
         call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
@@ -138,12 +138,14 @@ jobs:
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 
+    # Install Doxygen.
+    - uses: ssciwr/doxygen-install@v1
+
     - name: Download Packages
       shell: powershell
       run: |
         md c:\projects\install
         (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -151,8 +153,6 @@ jobs:
         echo ------ Setting up paths ------
         7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
         set PATH=c:\projects\install\ninja;%PATH%
-        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
-        set PATH=c:\projects\install\doxygen;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
         set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
         call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -86,7 +86,7 @@ jobs:
 
     # Downgrade from cmake 3.20 to avoid 32-bit toolchain problems (DRi#4830).
     - name: Downgrade cmake
-      uses: jwlawson/actions-setup-cmake@v1.8
+      uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: '3.19.7'
 


### PR DESCRIPTION
Switches from directly downloading from sourceforge, which was giving us 403 errors suddenly, to using
https://github.com/ssciwr/doxygen-install.

Updates jwlawson/actions-setup-cmake to v2.

Issue: DynamoRIO/dynamorio#7007