### PR TITLE
i#7013 build failure: Remove DOT_TRANSPARENT from Doxyfile.in

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -240,7 +240,6 @@ DOT_IMAGE_FORMAT       = png
 DOT_PATH               =
 DOTFILE_DIRS           =
 MAX_DOT_GRAPH_DEPTH    = 1000
-DOT_TRANSPARENT        = NO
 DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES


### PR DESCRIPTION
This causes the error

CMake Error at /tmp/dynamorio/drmemory/docs/CMake_doxyfile.cmake:256 (message):
  /usr/bin/doxygen -u failed: This tag has been removed.

Tested:
$ make htmldocs

Fixes #2524
Fixes Dynamorio/dynamorio#7013