### PR TITLE
Restore msgbox_mask package defaults

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+# Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
 # **********************************************************
 
@@ -136,7 +136,7 @@ set(base_cache "
   UNIQUE_BUILD_NUMBER:STRING=${arg_ubuild}
   BUILD_TOOL_TESTS:BOOL=OFF
   BUILDING_PACKAGE:BOOL=ON
-  AUTOMATED_TESTING:BOOL=ON
+  DISABLE_ZLIB:BOOL=ON
   ${sub_entry}
   ${arg_cacheappend}
   ${base_cache}


### PR DESCRIPTION
Updates DR to [a15656a0c](https://github.com/DynamoRIO/drmemory/pull/2527/commits/36a6d23d2c4048526613409e59cab6a0c72f1f91).
Replaces the AUTOMATED_TESTING set in package builds by PR #2474 with the new DISABLE_ZLIB CMake option added by
DynamoRIO/dynamorio#7030. This fixes a regression where msgbox_mask was set to 0 by default in packages, which caused many users to fail to obtain error information and has led to confusion with silent errors.

Tested:
Built https://github.com/DynamoRIO/drmemory/releases/tag/cronbuild-2.6.20005, unzipped it, and confirmed it pops up a message box by default on the machine where DynamoRIO/dynamorio#7024 is hit.

Fixes DynamoRIO/dynamorio#7025