### PR TITLE
Update DR to fix Windows build warning

### DIFF
--- a/common/utils.h
+++ b/common/utils.h
@@ -203,10 +203,12 @@ extern "C" {
 # define inline __inline
 # define INLINE_FORCED __forceinline
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
-# if _MSC_VER <= 1200 /* XXX: __pragma may work w/ vc6: then don't need #if */
-#  define ACTUAL_PRAGMA(p) _Pragma ( #p )
-# else
-#   define ACTUAL_PRAGMA(p) __pragma ( p )
+# ifndef ACTUAL_PRAGMA
+#  if _MSC_VER <= 1200 /* XXX: __pragma may work w/ vc6: then don't need #if */
+#   define ACTUAL_PRAGMA(p) _Pragma ( #p )
+#  else
+#    define ACTUAL_PRAGMA(p) __pragma ( p )
+#  endif
 # endif
 # define DO_NOT_OPTIMIZE ACTUAL_PRAGMA( optimize("g", off) )
 # define END_DO_NOT_OPTIMIZE ACTUAL_PRAGMA( optimize("g", on) )

--- a/common/utils.h
+++ b/common/utils.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -215,8 +215,10 @@ extern "C" {
  * struct have to be typedef-ed in two steps.
  * see example struct _packed_frame_t at common/callstack.c
  */
-# define START_PACKED_STRUCTURE ACTUAL_PRAGMA( pack(push,1) )
-# define END_PACKED_STRUCTURE ACTUAL_PRAGMA( pack(pop) )
+# ifndef START_PACKED_STRUCTURE
+#  define START_PACKED_STRUCTURE ACTUAL_PRAGMA( pack(push,1) )
+#  define END_PACKED_STRUCTURE ACTUAL_PRAGMA( pack(pop) )
+# endif
 #else /* UNIX */
 # define inline __inline__
 # define INLINE_FORCED inline
@@ -226,8 +228,10 @@ extern "C" {
 #   define DO_NOT_OPTIMIZE /* nothing */
 # endif
 # define END_DO_NOT_OPTIMIZE /* nothing */
-# define START_PACKED_STRUCTURE /* nothing */
-# define END_PACKED_STRUCTURE __attribute__ ((__packed__))
+# ifndef START_PACKED_STRUCTURE
+#  define START_PACKED_STRUCTURE /* nothing */
+#  define END_PACKED_STRUCTURE __attribute__ ((__packed__))
+# endif
 #endif
 #define INLINE_ONCE inline
 

--- a/drheapstat/drheapstat.c
+++ b/drheapstat/drheapstat.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2193,7 +2193,7 @@ dr_init(client_id_t client_id)
     create_global_logfile();
     LOG(0, "options are \"%s\"\n", opstr);
 
-    dr_register_exit_event(event_exit);
+    drmgr_register_exit_event(event_exit);
     drmgr_register_thread_init_event(event_thread_init);
     drmgr_register_thread_exit_event(event_thread_exit);
 
@@ -2214,7 +2214,7 @@ dr_init(client_id_t client_id)
 #endif
     }
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     /* simplest to filter all for pre-syscall-arg access: else we'd

--- a/drltrace/drltrace.cpp
+++ b/drltrace/drltrace.cpp
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2013-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -482,7 +482,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     drwrap_set_global_flags((drwrap_global_flags_t)
                             (DRWRAP_NO_FRILLS | DRWRAP_FAST_CLEANCALLS));
 
-    dr_register_exit_event(event_exit);
+    drmgr_register_exit_event(event_exit);
 #ifdef UNIX
     dr_register_fork_init_event(event_fork);
 #endif

--- a/drmemory/drmemory.c
+++ b/drmemory/drmemory.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1865,7 +1865,7 @@ dr_init(client_id_t id)
     ASSERT(app_base != NULL, "internal error finding executable base");
     LOG(2, "executable \"%s\" is "PFX"-"PFX"\n", app_path, app_base, app_end);
 
-    dr_register_exit_event(event_exit);
+    drmgr_register_exit_event(event_exit);
     drmgr_register_thread_init_event(event_thread_init);
     drmgr_register_thread_exit_event(event_thread_exit);
     drmgr_register_restore_state_ex_event(event_restore_state);

--- a/drmemory/syscall.c
+++ b/drmemory/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -701,7 +701,7 @@ syscall_init(void *drcontext _IF_WINDOWS(app_pc ntdll_base))
     /* We register our own filter to be independent of
      * drsys_filter_all_syscalls() for our own syscall tracking needs.
      */
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS)

--- a/drstrace/drstrace.c
+++ b/drstrace/drstrace.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -698,9 +698,9 @@ void dr_init(client_id_t id)
 #endif
     if (res != DRMF_SUCCESS)
         ASSERT(false, "drsys failed to init");
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS)

--- a/drsyscall/drsyscall.c
+++ b/drsyscall/drsyscall.c
@@ -2239,7 +2239,7 @@ drsys_init(client_id_t client_id, drsys_options_t *ops)
     drmgr_register_post_syscall_event_ex(drsys_event_post_syscall, &pri_postsys);
     drmgr_register_post_syscall_event_ex(drsys_event_post_syscall_last, &pri_postsys_last);
 
-    dr_register_filter_syscall_event(drsys_event_filter_syscall);
+    drmgr_register_filter_syscall_event(drsys_event_filter_syscall);
     hashtable_init(&filtered_table, FILTERED_TABLE_HASH_BITS, HASH_INTPTR,
                    false/*!strdup*/);
 

--- a/framework/samples/strace.c
+++ b/framework/samples/strace.c
@@ -73,12 +73,12 @@ dr_init(client_id_t id)
 {
     drsys_options_t ops = { sizeof(ops), 0, };
     drmgr_init();
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_init(id, &ops) != DRMF_SUCCESS)
         DR_ASSERT(false);
-    dr_register_exit_event(event_exit);
+    drmgr_register_exit_event(event_exit);
 #ifdef WINDOWS
     dr_enable_console_printing(); /* ensure output shows up in cmd */
 #endif

--- a/tests/framework/drfuzz_client_empty.c
+++ b/tests/framework/drfuzz_client_empty.c
@@ -51,5 +51,5 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     drmgr_init();
     if (drfuzz_init(id) != DRMF_SUCCESS)
         DR_ASSERT_MSG(false, "drfuzz failed to init");
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 }

--- a/tests/framework/drfuzz_client_repeat.c
+++ b/tests/framework/drfuzz_client_repeat.c
@@ -86,7 +86,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     drmgr_init();
     if (drfuzz_init(id) != DRMF_SUCCESS)
         EXPECT(false, "drfuzz failed to init");
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 
     /* fuzz repeatme */
     app = dr_get_main_module();

--- a/tests/framework/drfuzz_client_segfault.c
+++ b/tests/framework/drfuzz_client_segfault.c
@@ -246,7 +246,7 @@ void dr_client_main(client_id_t id, int argc, const char *argv[])
 
     drmgr_init();
     drsym_init(0);
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 
     if (drfuzz_init(id) != DRMF_SUCCESS)
         EXPECT(false, "drfuzz failed to init");

--- a/tests/framework/drsyscall_client.c
+++ b/tests/framework/drsyscall_client.c
@@ -387,9 +387,9 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     drmgr_init();
     if (drsys_init(id, &ops) != DRMF_SUCCESS)
         ASSERT(false, "drsys failed to init");
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS)

--- a/tests/framework/strace_client.c
+++ b/tests/framework/strace_client.c
@@ -248,9 +248,9 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     drmgr_init();
     if (drsys_init(id, &ops) != DRMF_SUCCESS)
         ASSERT(false, "drsys failed to init");
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS)

--- a/tests/framework/umbra_client_consistency.c
+++ b/tests/framework/umbra_client_consistency.c
@@ -79,7 +79,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT_MSG(false, "fail to create shadow memory mapping");
     drmgr_register_bb_instrumentation_event(event_app_analysis,
                                             event_app_instruction, NULL);
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 }
 
 static void

--- a/tests/framework/umbra_client_empty.c
+++ b/tests/framework/umbra_client_empty.c
@@ -66,5 +66,5 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT_MSG(false, "fail to init umbra");
     if (umbra_create_mapping(&umbra_map_ops, &umbra_map) != DRMF_SUCCESS)
         DR_ASSERT_MSG(false, "fail to create shadow memory mapping");
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 }

--- a/tests/framework/umbra_client_faulty_redzone.c
+++ b/tests/framework/umbra_client_faulty_redzone.c
@@ -93,7 +93,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 #else
     drmgr_register_signal_event(event_signal_instrumentation);
 #endif
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 }
 
 static void

--- a/tests/framework/umbra_client_insert_app_to_shadow.c
+++ b/tests/framework/umbra_client_insert_app_to_shadow.c
@@ -96,7 +96,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 #else
     drmgr_register_signal_event(event_signal_instrumentation);
 #endif
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 }
 
 #ifndef X64

--- a/tests/framework/umbra_client_shadow_mem.c
+++ b/tests/framework/umbra_client_shadow_mem.c
@@ -79,7 +79,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT_MSG(false, "fail to create shadow memory mapping");
     drmgr_register_bb_instrumentation_event(event_app_analysis,
                                             event_app_instruction, NULL);
-    dr_register_exit_event(exit_event);
+    drmgr_register_exit_event(exit_event);
 }
 
 static void

--- a/umbra/umbra.c
+++ b/umbra/umbra.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -317,7 +317,7 @@ umbra_init(client_id_t client_id)
     /* register event callbacks */
     if (!drmgr_init())
         return DRMF_ERROR;
-    dr_register_filter_syscall_event(umbra_event_filter_syscall);
+    drmgr_register_filter_syscall_event(umbra_event_filter_syscall);
     drmgr_register_pre_syscall_event(umbra_event_pre_syscall);
     drmgr_register_post_syscall_event(umbra_event_post_syscall);
 #ifdef WINDOWS
@@ -356,7 +356,7 @@ umbra_exit(void)
     umbra_arch_exit();
     dr_mutex_destroy(umbra_global_lock);
 
-    dr_unregister_filter_syscall_event(umbra_event_filter_syscall);
+    drmgr_unregister_filter_syscall_event(umbra_event_filter_syscall);
     drmgr_unregister_pre_syscall_event(umbra_event_pre_syscall);
     drmgr_unregister_post_syscall_event(umbra_event_post_syscall);
 #ifdef WINDOWS


### PR DESCRIPTION
Updates DR to 92be9e40f to pull in the fix for a drreg compiler warning which is breaking the build,
along with the drmgr fix for the umbra_test_allscales failure.

Updates drmemory usage of several DR events to use drmgr instead to comply with drmgr changes.

Avoids some double-definitions of macros.

Issue DynamoRIO/dynamorio#7739