### PR TITLE
Add signal_buffer_leak example for memory leak detection

### DIFF
--- a/examples/signal_buffer_leak.c
+++ b/examples/signal_buffer_leak.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#define SIGNAL_SIZE 1000
+
+int main() {
+    printf("Running signal_buffer_leak...\n");
+    float *signal = (float *)malloc(SIGNAL_SIZE * sizeof(float));
+
+    for (int i = 0; i < SIGNAL_SIZE; i++)
+        signal[i] = i * 0.01f;
+
+    printf("Signal processed.\n");
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a simple signal buffer example demonstrating a memory leak scenario in an ECE signal processing context. Verified using Dr. Memory.