### PR TITLE
Fix NtUserOpenClipboard

### DIFF
--- a/drsyscall/table_windows_ntuser.c
+++ b/drsyscall/table_windows_ntuser.c
@@ -1341,7 +1341,7 @@ syscall_info_t syscall_user32_info[] = {
     {{0,0},"NtUserOpenClipboard", OK, SYSARG_TYPE_BOOL32, 2,
      {
          {0, sizeof(HWND), SYSARG_INLINED, DRSYS_TYPE_HANDLE},
-         {1, sizeof(DWORD), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT},
+         {1, sizeof(BOOL), W|HT, DRSYS_TYPE_BOOL},
      }
     },
     {{0,0},"NtUserOpenDesktop", OK, DRSYS_TYPE_HANDLE, 3,

--- a/wininc/ntuser.h
+++ b/wininc/ntuser.h
@@ -2494,7 +2494,7 @@ BOOL
 NTAPI
 NtUserOpenClipboard(
   HWND hWnd,
-  DWORD Unknown1);
+  PBOOL pfEmptyClient);
 
 HDESK
 NTAPI


### PR DESCRIPTION
This pull request updates the definition for `NtUserOpenClipboard` to reflect that the syscall writes to a pointer provided in the second argument. `OpenClipboard` passes an address of a local variable to this parameter and then reads from it, causing the following warning:

```
Error #1: UNINITIALIZED READ: reading 0x00000092296ff998-0x00000092296ff99c 4 byte(s)
# 0 USER32.dll!OpenClipboard
# 1 main                        
Note: @0:00:00.082 in thread 11352
Note: instruction: cmp    0x38(%rsp) $0x00000000
```

Similar changes would apply to the following files in the dynamorio submodule; not sure if you want me to create a separate pull request to address that:
```
dynamorio\ext\drsyscall\table_windows_ntuser.c
dynamorio\ext\drmf\wininc\ntuser.h
```