### PR TITLE
Update DR to latest to fix elfutils issue

### DIFF
--- a/drmemory/docs/build.dox
+++ b/drmemory/docs/build.dox
@@ -424,7 +424,7 @@ $ make/git/devsetup.sh
 $ cd ..
 $ mkdir build_android
 $ cd build_android
-$ cmake -DCMAKE_TOOLCHAIN_FILE=../drmemory/dynamorio/make/toolchain-android.cmake -DANDROID_TOOLCHAIN=/mytooldir/android-ndk-21 ../drmemory
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../drmemory/dynamorio/make/toolchain-android-gcc.cmake -DANDROID_TOOLCHAIN=/mytooldir/android-ndk-21 ../drmemory
 $ make -j
 ```
 

--- a/drmemory/docs/new_release.dox
+++ b/drmemory/docs/new_release.dox
@@ -159,7 +159,7 @@ Android:
 
 ```
 cd /work/drmemory/build_package/
-ctest -D CMAKE_SYSTEM_PROCESSOR=arm -V -S /work/drmemory_package/package.cmake,drmem_only\;32_only\;build=2\;cacheappend=TOOL_VERSION_NUMBER:STRING=1.11.0\;cacheappend=DRMF_VERSION:STRING=1.0.0\;cacheappend=CMAKE_TOOLCHAIN_FILE=/work/drmemory/git/src/dynamorio/make/toolchain-android.cmake\;cacheappend=ANDROID_TOOLCHAIN=/work/toolchain/android-ndk-21\;cpackappend=set\(CPACK_PACKAGE_FILE_NAME\ DrMemory-ARM-Android-EABI-1.11.0-2\)\;cacheappend=VERSION_NUMBER:STRING=6.2.0
+ctest -D CMAKE_SYSTEM_PROCESSOR=arm -V -S /work/drmemory_package/package.cmake,drmem_only\;32_only\;build=2\;cacheappend=TOOL_VERSION_NUMBER:STRING=1.11.0\;cacheappend=DRMF_VERSION:STRING=1.0.0\;cacheappend=CMAKE_TOOLCHAIN_FILE=/work/drmemory/git/src/dynamorio/make/toolchain-android-gcc.cmake\;cacheappend=ANDROID_TOOLCHAIN=/work/toolchain/android-ndk-21\;cpackappend=set\(CPACK_PACKAGE_FILE_NAME\ DrMemory-ARM-Android-EABI-1.11.0-2\)\;cacheappend=VERSION_NUMBER:STRING=6.2.0
 ```
 
 On MacOS:

--- a/tests/runsuite.cmake
+++ b/tests/runsuite.cmake
@@ -372,7 +372,7 @@ if (UNIX AND ARCH_IS_X86)
     TOOL_DR_MEMORY:BOOL=ON
     ${DR_entry}
     CMAKE_BUILD_TYPE:STRING=Debug
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/dynamorio/make/toolchain-android.cmake
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/dynamorio/make/toolchain-android-gcc.cmake
     ${android_extra_dbg}
     " OFF OFF "")
   if (cross_android_only OR NOT TEST_LONG)
@@ -383,7 +383,7 @@ if (UNIX AND ARCH_IS_X86)
     TOOL_DR_MEMORY:BOOL=ON
     ${DR_entry}
     CMAKE_BUILD_TYPE:STRING=Release
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/dynamorio/make/toolchain-android.cmake
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/dynamorio/make/toolchain-android-gcc.cmake
     ${android_extra_rel}
     " OFF OFF "")
   set(run_tests ${prev_run_tests}) # restore


### PR DESCRIPTION
Updates DR to the latest a09c4c9f5a0503aaa4efc2c9d59aada92de85291 to pull in the fix for DynamoRIO/dynamorio#7253 to avoid submodule issues with elfutils from sourceware.org.