### PR TITLE
WIP: Fuzz per iteration leak scan implementation

### DIFF
--- a/drmemory/drmemory.c
+++ b/drmemory/drmemory.c
@@ -86,6 +86,7 @@ file_t f_results = INVALID_FILE;
 file_t f_missing_symbols;
 file_t f_suppress;
 file_t f_potential;
+file_t f_fuzz;
 static uint num_threads;
 
 #if defined(__DATE__) && defined(__TIME__)
@@ -488,6 +489,7 @@ event_exit(void)
     close_file(f_missing_symbols);
     close_file(f_suppress);
     close_file(f_potential);
+    close_file(f_fuzz);
     dr_fprintf(f_global, "LOG END\n");
     close_file(f_global);
 
@@ -1508,6 +1510,7 @@ create_global_logfile(void)
         f_suppress = open_logfile("suppress.txt", false, -1);
         f_potential = open_logfile(RESULTS_POTENTIAL_FNAME, false, -1);
         print_version(f_potential, true);
+        f_fuzz = open_logfile("fuzz_results.txt", false, -1);
     }
 }
 

--- a/drmemory/drmemory.h
+++ b/drmemory/drmemory.h
@@ -82,6 +82,7 @@ extern file_t f_results;
 extern file_t f_suppress;
 extern file_t f_missing_symbols;
 extern file_t f_potential;
+extern file_t f_fuzz;
 
 #ifdef WINDOWS
 extern app_pc ntdll_base;

--- a/drmemory/optionsx.h
+++ b/drmemory/optionsx.h
@@ -746,6 +746,10 @@ OPTION_CLIENT_SCOPE(drmemscope, fuzz_skip_initial, uint, 0, 0, UINT_MAX,
 OPTION_CLIENT_SCOPE(drmemscope, fuzz_stat_freq, uint, 0, 0, UINT_MAX,
                     "Enable fuzzer status logging with the specified frequency",
                     "Specify the fuzzer status log frequency in number of fuzz iterations (no status is logged when this option is not set).")
+OPTION_CLIENT_BOOL(drmemscope, fuzz_per_iter_leak_scan, false,
+                   "Saves the fuzz input that triggered a leak to the current log directory.",
+                   "Saves the fuzz input that triggered a leak to the current log directory. The name of the file is included in the error report summary.")
+
 #ifdef WINDOWS
 OPTION_CLIENT_BOOL(drmemscope, fuzz_mangled_names, false,
                    "Enable mangled names for fuzz targets on Windows",

--- a/drmemory/report.c
+++ b/drmemory/report.c
@@ -1586,6 +1586,8 @@ report_init(void)
 #endif
     ELOGF(0, f_suppress, "# File for suppressing errors found in pid %d: \"%s\""NL NL,
           dr_get_process_id(), dr_get_application_name());
+    ELOGF(0, f_fuzz, "Dr. Memory fuzzing errors for pid %d: \"%s\""NL,
+          dr_get_process_id(), dr_get_application_name());
     ELOGF(0, f_potential, "Dr. Memory errors that are likely to be false positives, "
           "for pid %d: \"%s\""NL, dr_get_process_id(), dr_get_application_name());
     if ((options.lib_allowlist_frames > 0 && options.lib_allowlist[0] != '\0') ||
@@ -1750,7 +1752,7 @@ report_errors_found(void)
 /* N.B.: for PR 477013, postprocess.pl duplicates some of this syntax
  * exactly: try to keep the two in sync
  */
-static void
+void
 report_summary_to_file(file_t f, bool stderr_too, bool print_full_stats, bool potential)
 {
     uint i;
@@ -3445,7 +3447,7 @@ report_leak(bool known_malloc, app_pc addr, size_t size, size_t indirect_size,
             } else {
                 /* num_unique was set to 0 after nudge */
 #ifdef STATISTICS /* for num_nudges */
-                ASSERT(err->id == 0 || num_nudges > 0 ||
+                ASSERT(err->id == 0 || num_nudges > 0 || option_specified.fuzz_per_iter_leak_scan ||
                        (maybe_reachable && !options.possible_leaks) ||
                        (reachable && !options.show_reachable),
                        "invalid dup error report!");

--- a/drmemory/report.h
+++ b/drmemory/report.h
@@ -52,6 +52,9 @@ void
 report_summary(void);
 
 void
+report_summary_to_file(file_t f, bool stderr_too, bool print_full_stats, bool potential);
+
+void
 report_thread_init(void *drcontext);
 
 void


### PR DESCRIPTION
Jumping back on this feature, as derek suggested i followed similar logic to the one in the `nudge_leak_scan` function, right now this builds and works fine (single-threaded) and although i tried to minimize logs it still does a lot of logging i think that's coming from `report_leak` but i didn't go too deep into this. Regardless, i know the changes may be a little intrusive, but I tried my best to use already existing logic without touching any of the core DynamoRIO API calls or the existing function signatures.