### PR TITLE
i#2560,#2548: Update to ubuntu22 and vs2022 GA platforms

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # AArchXX cross-compile with gcc, no tests:
   aarchxx-cross-compile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
 
   # Android ARM cross-compile with gcc, no tests:
   android-arm-cross-compile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-clang.yml
+++ b/.github/workflows/ci-clang.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # 32-bit and 64-bit Linux build with clang, no tests.
   clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -49,7 +49,7 @@ jobs:
   # Docs deployment, building on Linux.
   docs:
     # We use a more recent Ubuntu for better markdown support.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2024 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2025 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -45,7 +45,7 @@ jobs:
   ###########################################################################
   # Linux tarball with 64-bit and 32-bit builds:
   x86:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -126,7 +126,7 @@ jobs:
   ###########################################################################
   # Windows .zip and .msi with 32-bit and 64-bit x86 builds:
   windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -170,7 +170,7 @@ jobs:
         set PATH=c:\projects\install\ninja;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
         set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"
@@ -203,7 +203,7 @@ jobs:
 
   create_release:
     needs: [x86, windows]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       # We need a checkout to run git log for the version.

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2024 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2025 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Dr. Memory: the memory debugger
@@ -38,9 +38,9 @@ defaults:
     shell: cmd
 
 jobs:
-  # 32-bit VS2019 and tests:
+  # 32-bit VS2022 and tests:
   vs2019-32:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -73,15 +73,15 @@ jobs:
         set PATH=c:\projects\install\ninja;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
         set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"
         perl tests/runsuite_wrapper.pl travis use_ninja 32_only drmemory_only debug_only
 
-  # 64-bit VS2019 and tests:
+  # 64-bit VS2022 and tests:
   vs2019-64:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -114,7 +114,7 @@ jobs:
         set PATH=c:\projects\install\ninja;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
         set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"
@@ -122,7 +122,7 @@ jobs:
 
   # drheapstat and release builds:
   vs2019-builds:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -155,7 +155,7 @@ jobs:
         set PATH=c:\projects\install\ninja;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
         set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   # 64-bit and 32-bit Linux build with gcc and tests:
   x86:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/common/alloc_replace.c
+++ b/common/alloc_replace.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -152,7 +152,7 @@ enum {
 
     /* meta-flags */
 #ifdef WINDOWS
-    ALLOCATOR_TYPE_FLAGS  = (MALLOC_ALLOCATOR_FLAGS | CHUNK_LAYER_RTL |
+    ALLOCATOR_TYPE_FLAGS  = ((int)MALLOC_ALLOCATOR_FLAGS | CHUNK_LAYER_RTL |
                              CHUNK_LAYER_NOCHECK),
 #else
     ALLOCATOR_TYPE_FLAGS  = (MALLOC_ALLOCATOR_FLAGS),

--- a/common/alloc_replace.c
+++ b/common/alloc_replace.c
@@ -98,6 +98,7 @@
 # include <sys/mman.h>
 #else
 # include "../wininc/crtdbg.h"
+# pragma warning(disable : 5286) /* "implicit conversion from enum type" */
 # pragma warning(disable : 5287) /* "operands are different enum types" */
 #endif
 

--- a/common/alloc_replace.c
+++ b/common/alloc_replace.c
@@ -98,6 +98,7 @@
 # include <sys/mman.h>
 #else
 # include "../wininc/crtdbg.h"
+# pragma warning(disable : 5287) /* "operands are different enum types" */
 #endif
 
 #ifdef UNIX
@@ -152,7 +153,7 @@ enum {
 
     /* meta-flags */
 #ifdef WINDOWS
-    ALLOCATOR_TYPE_FLAGS  = ((int)MALLOC_ALLOCATOR_FLAGS | CHUNK_LAYER_RTL |
+    ALLOCATOR_TYPE_FLAGS  = (MALLOC_ALLOCATOR_FLAGS | CHUNK_LAYER_RTL |
                              CHUNK_LAYER_NOCHECK),
 #else
     ALLOCATOR_TYPE_FLAGS  = (MALLOC_ALLOCATOR_FLAGS),

--- a/drsyscall/drsyscall.c
+++ b/drsyscall/drsyscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -175,7 +175,8 @@ check_syscall_gateway(instr_t *inst)
                    "multiple system call gateways not supported");
         }
     } else if (instr_get_opcode(inst) == OP_syscall) {
-        if (syscall_gateway == DRSYS_GATEWAY_UNKNOWN)
+        if (syscall_gateway == DRSYS_GATEWAY_UNKNOWN ||
+            syscall_gateway == DRSYS_GATEWAY_INT)
             syscall_gateway = DRSYS_GATEWAY_SYSCALL;
         else {
             ASSERT(syscall_gateway == DRSYS_GATEWAY_SYSCALL

--- a/tests/runsuite_wrapper.pl
+++ b/tests/runsuite_wrapper.pl
@@ -266,6 +266,8 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'syscalls_unix' => 1,
                                    'pthread_test' => 1,
                                    'realloc' => 1,
+                                   'drmf_drsyscall_test' => 1,
+                                   'drmf_strace_test' => 1,
                                    # XXX: We should probably drop wrap_ support as we
                                    # do not have the resources to maintain it.
                                    'wrap_cs2bug' => 1,


### PR DESCRIPTION
Updates Github Actions (GA) jobs from ubuntu-20 to ubuntu-22 and from windows-2019 to windows-2022.

Updates DR to f233a38f9 to pull in DR's Ubuntu22 and VS2022 fixes.

Fixes #2560
Fixes #2548