### PR TITLE
i#2522 strcasestr prototype error: Remove `const` from result type

### DIFF
--- a/common/utils.h
+++ b/common/utils.h
@@ -1011,7 +1011,7 @@ drmem_strndup(const char *src, size_t max, heapstat_t type);
 #define MAX_OPTION_LEN DR_MAX_OPTIONS_LENGTH
 
 #if !defined(MACOS) && !defined(ANDROID) && !defined(NOLINK_STRCASESTR)
-const char *
+char *
 strcasestr(const char *text, const char *pattern);
 #endif
 

--- a/common/utils_shared.c
+++ b/common/utils_shared.c
@@ -51,7 +51,7 @@ strnchr(const char *str, int find, size_t max)
  * want a libc dependence.
  */
 #if !defined(MACOS) && !defined(ANDROID) && !defined(NOLINK_STRCASESTR)
-const char *
+char *
 strcasestr(const char *text, const char *pattern)
 {
     const char *cur_text, *cur_pattern, *root;
@@ -60,7 +60,7 @@ strcasestr(const char *text, const char *pattern)
     cur_pattern = pattern;
     while (true) {
         if (*cur_pattern == '\0')
-            return root;
+            return (char *) root;
         if (*cur_text == '\0')
             return NULL;
         /* XXX DRi#943: toupper is better, for int18n, and we need to call


### PR DESCRIPTION
The definition of strcasestr is

char *strcasestr(const char *text, const char *pattern);

but drmemory uses

const char *strcasestr(const char *text, const char *pattern);

This causes build errors when both /usr/include/string.h and common/utils.h are included in linux. The definition for strcasestr for C has always not had the `const` in the result type (going back to its original addition to glibc in 1997). Thus we're pretty safe in not breaking anything on *nix. The other main use case of drmemory's strcasestr is on Windows, which does not have strcasestr.

Tested:
$ cmake && make
Also, there are failures in the clang and x86 workflows, but comparing the logs before/after
shows all failures pre-exist this patch, no new failures.

Here is the complete audit, all failures are pre-existing.

Recorded (errantly) as i#1938 failures:
  - wrap_operators: "internal crash" (Received SIGSEGV)
    - filed as #2535
  - wrap_cs2bug: CHECK_TRUNCATE_TYPE_sbyte(new_offs) (#2342)
  - pcache-use: "Usage error: meta-instr faulted? must set translation field and handle fault!" (#2202)
  - app_suite: vsyscall incorrect assumption (#2491)
  - app_suite.pattern: assert failure: save->ignore_next_delete == 0 (premature deletion)
    - filed as i#2537
  - fuzz_threads: vsyscall incorrect assumption (#2491)

Note: The above are marked as expected failures but [runsuite_wrapper.pl hardwires the addition of "i#1938" to test output](https://github.com/DynamoRIO/drmemory/blob/master/tests/runsuite_wrapper.pl#L281). #2534

Not currently recorded as expected failures (all #2491 - vsyscall incorrect assumption):
  - selfmod
  - syscalls_unix
  - clone
  - pthread_test
  - realloc

Fixes #2522