### PR TITLE
i#2190: Fix a typo of identical conditions

### DIFF
--- a/drmemory/slowpath_x86.c
+++ b/drmemory/slowpath_x86.c
@@ -131,7 +131,7 @@ opc_is_stringop(uint opc)
     return (opc_is_stringop_loop(opc) ||
             opc == OP_ins || opc == OP_outs || opc == OP_movs ||
             opc == OP_stos || opc == OP_lods || opc == OP_cmps ||
-            opc == OP_cmps || opc == OP_scas || opc == OP_scas);
+            opc == OP_cmps || opc == OP_scas);
 }
 
 bool

--- a/drmemory/slowpath_x86.c
+++ b/drmemory/slowpath_x86.c
@@ -131,7 +131,7 @@ opc_is_stringop(uint opc)
     return (opc_is_stringop_loop(opc) ||
             opc == OP_ins || opc == OP_outs || opc == OP_movs ||
             opc == OP_stos || opc == OP_lods || opc == OP_cmps ||
-            opc == OP_cmps || opc == OP_scas);
+            opc == OP_scas);
 }
 
 bool


### PR DESCRIPTION
Among the conditions in return statement were identical ones, which is a simple typo. The solution is a removal of unnecessary repetitions.

**Before:**
```
return (opc_is_stringop_loop(opc) ||
        opc == OP_ins || opc == OP_outs || opc == OP_movs ||
        opc == OP_stos || opc == OP_lods || opc == OP_cmps ||
        opc == OP_cmps || opc == OP_scas || opc == OP_scas);
```
**After:**
```
return (opc_is_stringop_loop(opc) ||
        opc == OP_ins || opc == OP_outs || opc == OP_movs ||
        opc == OP_stos || opc == OP_lods || opc == OP_cmps ||
        opc == OP_scas);
```

Fixes #2190