### PR TITLE
i#1928: Fix cppcheck warning about uninitialized variable

### DIFF
--- a/drfuzz/drfuzz_mutator.c
+++ b/drfuzz/drfuzz_mutator.c
@@ -208,8 +208,8 @@ static bool
 drfuzz_parse_dictionary(const char *file, mutator_t *mutator)
 {
     const char *line, *next_line, *eof;
-    uint64 map_size;
-    size_t actual_size;
+    uint64 map_size = 0;
+    size_t actual_size = 0;
     bool res = false;
     void *map = NULL;
     file_t f;


### PR DESCRIPTION
In previous Cppcheck versions (like 2.8 and earlier) there were some warnings about uninitialized variables. This is easily fixed by trivial initialization with zero. In the new versions of Cppcheck these warnings does not arise, because, the init occurs in another place of the code and new Cppcheck versions can handle it.
But the created commit will still be useful for improving the quality of the code.

**Before:**
```
❯ ./cppcheck --version
Cppcheck 2.8
❯ ./cppcheck /Projects/drmemory/drfuzz/drfuzz_mutator.c
Checking /Projects/drmemory/drfuzz/drfuzz_mutator.c ...
/Projects/drmemory/drfuzz/drfuzz_mutator.c:228:32: error: Uninitialized variable: actual_size [uninitvar]
    if (!res || map == NULL || actual_size < map_size) {
                               ^
/Projects/drmemory/drfuzz/drfuzz_mutator.c:220:11: note: Assuming condition is false
    if (f != INVALID_FILE) {
          ^
/Projects/drmemory/drfuzz/drfuzz_mutator.c:228:32: note: Uninitialized variable: actual_size
    if (!res || map == NULL || actual_size < map_size) {
                               ^
/Projects/drmemory/drfuzz/drfuzz_mutator.c:228:46: error: Uninitialized variable: map_size [uninitvar]
    if (!res || map == NULL || actual_size < map_size) {
                                             ^
/Projects/drmemory/drfuzz/drfuzz_mutator.c:220:11: note: Assuming condition is false
    if (f != INVALID_FILE) {
          ^
/Projects/drmemory/drfuzz/drfuzz_mutator.c:228:46: note: Uninitialized variable: map_size
    if (!res || map == NULL || actual_size < map_size) {
                                             ^
Checking /Projects/drmemory/drfuzz/drfuzz_mutator.c: DYNAMIC_INTERFACE;DYNAMIC_INTERFACE;_DRFUZZ_MUTATOR_H_...
Checking /Projects/drmemory/drfuzz/drfuzz_mutator.c: DYNAMIC_INTERFACE;_DRFUZZ_MUTATOR_H_...
Checking /Projects/drmemory/drfuzz/drfuzz_mutator.c: DYNAMIC_INTERFACE;_DRFUZZ_MUTATOR_H_;WINDOWS...
```
Screenshot:
![before_#1928](https://github.com/user-attachments/assets/473dff8c-23bc-428f-b55b-30b03688de4b)

**After:**
```
❯ ./cppcheck /Projects/drmemory/drfuzz/drfuzz_mutator.c
Checking /Projects/drmemory/drfuzz/drfuzz_mutator.c ...
Checking /Projects/drmemory/drfuzz/drfuzz_mutator.c: DYNAMIC_INTERFACE;DYNAMIC_INTERFACE;_DRFUZZ_MUTATOR_H_...
Checking /Projects/drmemory/drfuzz/drfuzz_mutator.c: DYNAMIC_INTERFACE;_DRFUZZ_MUTATOR_H_...
Checking /Projects/drmemory/drfuzz/drfuzz_mutator.c: DYNAMIC_INTERFACE;_DRFUZZ_MUTATOR_H_;WINDOWS...
```
Screenshot:
![after_#1928](https://github.com/user-attachments/assets/76cc6883-8ea7-4f4b-a8b2-dc752182144c)

Fixes #1928