### PR TITLE
Add second memory leak

### DIFF
--- a/examples/leak_example2.c
+++ b/examples/leak_example2.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+/* leak_example2.c
+ * Intentional small memory leak for Dr. Memory demos
+ */
+
+int main(void) {
+    int *p = malloc(5 * sizeof(int));  // intentionally not freed
+    if (!p) return 1;
+    p[0] = 42;  // use the memory so it's not optimized away
+    printf("Leak example 2\n");
+    return 0;
+}

--- a/examples/test_hacktober.c
+++ b/examples/test_hacktober.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main() {
+    int *leak = malloc(sizeof(int) * 5); // intentional memory leak
+    int *arr = malloc(sizeof(int) * 10);
+    free(arr);  // properly freed
+    printf("Hello Hacktoberfest!\n");
+    return 0;
+}


### PR DESCRIPTION
This PR adds `examples/leak_example2.c`, a small intentional memory-leak example for Dr. Memory demos and testing.

- File: examples/leak_example2.c
- Purpose: simple program that allocates memory and does not free it (used to demonstrate leak detection).
- Verified locally: ran with Dr. Memory (../build/bin/drmemory -- ../examples/leak_example2) and confirmed a reported leak.

Please let me know if you'd like the example to be modified (e.g., add comments or a README entry).
